### PR TITLE
fix: harden FlowPilot telemetry and installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,10 +57,14 @@ jobs:
 
   windows-smoke:
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shell: [powershell, pwsh]
     steps:
       - uses: actions/checkout@v4
       - name: Parse PowerShell entrypoints
-        shell: pwsh
+        shell: ${{ matrix.shell }}
         run: |
           $files = @('install.ps1','bin/codex-flow.ps1','scripts/doctor.ps1','scripts/uninstall.ps1')
           foreach ($file in $files) {
@@ -72,33 +76,74 @@ jobs:
             }
           }
       - name: Installer and CLI smoke test
-        shell: pwsh
+        shell: ${{ matrix.shell }}
         run: |
           $root = (Get-Location).Path
-          $tmp = Join-Path $env:RUNNER_TEMP 'codex-flow-smoke'
+          $tmp = Join-Path $env:RUNNER_TEMP ('codex-flow-smoke-' + '${{ matrix.shell }}')
           $env:CODEX_HOME = Join-Path $tmp '.codex'
           $env:CODEX_FLOW_BIN_DIR = Join-Path $tmp 'bin-installed'
           $fakeBin = Join-Path $tmp 'bin'
           New-Item -ItemType Directory -Force -Path $env:CODEX_HOME,$env:CODEX_FLOW_BIN_DIR,$fakeBin | Out-Null
-          '@echo off\r\necho codex-test 0.0.0\r\n' | Set-Content (Join-Path $fakeBin 'codex.cmd') -NoNewline
+          $utf8NoBom = New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false
+          [System.IO.File]::WriteAllText((Join-Path $fakeBin 'codex.cmd'), "@echo off" + [Environment]::NewLine + "echo codex-test 0.0.0" + [Environment]::NewLine, $utf8NoBom)
+          [System.IO.File]::WriteAllText((Join-Path $fakeBin 'git.cmd'), "@echo off" + [Environment]::NewLine + "exit /b 0" + [Environment]::NewLine, $utf8NoBom)
           $env:PATH = "$fakeBin;$env:CODEX_FLOW_BIN_DIR;$env:PATH"
-          @('model = "user-parent-model"','model_reasoning_effort = "high"','','[unrelated]','keep_me = true') | Set-Content (Join-Path $env:CODEX_HOME 'config.toml')
+          $sentinel = [string][char]0x4f60 + [string][char]0x597d
+          $configText = 'model = "user-parent-model"' + [Environment]::NewLine + 'model_reasoning_effort = "high"' + [Environment]::NewLine + '# non-ASCII sentinel: ' + $sentinel + [Environment]::NewLine + [Environment]::NewLine + '[unrelated]' + [Environment]::NewLine + 'keep_me = true' + [Environment]::NewLine
+          [System.IO.File]::WriteAllText((Join-Path $env:CODEX_HOME 'config.toml'), $configText, $utf8NoBom)
 
-          & "$root\install.ps1"
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $installExit = 0
+          try {
+            $installOutput = (& "$root\install.ps1" 2>&1 | Out-String)
+            if ($null -ne $LASTEXITCODE -and $LASTEXITCODE -ne 0) { $installExit = $LASTEXITCODE }
+          } catch {
+            $installOutput = $_ | Out-String
+            $installExit = 1
+          }
+          $installOutput
+          if ($installExit -ne 0) { exit $installExit }
+          foreach ($expected in @(
+            'IMPORTANT: FULL CODEX RESTART REQUIRED',
+            'Fully quit Codex and open it again; starting a new task alone',
+            'Telemetry is enabled: run /hooks; approve FlowPilot telemetry',
+            'After restarting, start a new task and a new turn',
+            'already-running turn cannot rebuild its starting snapshot.'
+          )) {
+            if (-not $installOutput.Contains($expected)) { throw "installer reminder missing: $expected" }
+          }
           & (Join-Path $env:CODEX_FLOW_BIN_DIR 'codex-flow.cmd') status
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          & (Join-Path $env:CODEX_FLOW_BIN_DIR 'codex-flow.cmd') doctor
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $doctorOutput = (& (Join-Path $env:CODEX_FLOW_BIN_DIR 'codex-flow.cmd') doctor 2>&1 | Out-String)
+          $doctorExit = $LASTEXITCODE
+          if ($doctorExit -ne 0) { exit $doctorExit }
+          if ($doctorOutput -notmatch 'thread-attributed telemetry may be unavailable') { throw 'old Codex compatibility warning missing' }
 
-          $config = Get-Content (Join-Path $env:CODEX_HOME 'config.toml') -Raw
+          $config = [System.IO.File]::ReadAllText((Join-Path $env:CODEX_HOME 'config.toml'), $utf8NoBom)
+          if (-not $config.Contains('# non-ASCII sentinel: ' + $sentinel)) { throw 'non-ASCII config sentinel was not preserved after install' }
           if ($config -notmatch 'default_subagent_model\s*=\s*"gpt-5\.6-luna"') { throw 'worker model was not installed' }
-          $policy = Get-Content (Join-Path $env:CODEX_HOME 'codex-flow.toml') -Raw
+          $policy = [System.IO.File]::ReadAllText((Join-Path $env:CODEX_HOME 'codex-flow.toml'), $utf8NoBom)
           if ($policy -notmatch 'schema_version\s*=\s*3') { throw 'policy schema was not upgraded' }
           if ($policy -notmatch 'model\s*=\s*"auto"') { throw 'auto worker policy was not preserved' }
+          $binState = Join-Path $env:CODEX_HOME 'codex-flow/bin_dir'
+          if (-not ([System.IO.File]::ReadAllText($binState, $utf8NoBom).Trim() -eq $env:CODEX_FLOW_BIN_DIR)) { throw 'custom bin directory was not persisted' }
+          $policyBytes = [System.IO.File]::ReadAllBytes((Join-Path $env:CODEX_HOME 'codex-flow.toml'))
+          if ($policyBytes.Length -ge 3 -and $policyBytes[0] -eq 0xef -and $policyBytes[1] -eq 0xbb -and $policyBytes[2] -eq 0xbf) { throw 'policy unexpectedly has a UTF-8 BOM' }
           if (-not (Test-Path (Join-Path $env:CODEX_HOME 'skills/flow-pilot/SKILL.md'))) { throw 'FlowPilot skill missing' }
           if (-not (Test-Path (Join-Path $env:CODEX_HOME 'hooks.json'))) { throw 'telemetry hooks missing' }
 
-          & (Join-Path $env:CODEX_FLOW_BIN_DIR 'codex-flow.cmd') uninstall
+          Remove-Item Env:CODEX_FLOW_BIN_DIR
+          & (Join-Path $tmp 'bin-installed/codex-flow.cmd') update
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          if (-not (Test-Path (Join-Path $tmp 'bin-installed/codex-flow.cmd'))) { throw 'custom bin directory was not reused by update' }
+          if (-not (Test-Path (Join-Path $tmp 'bin-installed/codex-flow.ps1'))) { throw 'PowerShell wrapper was not refreshed in custom bin directory' }
+          $config = [System.IO.File]::ReadAllText((Join-Path $env:CODEX_HOME 'config.toml'), $utf8NoBom)
+          if (-not $config.Contains('# non-ASCII sentinel: ' + $sentinel)) { throw 'non-ASCII config sentinel was not preserved after update' }
+
+          & (Join-Path $tmp 'bin-installed/codex-flow.cmd') uninstall
           if (Test-Path (Join-Path $env:CODEX_HOME 'codex-flow.toml')) { throw 'policy survived uninstall' }
           if (Test-Path (Join-Path $env:CODEX_HOME 'skills/flow-pilot')) { throw 'FlowPilot skill survived uninstall' }
+          if (Test-Path (Join-Path $env:CODEX_HOME 'codex-flow')) { throw 'state survived uninstall' }
+          if (Test-Path (Join-Path $tmp 'bin-installed/codex-flow.cmd')) { throw 'custom cmd wrapper survived uninstall' }
+          if (Test-Path (Join-Path $tmp 'bin-installed/codex-flow.ps1')) { throw 'custom PowerShell wrapper survived uninstall' }
+          $config = [System.IO.File]::ReadAllText((Join-Path $env:CODEX_HOME 'config.toml'), $utf8NoBom)
+          if (-not $config.Contains('# non-ASCII sentinel: ' + $sentinel)) { throw 'non-ASCII config sentinel was not preserved after uninstall' }

--- a/README.en.md
+++ b/README.en.md
@@ -78,9 +78,11 @@ cd codex-flow
 .\install.ps1
 ```
 
-The management command is installed under `~/.local/bin`. When the default shell is Bash or zsh, installation also adds one marked, idempotent block to the corresponding shell rc file. That block adds the CLI directory to `PATH` and registers subcommand completion, including `usage last`, `benchmark-local quick|full`, and `benchmark-corpus quick|full`. Restart Codex after installation, then use it normally.
+The management command is installed under `~/.local/bin`. When the default shell is Bash or zsh, installation also adds one marked, idempotent block to the corresponding shell rc file. That block adds the CLI directory to `PATH` and registers subcommand completion, including `usage last`, `benchmark-local quick|full`, and `benchmark-corpus quick|full`.
 
-FlowPilot telemetry merges managed command hooks into `~/.codex/hooks.json` without replacing unrelated user hooks. Because Codex applies a security trust flow to command hooks, **the first installation or a later hook-content change may require one trust approval**. If Codex prompts, inspect and approve the hooks with `/hooks`. Normal tasks require no additional action after approval.
+After installation, **fully quit Codex and open it again**; starting a new task alone is not enough. After the restart, start a new task/turn because an already-running turn cannot rebuild its starting snapshot. When telemetry is enabled, run `/hooks` and approve FlowPilot telemetry there if it is pending approval. When telemetry is disabled, no hook authorization is required, but you must still fully restart Codex and start a new task/turn.
+
+FlowPilot telemetry merges managed command hooks into `~/.codex/hooks.json` without replacing unrelated user hooks. Because Codex applies a security trust flow to command hooks, **the first installation or a later hook-content change may require one trust approval**. If Codex prompts, inspect and approve the hooks with `/hooks`. Normal tasks require no additional action after approval. With telemetry disabled, these hooks are not installed and no hook authorization is required.
 
 Shell selection follows `CODEX_FLOW_SHELL` when set, otherwise the basename of `SHELL`. Use `CODEX_FLOW_SHELL_CONFIG_DIR` to place the managed shell files in another configuration directory.
 

--- a/README.md
+++ b/README.md
@@ -88,9 +88,11 @@ cd codex-flow
 .\install.ps1
 ```
 
-管理命令默认安装到 `~/.local/bin`。如果当前默认 shell 是 Bash 或 zsh，安装器还会向对应的 rc 文件写入一个带明确标记、可重复执行的托管块。该托管块会自动把 CLI 目录加入 `PATH`，并注册 `codex-flow` 子命令补全，包括 `usage last`、`benchmark-local quick|full` 和 `benchmark-corpus quick|full`。安装完成后，安装器会明确提示执行 `source ~/.zshrc`（Bash 为 `source ~/.bashrc`）立即更新当前终端，或者打开一个新终端。Codex 本身仍需重启，之后正常使用即可，不需要每次手动调用特殊命令或 Prompt。
+管理命令默认安装到 `~/.local/bin`。如果当前默认 shell 是 Bash 或 zsh，安装器还会向对应的 rc 文件写入一个带明确标记、可重复执行的托管块。该托管块会自动把 CLI 目录加入 `PATH`，并注册 `codex-flow` 子命令补全，包括 `usage last`、`benchmark-local quick|full` 和 `benchmark-corpus quick|full`。安装完成后，安装器会明确提示执行 `source ~/.zshrc`（Bash 为 `source ~/.bashrc`）立即更新当前终端，或者打开一个新终端。
 
-FlowPilot telemetry 默认会把托管的 command hooks 合并进 `~/.codex/hooks.json`，不会覆盖用户已有 hooks。由于 Codex 对 command hooks 有安全信任机制，**首次安装或 hook 内容发生变化后，Codex 可能要求一次 trust approval**；出现提示时用 `/hooks` 查看并批准即可。批准以后正常任务不需要额外操作。
+安装完成后必须**完整退出 Codex，再重新打开 Codex**；只新建任务不够。重启后请开始一个新的 task/turn，因为已经运行中的 turn 无法补建它的起始快照。Telemetry 启用时，请运行 `/hooks`；如果 FlowPilot telemetry 处于待批准状态，请在那里授权。Telemetry 禁用时不需要 hook 授权，但仍必须完整重启 Codex 并开始新的 task/turn。
+
+FlowPilot telemetry 默认会把托管的 command hooks 合并进 `~/.codex/hooks.json`，不会覆盖用户已有 hooks。由于 Codex 对 command hooks 有安全信任机制，**首次安装或 hook 内容发生变化后，Codex 可能要求一次 trust approval**；出现提示时用 `/hooks` 查看并批准即可。批准以后正常任务不需要额外操作。关闭 telemetry 时不会安装这些 hooks，也不会要求 hook 授权。
 
 Shell 选择优先读取 `CODEX_FLOW_SHELL`，否则使用 `SHELL` 的 basename。`CODEX_FLOW_SHELL_CONFIG_DIR` 可将托管的 `.bashrc`、登录 profile 或 `.zshrc` 放到指定配置目录；无法识别 shell 时，安装器仍会输出手动添加 `PATH` 的提示。
 

--- a/bin/codex-flow.ps1
+++ b/bin/codex-flow.ps1
@@ -1,5 +1,12 @@
 $ErrorActionPreference = 'Stop'
 
+function New-Utf8NoBomEncoding {
+    return New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false
+}
+function Read-Utf8NoBom([string]$Path) {
+    return [System.IO.File]::ReadAllText($Path, (New-Utf8NoBomEncoding))
+}
+
 $CodexHome = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $HOME '.codex' }
 $StateDir = Join-Path $CodexHome 'codex-flow'
 $SourceFile = Join-Path $StateDir 'source'
@@ -7,12 +14,12 @@ $Policy = Join-Path $CodexHome 'codex-flow.toml'
 
 function Get-SourceDir {
     if (-not (Test-Path $SourceFile)) { throw 'missing source metadata; reinstall codex-flow' }
-    $dir = (Get-Content $SourceFile -Raw).Trim()
+    $dir = (Read-Utf8NoBom $SourceFile).Trim()
     if (-not (Test-Path $dir)) { throw "source checkout no longer exists: $dir" }
     return $dir
 }
 function Get-PolicyValue([string]$Section, [string]$Key) {
-    $text = Get-Content $Policy -Raw
+    $text = Read-Utf8NoBom $Policy
     $m = [regex]::Match($text, '(?ms)^\[' + [regex]::Escape($Section) + '\]\s*(.*?)(?=^\[[^\r\n]+\]|\z)')
     if (-not $m.Success) { return '' }
     $k = [regex]::Match($m.Groups[1].Value, '(?m)^\s*' + [regex]::Escape($Key) + '\s*=\s*"?([^"\r\n]+)"?\s*$')
@@ -25,8 +32,8 @@ $rest = if ($args.Count -gt 1) { @($args[1..($args.Count - 1)]) } else { @() }
 switch ($cmd) {
     'status' {
         $src = Get-SourceDir
-        $installed = if (Test-Path (Join-Path $StateDir 'version')) { (Get-Content (Join-Path $StateDir 'version') -Raw).Trim() } else { 'unknown' }
-        $available = if (Test-Path (Join-Path $src 'VERSION')) { (Get-Content (Join-Path $src 'VERSION') -Raw).Trim() } else { 'unknown' }
+        $installed = if (Test-Path (Join-Path $StateDir 'version')) { (Read-Utf8NoBom (Join-Path $StateDir 'version')).Trim() } else { 'unknown' }
+        $available = if (Test-Path (Join-Path $src 'VERSION')) { (Read-Utf8NoBom (Join-Path $src 'VERSION')).Trim() } else { 'unknown' }
         Write-Host 'codex-flow'
         Write-Host "  installed: $installed"
         Write-Host "  checkout:  $src"
@@ -84,10 +91,10 @@ switch ($cmd) {
         $telemetryEnabled = Get-PolicyValue telemetry enabled
         $env:CODEX_FLOW_TELEMETRY_ENABLED = if ($telemetryEnabled) { $telemetryEnabled } else { 'true' }
 
-        $before = if (Test-Path (Join-Path $src 'VERSION')) { (Get-Content (Join-Path $src 'VERSION') -Raw).Trim() } else { 'unknown' }
+        $before = if (Test-Path (Join-Path $src 'VERSION')) { (Read-Utf8NoBom (Join-Path $src 'VERSION')).Trim() } else { 'unknown' }
         git -C $src pull --ff-only
         if ($LASTEXITCODE -ne 0) { throw 'git pull failed' }
-        $after = if (Test-Path (Join-Path $src 'VERSION')) { (Get-Content (Join-Path $src 'VERSION') -Raw).Trim() } else { 'unknown' }
+        $after = if (Test-Path (Join-Path $src 'VERSION')) { (Read-Utf8NoBom (Join-Path $src 'VERSION')).Trim() } else { 'unknown' }
         & (Join-Path $src 'install.ps1')
         Write-Host "updated $before -> $after"
     }

--- a/install.ps1
+++ b/install.ps1
@@ -1,5 +1,15 @@
 $ErrorActionPreference = 'Stop'
 
+function New-Utf8NoBomEncoding {
+    return New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false
+}
+function Read-Utf8NoBom([string]$Path) {
+    return [System.IO.File]::ReadAllText($Path, (New-Utf8NoBomEncoding))
+}
+function Write-Utf8NoBom([string]$Path, [string]$Value) {
+    [System.IO.File]::WriteAllText($Path, $Value, (New-Utf8NoBomEncoding))
+}
+
 $RootDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $CodexHome = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $HOME '.codex' }
 $Config = Join-Path $CodexHome 'config.toml'
@@ -7,9 +17,19 @@ $Policy = Join-Path $CodexHome 'codex-flow.toml'
 $Hooks = Join-Path $CodexHome 'hooks.json'
 $Defaults = Join-Path $RootDir 'policy/defaults.toml'
 $StateDir = Join-Path $CodexHome 'codex-flow'
-$BinDir = if ($env:CODEX_FLOW_BIN_DIR) { $env:CODEX_FLOW_BIN_DIR } else { Join-Path $HOME '.local/bin' }
+$BinDirState = Join-Path $StateDir 'bin_dir'
+$PersistedBinDir = if (Test-Path $BinDirState) { (Read-Utf8NoBom $BinDirState).Trim() } else { '' }
+$PreviousBinDir = $PersistedBinDir
+$BinDir = if ($env:CODEX_FLOW_BIN_DIR) {
+    $env:CODEX_FLOW_BIN_DIR
+} elseif ($PersistedBinDir) {
+    $PersistedBinDir
+} else {
+    Join-Path $HOME '.local/bin'
+}
+$BinDir = [System.IO.Path]::GetFullPath($BinDir)
 $Stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
-$Version = if (Test-Path (Join-Path $RootDir 'VERSION')) { (Get-Content (Join-Path $RootDir 'VERSION') -Raw).Trim() } else { 'dev' }
+$Version = if (Test-Path (Join-Path $RootDir 'VERSION')) { (Read-Utf8NoBom (Join-Path $RootDir 'VERSION')).Trim() } else { 'dev' }
 
 function Get-TomlString([string]$Text, [string]$Section, [string]$Key) {
     $m = [regex]::Match($Text, '(?ms)^\[' + [regex]::Escape($Section) + '\]\s*(.*?)(?=^\[[^\r\n]+\]|\z)')
@@ -27,7 +47,7 @@ function Get-TomlInt([string]$Text, [string]$Section, [string]$Key) {
 }
 
 if (-not (Get-Command python3 -ErrorAction SilentlyContinue)) { throw 'python3 is required' }
-$defaultsText = Get-Content $Defaults -Raw
+$defaultsText = Read-Utf8NoBom $Defaults
 $DefaultWorkerModel = Get-TomlString $defaultsText 'models' 'worker_model'
 $DefaultParentPolicy = Get-TomlString $defaultsText 'models' 'parent_policy'
 $DefaultParentMinModel = Get-TomlString $defaultsText 'models' 'parent_min_model'
@@ -55,7 +75,7 @@ New-Item -ItemType Directory -Force -Path $StateDir | Out-Null
 New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
 if (Test-Path $Config) { Copy-Item $Config "$Config.codex-flow.$Stamp.bak" } else { New-Item -ItemType File -Force -Path $Config | Out-Null }
 
-$text = Get-Content $Config -Raw
+$text = Read-Utf8NoBom $Config
 $managed = [ordered]@{
     enabled = 'true'
     max_concurrent_threads_per_session = $MaxThreads
@@ -79,7 +99,7 @@ if ($match.Success) {
     $text += "[agents]`n"
     foreach ($entry in $managed.GetEnumerator()) { $text += "$($entry.Key) = $($entry.Value)`n" }
 }
-Set-Content -Path $Config -Value $text -NoNewline
+Write-Utf8NoBom $Config $text
 
 @"
 schema_version = 3
@@ -111,7 +131,7 @@ max_repair_cycles = $MaxRepairs
 enabled = $TelemetryEnabled
 summary = true
 source = "hooks+app-server"
-"@ | Set-Content -Path $Policy
+"@ | ForEach-Object { Write-Utf8NoBom $Policy $_ }
 
 Copy-Item (Join-Path $RootDir 'templates/agents/worker-explorer.toml') (Join-Path $CodexHome 'agents/worker-explorer.toml') -Force
 Copy-Item (Join-Path $RootDir 'templates/agents/worker-implementer.toml') (Join-Path $CodexHome 'agents/worker-implementer.toml') -Force
@@ -120,8 +140,9 @@ Remove-Item (Join-Path $CodexHome 'skills/cost-aware-development') -Force -Recur
 Remove-Item (Join-Path $CodexHome 'agents/luna-explorer.toml') -Force -ErrorAction SilentlyContinue
 Remove-Item (Join-Path $CodexHome 'agents/luna-implementer.toml') -Force -ErrorAction SilentlyContinue
 
-Set-Content -Path (Join-Path $StateDir 'source') -Value $RootDir -NoNewline
-Set-Content -Path (Join-Path $StateDir 'version') -Value $Version -NoNewline
+Write-Utf8NoBom (Join-Path $StateDir 'source') $RootDir
+Write-Utf8NoBom (Join-Path $StateDir 'version') $Version
+Write-Utf8NoBom $BinDirState $BinDir
 Copy-Item (Join-Path $RootDir 'scripts/telemetry.py') (Join-Path $StateDir 'telemetry.py') -Force
 Copy-Item (Join-Path $RootDir 'scripts/manage-hooks.py') (Join-Path $StateDir 'manage-hooks.py') -Force
 if ($TelemetryEnabled -eq 'true') {
@@ -133,6 +154,15 @@ if ($TelemetryEnabled -eq 'true') {
 Copy-Item (Join-Path $RootDir 'bin/codex-flow.ps1') (Join-Path $BinDir 'codex-flow.ps1') -Force
 Copy-Item (Join-Path $RootDir 'bin/codex-flow.cmd') (Join-Path $BinDir 'codex-flow.cmd') -Force
 
+if ($PreviousBinDir) {
+    $previousFullPath = [System.IO.Path]::GetFullPath($PreviousBinDir)
+    $currentFullPath = [System.IO.Path]::GetFullPath($BinDir)
+    if (-not [string]::Equals($previousFullPath, $currentFullPath, [System.StringComparison]::OrdinalIgnoreCase)) {
+        Remove-Item (Join-Path $PreviousBinDir 'codex-flow.ps1') -Force -ErrorAction SilentlyContinue
+        Remove-Item (Join-Path $PreviousBinDir 'codex-flow.cmd') -Force -ErrorAction SilentlyContinue
+    }
+}
+
 Write-Host "codex-flow $Version installed."
 Write-Host "  config:    $Config"
 Write-Host "  policy:    $Policy"
@@ -142,9 +172,21 @@ Write-Host "  parent:    $ParentModelPolicy / min=$ParentMinModel / reasoning >=
 Write-Host "  worker:    $WorkerModelPolicy / requested=$WorkerRequested / resolved=$WorkerModel / reasoning >= $WorkerMinEffort"
 Write-Host "  telemetry: $TelemetryEnabled (deterministic hooks + app-server; no model call)"
 Write-Host '  adaptive effort: high -> xhigh -> max only when justified'
-Write-Host ''
-Write-Host 'Restart Codex, then use it normally.'
-if ($TelemetryEnabled -eq 'true') { Write-Host 'Codex may ask once to trust the new command hooks. If prompted, review/approve them with /hooks.' }
 
 $userPath = [Environment]::GetEnvironmentVariable('Path','User')
 if (($userPath -split ';') -contains $BinDir) { Write-Host 'Run: codex-flow status' } else { Write-Host "Add $BinDir to your user PATH to run: codex-flow status" }
+
+Write-Host ''
+Write-Host '+------------------------------------------------------------------+'
+Write-Host '| IMPORTANT: FULL CODEX RESTART REQUIRED                           |'
+Write-Host '| Fully quit Codex and open it again; starting a new task alone    |'
+Write-Host '| is not enough.                                                   |'
+if ($TelemetryEnabled -eq 'true') {
+    Write-Host '| Telemetry is enabled: run /hooks; approve FlowPilot telemetry    |'
+    Write-Host '| there if it is pending approval.                                 |'
+} else {
+    Write-Host '| Telemetry is disabled: no hook authorization is required.        |'
+}
+Write-Host '| After restarting, start a new task and a new turn; an            |'
+Write-Host '| already-running turn cannot rebuild its starting snapshot.       |'
+Write-Host '+------------------------------------------------------------------+'

--- a/install.sh
+++ b/install.sh
@@ -180,12 +180,7 @@ codex-flow $VERSION installed.
   telemetry: $TELEMETRY_ENABLED (deterministic hooks + app-server; no model call)
 
 Adaptive effort: high baseline -> xhigh for complex work -> max only for critical quality-first work.
-Restart Codex, then use it normally.
 EOF
-
-if [[ "$TELEMETRY_ENABLED" == "true" ]]; then
-  printf '\nCodex may ask once to trust the new command hooks. If prompted, review/approve them with /hooks.\n'
-fi
 
 if [[ "$SHELL_NAME" == "bash" || "$SHELL_NAME" == "zsh" ]]; then
   printf '\nShell integration installed for %s.\n' "$SHELL_NAME"
@@ -197,3 +192,22 @@ else
     *) printf 'Add %s to PATH to use: codex-flow status\n' "$BIN_DIR" ;;
   esac
 fi
+
+printf '\n'
+printf '%s\n' \
+  '+------------------------------------------------------------------+' \
+  '| IMPORTANT: FULL CODEX RESTART REQUIRED                           |' \
+  '| Fully quit Codex and open it again; starting a new task alone    |' \
+  '| is not enough.                                                   |'
+if [[ "$TELEMETRY_ENABLED" == "true" ]]; then
+  printf '%s\n' \
+    '| Telemetry is enabled: run /hooks; approve FlowPilot telemetry    |' \
+    '| there if it is pending approval.                                 |'
+else
+  printf '%s\n' \
+    '| Telemetry is disabled: no hook authorization is required.        |'
+fi
+printf '%s\n' \
+  '| After restarting, start a new task and a new turn; an            |' \
+  '| already-running turn cannot rebuild its starting snapshot.       |' \
+  '+------------------------------------------------------------------+'

--- a/scripts/doctor
+++ b/scripts/doctor
@@ -12,6 +12,15 @@ CODEX_CLI_AVAILABLE=1
 ok() { printf '✓ %s\n' "$1"; }
 warn() { printf '! %s\n' "$1"; }
 fail() { printf '✗ %s\n' "$1"; FAILED=1; }
+# Codex 0.151 is the known support baseline for thread attribution. Compare
+# major/minor so prereleases such as 0.151.0-alpha qualify conservatively.
+codex_thread_usage_capable() {
+  local version="$1" major minor
+  [[ "$version" =~ ([0-9]+)\.([0-9]+) ]] || return 2
+  major=$((10#${BASH_REMATCH[1]}))
+  minor=$((10#${BASH_REMATCH[2]}))
+  (( major > 0 || (major == 0 && minor >= 151) ))
+}
 value() { local key="$1" section="$2"; awk -v sec="[$section]" -v key="$key" '
   $0==sec {insec=1; next} /^\[/ {insec=0} insec && $0 ~ "^" key "[[:space:]]*=" {sub(/^[^=]*=[[:space:]]*/, ""); gsub(/^\"|\"$/, ""); print; exit}
 ' "$POLICY"; }
@@ -27,6 +36,9 @@ printf 'codex-flow doctor\n\n'
 if command -v codex >/dev/null 2>&1; then
   VERSION="$(codex --version 2>/dev/null || true)"
   ok "Codex CLI found${VERSION:+: $VERSION}"
+  if [[ "$VERSION" =~ ([0-9]+)\.([0-9]+) ]] && ! codex_thread_usage_capable "$VERSION"; then
+    warn "Codex CLI $VERSION is below the known 0.151 support baseline; thread-attributed telemetry may be unavailable; upgrade to 0.151+ recommended"
+  fi
 else
   CODEX_CLI_AVAILABLE=0
   warn "Codex CLI not found in PATH; core routing remains usable, telemetry quota reads and real local benchmark execution are unavailable"

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -9,6 +9,14 @@ $CodexAvailable = $true
 function Ok($m) { Write-Host "[OK] $m" }
 function Warn($m) { Write-Warning $m }
 function Fail($m) { Write-Host "[FAIL] $m"; $script:Failed = $true }
+# Codex 0.151 is the known support baseline for thread attribution. Comparing
+# major/minor treats 0.151 prereleases as capable conservatively.
+function Test-CodexThreadUsage([string]$Version) {
+    if ($Version -notmatch '([0-9]+)\.([0-9]+)') { return $false }
+    $major = [int]$Matches[1]
+    $minor = [int]$Matches[2]
+    return ($major -gt 0 -or ($major -eq 0 -and $minor -ge 151))
+}
 function Get-PolicyValue([string]$Section, [string]$Key) {
     $text = Get-Content $Policy -Raw
     $m = [regex]::Match($text, '(?ms)^\[' + [regex]::Escape($Section) + '\]\s*(.*?)(?=^\[[^\r\n]+\]|\z)')
@@ -19,7 +27,13 @@ function Get-PolicyValue([string]$Section, [string]$Key) {
 }
 
 Write-Host 'codex-flow doctor'
-if (Get-Command codex -ErrorAction SilentlyContinue) { Ok "Codex CLI found: $(& codex --version 2>$null)" } else { $CodexAvailable = $false; Warn 'Codex CLI not found in PATH; telemetry quota reads and real benchmarks are unavailable' }
+if (Get-Command codex -ErrorAction SilentlyContinue) {
+    $CodexVersion = (& codex --version 2>$null | Out-String).Trim()
+    Ok "Codex CLI found: $CodexVersion"
+    if ($CodexVersion -match '[0-9]+\.[0-9]+' -and -not (Test-CodexThreadUsage $CodexVersion)) {
+        Warn "Codex CLI $CodexVersion is below the known 0.151 support baseline; thread-attributed telemetry may be unavailable; upgrade to 0.151+ recommended"
+    }
+} else { $CodexAvailable = $false; Warn 'Codex CLI not found in PATH; telemetry quota reads and real benchmarks are unavailable' }
 if (Test-Path $Config) { Ok 'config.toml found' } else { Fail "missing $Config" }
 if (Test-Path $Policy) { Ok 'codex-flow policy found' } else { Fail "missing $Policy" }
 foreach ($p in @('agents/worker-explorer.toml','agents/worker-implementer.toml','skills/flow-pilot/SKILL.md')) {

--- a/scripts/manage-hooks.py
+++ b/scripts/manage-hooks.py
@@ -27,22 +27,43 @@ def load(path: Path) -> dict[str, Any]:
     return value
 
 
+def is_managed_hook(hook: Any) -> bool:
+    if not isinstance(hook, dict):
+        return False
+    command = hook.get("command")
+    return isinstance(command, str) and MARKER in command.replace("\\", "/")
+
+
 def is_managed_entry(entry: Any) -> bool:
     if not isinstance(entry, dict):
         return False
-    for hook in entry.get("hooks", []):
-        if isinstance(hook, dict) and MARKER in str(hook.get("command", "")).replace("\\", "/"):
-            return True
-    return False
+    hooks = entry.get("hooks", [])
+    return isinstance(hooks, list) and any(is_managed_hook(hook) for hook in hooks)
 
 
 def remove_managed(data: dict[str, Any]) -> None:
     hooks = data.get("hooks", {})
+    if not isinstance(hooks, dict):
+        return
     for event in list(hooks):
         entries = hooks[event]
         if not isinstance(entries, list):
             continue
-        kept = [entry for entry in entries if not is_managed_entry(entry)]
+        kept = []
+        for entry in entries:
+            # Keep malformed entries and entries with malformed `hooks` values
+            # unchanged; only a valid hook list is safe to filter.
+            if not isinstance(entry, dict) or not isinstance(entry.get("hooks"), list):
+                kept.append(entry)
+                continue
+
+            entry_hooks = entry["hooks"]
+            filtered_hooks = [hook for hook in entry_hooks if not is_managed_hook(hook)]
+            if len(filtered_hooks) == len(entry_hooks):
+                kept.append(entry)
+            elif filtered_hooks:
+                entry["hooks"] = filtered_hooks
+                kept.append(entry)
         if kept:
             hooks[event] = kept
         else:

--- a/scripts/telemetry.py
+++ b/scripts/telemetry.py
@@ -24,6 +24,7 @@ STATE_ROOT = CODEX_HOME / "codex-flow" / "telemetry"
 RUNS_DIR = STATE_ROOT / "runs"
 LAST_FILE = STATE_ROOT / "last.json"
 TIMEOUT = float(os.environ.get("CODEX_FLOW_TELEMETRY_TIMEOUT", "3.0"))
+LOCK_TIMEOUT = float(os.environ.get("CODEX_FLOW_TELEMETRY_LOCK_TIMEOUT", "2.0"))
 
 
 def now_ms() -> int:
@@ -47,7 +48,7 @@ def atomic_json(path: Path, value: Any) -> None:
 def state_lock(key: str):
     STATE_ROOT.mkdir(parents=True, exist_ok=True)
     lock = STATE_ROOT / ("." + key.replace("/", "_") + ".lock")
-    deadline = time.monotonic() + 2.0
+    deadline = time.monotonic() + LOCK_TIMEOUT
     acquired = False
     while True:
         try:
@@ -59,7 +60,10 @@ def state_lock(key: str):
                 break
             time.sleep(0.025)
     try:
-        yield
+        # Callers must not enter a critical section unless this process owns
+        # the lock.  A timeout is a normal fail-open outcome for telemetry,
+        # not permission to proceed without serialization.
+        yield acquired
     finally:
         if acquired:
             try:
@@ -280,13 +284,18 @@ def usage_summary(usage: dict[str, Any] | None) -> dict[str, Any] | None:
     if not usage:
         return None
     groups = usage.get("groups") if isinstance(usage.get("groups"), list) else []
+    estimated_credits = usage.get("estimatedUsageCreditsMicros")
     totals: dict[str, Any] = {
         "input_tokens": 0,
         "cached_input_tokens": 0,
         "net_new_input_tokens": 0,
         "output_tokens": 0,
         "total_tokens": 0,
-        "estimated_credits_micros": int(usage.get("estimatedUsageCreditsMicros") or 0),
+        "estimated_credits_micros": (
+            int(estimated_credits)
+            if isinstance(estimated_credits, (int, float))
+            else None
+        ),
         "estimated_usd_micros": usage.get("estimatedUsageUsdMicros"),
     }
     normalized_groups = []
@@ -304,7 +313,11 @@ def usage_summary(usage: dict[str, Any] | None) -> dict[str, Any] | None:
             "model": group.get("model"),
             "reasoning_effort": group.get("reasoningEffort"),
             "speed": group.get("speed"),
-            "estimated_credits_micros": int(group.get("estimatedUsageCreditsMicros") or 0),
+            "estimated_credits_micros": (
+                int(group["estimatedUsageCreditsMicros"])
+                if isinstance(group.get("estimatedUsageCreditsMicros"), (int, float))
+                else None
+            ),
         }
         for source, target in mapping.items():
             value = group.get(source)
@@ -317,7 +330,7 @@ def usage_summary(usage: dict[str, Any] | None) -> dict[str, Any] | None:
 
 
 def usage_delta(before: dict[str, Any] | None, after: dict[str, Any] | None) -> dict[str, Any] | None:
-    if not after:
+    if not before or not after:
         return None
     numeric = [
         "input_tokens",
@@ -330,14 +343,73 @@ def usage_delta(before: dict[str, Any] | None, after: dict[str, Any] | None) -> 
     result: dict[str, Any] = {}
     for key in numeric:
         end = after.get(key)
-        start = before.get(key, 0) if before else 0
+        start = before.get(key)
         if isinstance(end, (int, float)) and isinstance(start, (int, float)):
             result[key] = max(0, int(end - start))
     usd_after = after.get("estimated_usd_micros")
-    usd_before = before.get("estimated_usd_micros", 0) if before else 0
+    usd_before = before.get("estimated_usd_micros")
     if isinstance(usd_after, (int, float)) and isinstance(usd_before, (int, float)):
         result["estimated_usd_micros"] = max(0, int(usd_after - usd_before))
-    result["groups"] = after.get("groups", [])
+    # Group totals are cumulative too.  Only subtract groups whose complete
+    # stable identity exists in both snapshots; newly appearing groups have
+    # no defensible baseline and must not be attributed to this run.
+    identity_fields = ("model", "reasoning_effort", "speed")
+    group_numeric = (
+        "input_tokens",
+        "cached_input_tokens",
+        "net_new_input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "estimated_credits_micros",
+        "estimated_usd_micros",
+    )
+
+    def group_identity(group: Any) -> tuple[Any, ...] | None:
+        if not isinstance(group, dict):
+            return None
+        identity = tuple(group.get(field) for field in identity_fields)
+        if any(value is None for value in identity):
+            return None
+        return identity
+
+    before_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
+    duplicate_before: set[tuple[Any, ...]] = set()
+    before_group_values = before.get("groups")
+    if not isinstance(before_group_values, list):
+        before_group_values = []
+    for group in before_group_values:
+        identity = group_identity(group)
+        if identity is None:
+            continue
+        if identity in before_groups:
+            duplicate_before.add(identity)
+        else:
+            before_groups[identity] = group
+
+    delta_groups: list[dict[str, Any]] = []
+    after_group_values = after.get("groups")
+    if not isinstance(after_group_values, list):
+        after_group_values = []
+    for group in after_group_values:
+        identity = group_identity(group)
+        if identity is None or identity in duplicate_before:
+            continue
+        old = before_groups.get(identity)
+        if old is None:
+            continue
+        delta_group: dict[str, Any] = {
+            field: group[field] for field in identity_fields
+        }
+        comparable = False
+        for key in group_numeric:
+            end = group.get(key)
+            start = old.get(key)
+            if isinstance(end, (int, float)) and isinstance(start, (int, float)):
+                delta_group[key] = max(0, int(end - start))
+                comparable = True
+        if comparable:
+            delta_groups.append(delta_group)
+    result["groups"] = delta_groups
     return result
 
 
@@ -384,16 +456,36 @@ def window_label(minutes: Any) -> str:
     return "quota"
 
 
+def aggregate_usage_value(
+    usages: list[dict[str, Any] | None], key: str
+) -> int | None:
+    """Return a complete participant aggregate, or None when any is unknown."""
+    values: list[int] = []
+    for usage in usages:
+        if not isinstance(usage, dict):
+            return None
+        value = usage.get(key)
+        if not isinstance(value, (int, float)):
+            return None
+        values.append(int(value))
+    return sum(values) if values else None
+
+
 def render_summary(run: dict[str, Any]) -> str:
     workers = list((run.get("workers") or {}).values())
-    parent_usage = run.get("parent", {}).get("usage_delta") or {}
+    parent = run.get("parent") or {}
+    parent_usage = parent.get("usage_delta") if isinstance(parent, dict) else None
+    participant_usages = [parent_usage]
+    participant_usages.extend(
+        worker.get("usage") if isinstance(worker, dict) else None for worker in workers
+    )
     lines = ["", "FlowPilot summary"]
     lines.append(
         f"  participants  1 parent + {len(workers)} worker{'s' if len(workers) != 1 else ''}"
     )
     lines.append(
-        f"  parent        {run.get('parent', {}).get('model') or 'unknown'}  "
-        f"{fmt_tokens(parent_usage.get('total_tokens'))} tokens"
+        f"  parent        {parent.get('model') or 'unknown'}  "
+        f"{fmt_tokens(parent_usage.get('total_tokens') if isinstance(parent_usage, dict) else None)} tokens"
     )
     for worker in workers:
         usage = worker.get("usage") or {}
@@ -403,15 +495,10 @@ def render_summary(run: dict[str, Any]) -> str:
             f"{worker.get('model') or 'unknown'}  "
             f"{fmt_tokens(usage.get('total_tokens'))} tokens  {state}"
         )
-    total_tokens = int(parent_usage.get("total_tokens") or 0) + sum(
-        int((worker.get("usage") or {}).get("total_tokens") or 0) for worker in workers
-    )
-    credits = int(parent_usage.get("estimated_credits_micros") or 0) + sum(
-        int((worker.get("usage") or {}).get("estimated_credits_micros") or 0)
-        for worker in workers
-    )
+    total_tokens = aggregate_usage_value(participant_usages, "total_tokens")
+    credits = aggregate_usage_value(participant_usages, "estimated_credits_micros")
     attributed = f"  attributed    {fmt_tokens(total_tokens)} tokens"
-    if credits:
+    if credits is not None:
         attributed += f"  {credits / 1_000_000:.3f} credits"
     lines.append(attributed)
 
@@ -446,18 +533,17 @@ def render_summary(run: dict[str, Any]) -> str:
     return "\n".join(lines) + "\n"
 
 
-def write_terminal(text: str) -> None:
-    if os.environ.get("CODEX_FLOW_TELEMETRY_STDOUT") == "1":
+def write_stop_output(text: str) -> None:
+    # Codex command hooks consume JSON on stdout.  Keep a deliberately named
+    # plain-text escape hatch for shell tests; production hooks always use the
+    # supported systemMessage field so Desktop/UI can surface the summary.
+    if os.environ.get("CODEX_FLOW_TELEMETRY_TEST_PLAIN_OUTPUT") == "1":
         sys.stdout.write(text)
         return
-    targets = ["/dev/tty"] if os.name != "nt" else ["CONOUT$"]
-    for target in targets:
-        try:
-            with open(target, "w", encoding="utf-8", buffering=1) as handle:
-                handle.write(text)
-            return
-        except OSError:
-            pass
+    sys.stdout.write(
+        json.dumps({"systemMessage": text}, ensure_ascii=False, separators=(",", ":"))
+        + "\n"
+    )
 
 
 def collect_hook(event: dict[str, Any]) -> None:
@@ -465,7 +551,9 @@ def collect_hook(event: dict[str, Any]) -> None:
     if kind not in {"UserPromptSubmit", "SubagentStart", "SubagentStop", "Stop"}:
         return
     key = run_key(event)
-    with state_lock(key):
+    with state_lock(key) as acquired:
+        if not acquired:
+            return
         run = load_run(event)
         path = run_path(event)
 
@@ -537,7 +625,7 @@ def collect_hook(event: dict[str, Any]) -> None:
                     worker["status"] = "observed"
         atomic_json(path, run)
         atomic_json(LAST_FILE, run)
-        write_terminal(render_summary(run))
+        write_stop_output(render_summary(run))
 
 
 def show_last(as_json: bool = False) -> int:

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -1,9 +1,28 @@
 $ErrorActionPreference = 'Stop'
+
+function New-Utf8NoBomEncoding {
+    return New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false
+}
+function Read-Utf8NoBom([string]$Path) {
+    return [System.IO.File]::ReadAllText($Path, (New-Utf8NoBomEncoding))
+}
+function Write-Utf8NoBom([string]$Path, [string]$Value) {
+    [System.IO.File]::WriteAllText($Path, $Value, (New-Utf8NoBomEncoding))
+}
+
 $CodexHome = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $HOME '.codex' }
 $Config = Join-Path $CodexHome 'config.toml'
 $Hooks = Join-Path $CodexHome 'hooks.json'
 $StateDir = Join-Path $CodexHome 'codex-flow'
-$BinDir = if ($env:CODEX_FLOW_BIN_DIR) { $env:CODEX_FLOW_BIN_DIR } else { Join-Path $HOME '.local/bin' }
+$BinDirState = Join-Path $StateDir 'bin_dir'
+$PersistedBinDir = if (Test-Path $BinDirState) { (Read-Utf8NoBom $BinDirState).Trim() } else { '' }
+$BinDir = if ($env:CODEX_FLOW_BIN_DIR) {
+    $env:CODEX_FLOW_BIN_DIR
+} elseif ($PersistedBinDir) {
+    $PersistedBinDir
+} else {
+    Join-Path $HOME '.local/bin'
+}
 
 $hookManager = Join-Path $StateDir 'manage-hooks.py'
 if ((Test-Path $hookManager) -and (Get-Command python3 -ErrorAction SilentlyContinue)) {
@@ -28,7 +47,7 @@ if ($env:CODEX_FLOW_DEFER_WINDOWS_CLI_DELETE -ne '1') {
 }
 
 if (Test-Path $Config) {
-    $text = Get-Content $Config -Raw
+    $text = Read-Utf8NoBom $Config
     $pattern = '(?ms)^\[agents\]\s*\r?\n(.*?)(?=^\[[^\r\n]+\]\s*$|\z)'
     $match = [regex]::Match($text, $pattern)
     if ($match.Success) {
@@ -46,7 +65,7 @@ if (Test-Path $Config) {
             $text = $text.Substring(0,$match.Index) + $text.Substring($match.Index + $match.Length)
             $text = [regex]::Replace($text, "`n{3,}", "`n`n")
         }
-        Set-Content -Path $Config -Value $text -NoNewline
+        Write-Utf8NoBom $Config $text
     }
 }
 

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -16,9 +16,10 @@ printf '%s\n' '# profile sentinel' > "$CODEX_FLOW_SHELL_CONFIG_DIR/.profile"
 
 cat > "$TMP/bin/codex" <<'EOF'
 #!/usr/bin/env bash
-[[ "${1:-}" == "--version" ]] && echo "codex-test 0.0.0" || exit 0
+[[ "${1:-}" == "--version" ]] && echo "codex-test ${CODEX_TEST_VERSION:-0.147.0}" || exit 0
 EOF
 chmod +x "$TMP/bin/codex"
+export CODEX_TEST_VERSION=0.147.0
 export PATH="$TMP/bin:$CODEX_FLOW_BIN_DIR:$PATH"
 
 cat > "$CODEX_HOME/config.toml" <<'EOF'
@@ -35,6 +36,27 @@ printf '%s\n' "$install_output"
 [[ "$install_output" == *"telemetry: true"* ]]
 [[ "$install_output" == *"source $CODEX_FLOW_SHELL_CONFIG_DIR/.bashrc"* ]]
 [[ "$install_output" == *"Or open a new terminal."* ]]
+[[ "$install_output" == *"IMPORTANT: FULL CODEX RESTART REQUIRED"* ]]
+[[ "$install_output" == *"Fully quit Codex and open it again; starting a new task alone"* ]]
+[[ "$install_output" == *"Telemetry is enabled: run /hooks; approve FlowPilot telemetry"* ]]
+[[ "$install_output" == *"After restarting, start a new task and a new turn"* ]]
+[[ "$install_output" == *"already-running turn cannot rebuild its starting snapshot."* ]]
+[[ "${install_output##*$'\n'}" == '+------------------------------------------------------------------+' ]]
+
+disabled_output="$(
+  CODEX_HOME="$TMP/.codex-disabled" \
+  CODEX_FLOW_BIN_DIR="$TMP/bin-disabled" \
+  CODEX_FLOW_SHELL=none \
+  CODEX_FLOW_TELEMETRY_ENABLED=false \
+  bash "$ROOT_DIR/install.sh"
+)"
+printf '%s\n' "$disabled_output"
+[[ "$disabled_output" == *"Telemetry is disabled: no hook authorization is required."* ]]
+[[ "$disabled_output" == *"IMPORTANT: FULL CODEX RESTART REQUIRED"* ]]
+[[ "$disabled_output" == *"After restarting, start a new task and a new turn"* ]]
+! [[ "$disabled_output" == *"run /hooks"* ]]
+! [[ "$disabled_output" == *"approve FlowPilot telemetry"* ]]
+[[ "${disabled_output##*$'\n'}" == '+------------------------------------------------------------------+' ]]
 
 [[ -f "$CODEX_HOME/codex-flow.toml" ]]
 [[ -f "$CODEX_HOME/codex-flow/source" ]]
@@ -81,12 +103,33 @@ doctor_output="$(codex-flow doctor 2>&1)"
 printf '%s\n' "$doctor_output"
 [[ "$doctor_output" == *"✓ policy schema v3"* ]]
 [[ "$doctor_output" == *"✓ FlowPilot lifecycle hooks installed"* ]]
+[[ "$doctor_output" == *"thread-attributed telemetry may be unavailable"* ]]
 [[ "$doctor_output" == *"Ready. FlowPilot routing and deterministic telemetry are installed."* ]]
+
+for CODEX_TEST_VERSION in 0.151.0 0.151.0-alpha.1; do
+  export CODEX_TEST_VERSION
+  capable_doctor_output="$(codex-flow doctor 2>&1)"
+  ! [[ "$capable_doctor_output" == *"thread-attributed telemetry may be unavailable"* ]]
+done
 
 no_cli_output="$(env PATH="$CODEX_FLOW_BIN_DIR:/usr/bin:/bin" "$CODEX_FLOW_BIN_DIR/codex-flow" doctor 2>&1)"
 printf '%s\n' "$no_cli_output"
 [[ "$no_cli_output" == *"Codex CLI not found in PATH"* ]]
 [[ "$no_cli_output" == *"Core FlowPilot routing is installed and healthy"* ]]
+
+# A mixed hook group must preserve user handlers across reinstall and uninstall.
+python3 - "$CODEX_HOME/hooks.json" <<'PY'
+import json, sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as stream:
+    data = json.load(stream)
+entry = data["hooks"]["Stop"][0]
+entry["hooks"].append({"type": "command", "command": "user-stop-handler"})
+with open(path, "w", encoding="utf-8") as stream:
+    json.dump(data, stream, ensure_ascii=False, indent=2)
+    stream.write("\n")
+PY
 
 # A second install must replace managed hooks and shell blocks, not duplicate them.
 bash "$ROOT_DIR/install.sh"
@@ -98,6 +141,8 @@ hooks=json.load(open(sys.argv[1]))["hooks"]
 for event in ("UserPromptSubmit","SubagentStart","SubagentStop","Stop"):
     managed=[entry for entry in hooks[event] if any("codex-flow/telemetry.py" in hook.get("command", "").replace("\\", "/") for hook in entry.get("hooks", []))]
     assert len(managed) == 1, (event, managed)
+stop_hooks = hooks["Stop"][0]["hooks"]
+assert any(hook.get("command") == "user-stop-handler" for hook in stop_hooks), stop_hooks
 PY
 
 grep -Fq '# bashrc sentinel' "$CODEX_FLOW_SHELL_CONFIG_DIR/.bashrc"
@@ -135,6 +180,14 @@ env -u CODEX_FLOW_BIN_DIR codex-flow uninstall
 [[ ! -e "$CODEX_HOME/skills/flow-pilot" ]]
 [[ ! -e "$CODEX_HOME/skills/cost-aware-development" ]]
 ! grep -qF 'codex-flow/telemetry.py' "$CODEX_HOME/hooks.json"
+python3 - "$CODEX_HOME/hooks.json" <<'PY'
+import json, sys
+
+with open(sys.argv[1], encoding="utf-8") as stream:
+    hooks = json.load(stream)["hooks"]
+stop_hooks = hooks["Stop"][0]["hooks"]
+assert stop_hooks == [{"type": "command", "command": "user-stop-handler"}], stop_hooks
+PY
 ! grep -qF '# >>> codex-flow >>>' "$CODEX_FLOW_SHELL_CONFIG_DIR/.bashrc"
 ! grep -qF '# >>> codex-flow >>>' "$CODEX_FLOW_SHELL_CONFIG_DIR/.profile"
 ! grep -qF '# >>> codex-flow >>>' "$CODEX_FLOW_SHELL_CONFIG_DIR/.zshrc"

--- a/tests/telemetry.sh
+++ b/tests/telemetry.sh
@@ -5,7 +5,6 @@ TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 export CODEX_HOME="$TMP/.codex"
 export FAKE_COUNTER="$TMP/counter"
-export CODEX_FLOW_TELEMETRY_STDOUT=1
 
 cat > "$TMP/fake-app-server.py" <<'PY'
 #!/usr/bin/env python3
@@ -41,7 +40,9 @@ hook() { printf '%s' "$1" | python3 "$ROOT_DIR/scripts/telemetry.py"; }
 hook '{"hook_event_name":"UserPromptSubmit","session_id":"parent-1","turn_id":"turn-1","cwd":"/tmp/work","model":"gpt-parent","prompt":"do work"}'
 hook '{"hook_event_name":"SubagentStart","session_id":"parent-1","turn_id":"turn-1","cwd":"/tmp/work","model":"gpt-worker","agent_id":"worker-1","agent_type":"worker-implementer"}'
 hook '{"hook_event_name":"SubagentStop","session_id":"parent-1","turn_id":"turn-1","cwd":"/tmp/work","model":"gpt-worker","agent_id":"worker-1","agent_type":"worker-implementer"}'
-summary="$(hook '{"hook_event_name":"Stop","session_id":"parent-1","turn_id":"turn-1","cwd":"/tmp/work","model":"gpt-parent","last_assistant_message":"done"}')"
+summary_json="$(hook '{"hook_event_name":"Stop","session_id":"parent-1","turn_id":"turn-1","cwd":"/tmp/work","model":"gpt-parent","last_assistant_message":"done"}')"
+summary="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["systemMessage"], end="")' <<<"$summary_json")"
+python3 -c 'import json,sys; assert isinstance(json.load(sys.stdin)["systemMessage"], str)' <<<"$summary_json"
 printf '%s\n' "$summary"
 [[ "$summary" == *"FlowPilot summary"* ]]
 [[ "$summary" == *"1 parent + 1 worker"* ]]
@@ -57,3 +58,160 @@ json_out="$(python3 "$ROOT_DIR/scripts/telemetry.py" last --json)"
 python3 -c 'import json,sys; d=json.load(sys.stdin); assert d["workers"]["worker-1"]["status"] == "completed"; assert d["parent"]["usage_delta"]["total_tokens"] == 1500' <<<"$json_out"
 
 printf 'telemetry test passed\n'
+
+# Missing thread usage must remain unavailable in both participant rows and
+# the aggregate; an explicitly reported zero is still a real zero.
+python3 - "$ROOT_DIR/scripts/telemetry.py" <<'PY'
+import importlib.util
+import sys
+
+spec = importlib.util.spec_from_file_location("telemetry", sys.argv[1])
+telemetry = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(telemetry)
+
+unavailable = {
+    "parent": {"model": "gpt-parent", "usage_delta": None},
+    "workers": {
+        "worker-1": {
+            "agent_type": "worker-implementer",
+            "model": "gpt-worker",
+            "usage": None,
+            "status": "completed",
+        }
+    },
+}
+summary = telemetry.render_summary(unavailable)
+assert "parent        gpt-parent  n/a tokens" in summary, summary
+assert "worker        worker-implementer  gpt-worker  n/a tokens" in summary, summary
+assert "attributed    n/a tokens" in summary, summary
+assert "attributed    0 tokens" not in summary, summary
+assert "credits" not in summary, summary
+
+partial = {
+    "parent": {
+        "model": "gpt-parent",
+        "usage_delta": {"total_tokens": 12, "estimated_credits_micros": 100},
+    },
+    "workers": {
+        "worker-1": {
+            "agent_type": "worker-implementer",
+            "model": "gpt-worker",
+            "usage": None,
+            "status": "completed",
+        }
+    },
+}
+summary = telemetry.render_summary(partial)
+assert "parent        gpt-parent  12 tokens" in summary, summary
+assert "attributed    n/a tokens" in summary, summary
+assert "attributed    12 tokens" not in summary, summary
+
+zero = {
+    "parent": {
+        "model": "gpt-parent",
+        "usage_delta": {"total_tokens": 0, "estimated_credits_micros": 0},
+    },
+    "workers": {
+        "worker-1": {
+            "agent_type": "worker-implementer",
+            "model": "gpt-worker",
+            "usage": {"total_tokens": 0, "estimated_credits_micros": 0},
+            "status": "completed",
+        }
+    },
+}
+summary = telemetry.render_summary(zero)
+assert "parent        gpt-parent  0 tokens" in summary, summary
+assert "worker        worker-implementer  gpt-worker  0 tokens" in summary, summary
+assert "attributed    0 tokens" in summary, summary
+assert "0.000 credits" in summary, summary
+PY
+
+printf 'telemetry unavailable/zero regression test passed\n'
+
+# A lock timeout must skip the event rather than entering an unlocked
+# critical section or creating a run file.
+mkdir -p "$CODEX_HOME/codex-flow/telemetry"
+mkdir "$CODEX_HOME/codex-flow/telemetry/.locked--turn.lock"
+export CODEX_FLOW_TELEMETRY_LOCK_TIMEOUT=0.01
+locked_output="$(hook '{"hook_event_name":"UserPromptSubmit","session_id":"locked","turn_id":"turn","cwd":"/tmp/work","model":"gpt-parent"}')"
+[[ -z "$locked_output" ]]
+[[ ! -e "$CODEX_HOME/codex-flow/telemetry/runs/locked--turn.json" ]]
+rmdir "$CODEX_HOME/codex-flow/telemetry/.locked--turn.lock"
+unset CODEX_FLOW_TELEMETRY_LOCK_TIMEOUT
+printf 'telemetry lock-timeout regression test passed\n'
+
+# Usage deltas require both snapshots. Group deltas use stable identity and
+# never treat a newly appearing group as if its cumulative total were new.
+python3 - "$ROOT_DIR/scripts/telemetry.py" <<'PY'
+import importlib.util
+import sys
+
+spec = importlib.util.spec_from_file_location("telemetry", sys.argv[1])
+telemetry = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(telemetry)
+
+before = {
+    "total_tokens": 100,
+    "estimated_credits_micros": 1_000,
+    "groups": [
+        {
+            "model": "gpt-test",
+            "reasoning_effort": "high",
+            "speed": "standard",
+            "total_tokens": 100,
+            "estimated_credits_micros": 1_000,
+        }
+    ],
+}
+after = {
+    "total_tokens": 175,
+    "estimated_credits_micros": 1_750,
+    "groups": [
+        {
+            "model": "gpt-test",
+            "reasoning_effort": "high",
+            "speed": "standard",
+            "total_tokens": 175,
+            "estimated_credits_micros": 1_750,
+        },
+        {
+            "model": "new-model",
+            "reasoning_effort": "low",
+            "speed": "standard",
+            "total_tokens": 999,
+            "estimated_credits_micros": 999,
+        },
+    ],
+}
+delta = telemetry.usage_delta(before, after)
+assert delta is not None
+assert delta["total_tokens"] == 75
+assert delta["estimated_credits_micros"] == 750
+assert delta["groups"] == [
+    {
+        "model": "gpt-test",
+        "reasoning_effort": "high",
+        "speed": "standard",
+        "total_tokens": 75,
+        "estimated_credits_micros": 750,
+    }
+]
+assert telemetry.usage_delta(None, after) is None
+assert telemetry.usage_delta(before, None) is None
+assert telemetry.usage_delta({}, after) is None
+
+# A group without a stable identity or with no comparable numeric field is
+# conservatively omitted.
+partial_after = {
+    "groups": [
+        {"model": "gpt-test", "reasoning_effort": "high", "speed": "standard"},
+        {"model": "gpt-test", "reasoning_effort": "high", "speed": None, "total_tokens": 3},
+    ]
+}
+assert telemetry.usage_delta({"groups": before["groups"]}, partial_after)["groups"] == []
+PY
+
+printf 'telemetry usage-delta regression test passed\n'


### PR DESCRIPTION
## Summary

- preserve user handlers when FlowPilot shares a hook group and skip telemetry writes when locking fails
- report usage only from complete snapshots, keep unavailable/zero semantics distinct, and warn on older Codex CLI compatibility
- preserve UTF-8 configuration and custom bin locations across Windows install, update, and uninstall
- make the required full Codex restart and /hooks approval unmistakable at the end of both installers
- expand Unix and Windows regression coverage, including PowerShell 5.1 and PowerShell 7 CI

## Validation

- bash tests/smoke.sh
- bash tests/telemetry.sh
- bash tests/runner.sh
- bash tests/benchmark.sh
- bash tests/corpus.sh
- bash tests/report.sh
- bash syntax checks
- GitHub Actions YAML parse
- git diff --check

Windows runtime validation is included in CI because PowerShell is not installed in the local macOS environment.