### PR TITLE
feat: localize native macOS FlowPilot app

### DIFF
--- a/apps/macos-overlay/Sources/Controllers/OverlayWindowController.swift
+++ b/apps/macos-overlay/Sources/Controllers/OverlayWindowController.swift
@@ -357,7 +357,7 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
         if let state = windowController?.state {
             if state.isExpanded {
                 let pinItem = NSMenuItem(
-                    title: state.isPinned ? "Unpin Window" : "Pin Window",
+                    title: state.isPinned ? L("Unpin Window", "取消置顶") : L("Pin Window", "置顶窗口"),
                     action: #selector(togglePin),
                     keyEquivalent: "p"
                 )
@@ -365,7 +365,7 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
                 menu.addItem(pinItem)
                 
                 let collapseItem = NSMenuItem(
-                    title: "Collapse to Bubble",
+                    title: L("Collapse to Bubble", "收起为悬浮球"),
                     action: #selector(collapseBubble),
                     keyEquivalent: "c"
                 )
@@ -373,7 +373,7 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
                 menu.addItem(collapseItem)
             } else {
                 let expandItem = NSMenuItem(
-                    title: "Expand Summary",
+                    title: L("Expand Summary", "展开摘要"),
                     action: #selector(expandSummary),
                     keyEquivalent: "e"
                 )
@@ -385,7 +385,7 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
         menu.addItem(NSMenuItem.separator())
         
         let consoleItem = NSMenuItem(
-            title: "Open FlowPilot Console",
+            title: L("Open FlowPilot Console", "打开 FlowPilot 控制台"),
             action: #selector(openConsole),
             keyEquivalent: "t"
         )
@@ -393,7 +393,7 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
         menu.addItem(consoleItem)
         
         let refreshItem = NSMenuItem(
-            title: "Refresh Telemetry",
+            title: L("Refresh Telemetry", "刷新遥测数据"),
             action: #selector(refreshData),
             keyEquivalent: "r"
         )
@@ -403,7 +403,7 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
         menu.addItem(NSMenuItem.separator())
         
         let quitItem = NSMenuItem(
-            title: "Quit FlowPilot",
+            title: L("Quit FlowPilot", "退出 FlowPilot"),
             action: #selector(quitApp),
             keyEquivalent: "q"
         )

--- a/apps/macos-overlay/Sources/Localization.swift
+++ b/apps/macos-overlay/Sources/Localization.swift
@@ -1,0 +1,159 @@
+import Foundation
+import Combine
+
+public enum AppLanguage: String {
+    case zh
+    case en
+}
+
+public final class AppLocalization: ObservableObject {
+    public static let shared = AppLocalization()
+
+    @Published public private(set) var language: AppLanguage
+    private var refreshTimer: Timer?
+
+    private init() {
+        language = Self.resolveLanguage()
+        refreshTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            guard let self else { return }
+            let resolved = Self.resolveLanguage()
+            if resolved != self.language {
+                self.language = resolved
+            }
+        }
+    }
+
+    deinit {
+        refreshTimer?.invalidate()
+    }
+
+    public func text(_ english: String, _ chinese: String) -> String {
+        language == .zh ? chinese : english
+    }
+
+    public static func resolveLanguage() -> AppLanguage {
+        let env = ProcessInfo.processInfo.environment
+        if let rawOverride = env["CODEX_FLOW_LANGUAGE"], !rawOverride.isEmpty {
+            return resolve(normalize(rawOverride) ?? "auto")
+        }
+        return resolve(configuredLanguage())
+    }
+
+    public static func configuredLanguage() -> String {
+        let env = ProcessInfo.processInfo.environment
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let codexHome = env["CODEX_HOME"] ?? home.appendingPathComponent(".codex").path
+        let policy = URL(fileURLWithPath: codexHome).appendingPathComponent("codex-flow.toml")
+        guard let text = try? String(contentsOf: policy, encoding: .utf8) else { return "auto" }
+
+        var inUI = false
+        for rawLine in text.components(separatedBy: .newlines) {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            if line.hasPrefix("[") && line.hasSuffix("]") {
+                inUI = line == "[ui]"
+                continue
+            }
+            guard inUI else { continue }
+            let noComment = line.split(separator: "#", maxSplits: 1, omittingEmptySubsequences: false)[0]
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard noComment.hasPrefix("language"), let eq = noComment.firstIndex(of: "=") else { continue }
+            let rawValue = noComment[noComment.index(after: eq)...]
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+            return normalize(rawValue) ?? "auto"
+        }
+        return "auto"
+    }
+
+    public static func systemLanguage() -> AppLanguage {
+        for candidate in Locale.preferredLanguages {
+            if let normalized = normalize(candidate), normalized != "auto" {
+                return normalized == "zh" ? .zh : .en
+            }
+        }
+
+        let env = ProcessInfo.processInfo.environment
+        for key in ["LC_ALL", "LC_MESSAGES", "LANGUAGE", "LANG"] {
+            if let normalized = normalize(env[key]), normalized != "auto" {
+                return normalized == "zh" ? .zh : .en
+            }
+        }
+        return .en
+    }
+
+    private static func resolve(_ normalized: String) -> AppLanguage {
+        switch normalized {
+        case "zh": return .zh
+        case "en": return .en
+        default: return systemLanguage()
+        }
+    }
+
+    private static func normalize(_ raw: String?) -> String? {
+        let value = (raw ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "_", with: "-")
+        if value.isEmpty || ["auto", "system", "default"].contains(value) { return "auto" }
+        if value == "zh" || value.hasPrefix("zh-") || value.hasPrefix("chinese") { return "zh" }
+        if value == "en" || value.hasPrefix("en-") || value.hasPrefix("english") { return "en" }
+        return nil
+    }
+}
+
+@inline(__always)
+public func L(_ english: String, _ chinese: String) -> String {
+    AppLocalization.shared.text(english, chinese)
+}
+
+public func localizedRole(_ role: String) -> String {
+    switch role.lowercased() {
+    case "parent": return L("parent", "父 Agent")
+    case "worker", "subagent": return L("worker", "Worker")
+    default: return role
+    }
+}
+
+public extension OverlayTab {
+    var localizedTitle: String {
+        switch self {
+        case .inspector: return L("Inspector", "任务")
+        case .history: return L("History", "历史")
+        case .analytics: return L("Analytics", "统计")
+        }
+    }
+}
+
+public extension QuotaWindow {
+    var localizedFormattedResetsAt: String? {
+        guard let r = resetsAt, r > 0 else { return nil }
+        let date = Date(timeIntervalSince1970: r > 1_000_000_000_000 ? r / 1000.0 : r)
+        let interval = date.timeIntervalSince(Date())
+        if interval > 0 && interval < 86400 {
+            let mins = Int(interval) / 60
+            if mins < 60 {
+                return L("resets in \(mins)m", "\(mins) 分钟后重置")
+            }
+            let hours = mins / 60
+            let remMins = mins % 60
+            return L("resets in \(hours)h \(remMins)m", "\(hours) 小时 \(remMins) 分钟后重置")
+        }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        return L("resets at \(formatter.string(from: date))", "\(formatter.string(from: date)) 重置")
+    }
+}
+
+public extension TaskRun {
+    var localizedFormattedDate: String {
+        guard let s = startedAtMs else { return "--:--" }
+        let date = Date(timeIntervalSince1970: s / 1000.0)
+        let formatter = DateFormatter()
+        if Calendar.current.isDateInToday(date) {
+            formatter.dateFormat = "HH:mm"
+            return L("Today \(formatter.string(from: date))", "今天 \(formatter.string(from: date))")
+        }
+        formatter.dateFormat = "MM-dd HH:mm"
+        return formatter.string(from: date)
+    }
+}

--- a/apps/macos-overlay/Sources/Services/IPCServer.swift
+++ b/apps/macos-overlay/Sources/Services/IPCServer.swift
@@ -190,12 +190,12 @@ public class IPCService {
     // MARK: - Client Implementation
     public static func sendCommand(_ cmd: String, socketPath: String = IPCService.socketPath) -> (success: Bool, response: String) {
         guard FileManager.default.fileExists(atPath: socketPath) else {
-            return (false, "Overlay is not running (socket not found).")
+            return (false, L("Overlay is not running (socket not found).", "悬浮窗未运行（未找到 socket）。"))
         }
         
         let clientSocket = socket(AF_UNIX, SOCK_STREAM, 0)
         guard clientSocket >= 0 else {
-            return (false, "Failed to create client socket.")
+            return (false, L("Failed to create client socket.", "创建客户端 socket 失败。"))
         }
         defer { close(clientSocket) }
         
@@ -218,11 +218,11 @@ public class IPCService {
         }
         
         guard connectResult == 0 else {
-            return (false, "Failed to connect to overlay socket.")
+            return (false, L("Failed to connect to overlay socket.", "连接悬浮窗 socket 失败。"))
         }
         
         guard let data = cmd.data(using: .utf8) else {
-            return (false, "Encoding error.")
+            return (false, L("Encoding error.", "编码错误。"))
         }
         
         _ = data.withUnsafeBytes { raw in

--- a/apps/macos-overlay/Sources/Views/AnalyticsView.swift
+++ b/apps/macos-overlay/Sources/Views/AnalyticsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 public struct AnalyticsView: View {
     @ObservedObject var state: OverlayState
+    @ObservedObject private var localization = AppLocalization.shared
     
     public init(state: OverlayState) {
         self.state = state
@@ -48,15 +49,15 @@ public struct AnalyticsView: View {
     // MARK: - Period Header
     private var periodHeader: some View {
         HStack {
-            Text("Aggregation Summary")
+            Text(L("Aggregation Summary", "聚合统计"))
                 .font(.system(size: 10.5, weight: .bold, design: .rounded))
                 .foregroundColor(.white.opacity(0.85))
             
             Spacer()
             
             HStack(spacing: 2) {
-                dayButton(days: 7, title: "7 Days")
-                dayButton(days: 30, title: "30 Days")
+                dayButton(days: 7, title: L("7 Days", "7 天"))
+                dayButton(days: 30, title: L("30 Days", "30 天"))
             }
             .padding(2)
             .background(Capsule().fill(Color.white.opacity(0.06)))
@@ -109,23 +110,23 @@ public struct AnalyticsView: View {
     private var kpiSummaryGrid: some View {
         HStack(spacing: 6) {
             kpiCard(
-                title: "Tasks",
+                title: L("Tasks", "任务"),
                 value: "\(stats.totalRuns)",
-                subtext: "\(stats.delegatedRuns) delegated",
+                subtext: L("\(stats.delegatedRuns) delegated", "委派 \(stats.delegatedRuns) 次"),
                 icon: "sparkles",
                 accentColor: .cyan
             )
             
             kpiCard(
-                title: "Active Time",
+                title: L("Active Time", "活跃时长"),
                 value: stats.formattedTotalDuration,
-                subtext: "\(stats.days)d total",
+                subtext: L("\(stats.days)d total", "累计 \(stats.days) 天"),
                 icon: "timer",
                 accentColor: .indigo
             )
             
             kpiCard(
-                title: "Tokens",
+                title: L("Tokens", "Token"),
                 value: TaskRun.formatTokenCount(stats.totalTokens),
                 subtext: stats.formattedCost,
                 icon: "circle.grid.cross.fill",
@@ -173,15 +174,15 @@ public struct AnalyticsView: View {
         VStack(spacing: 6) {
             // Cache Ratio Bar
             efficiencyRow(
-                title: "Cache Efficiency",
+                title: L("Cache Efficiency", "缓存效率"),
                 percentage: stats.cacheRatio,
-                detail: "\(TaskRun.formatTokenCount(stats.cachedInputTokens)) cached",
+                detail: L("\(TaskRun.formatTokenCount(stats.cachedInputTokens)) cached", "缓存 \(TaskRun.formatTokenCount(stats.cachedInputTokens))"),
                 color: Color(red: 0.28, green: 0.58, blue: 0.95)
             )
             
             // Worker Offload Bar
             efficiencyRow(
-                title: "Worker Offload",
+                title: L("Worker Offload", "Worker 分流"),
                 percentage: stats.workerOffloadRatio,
                 detail: "\(TaskRun.formatTokenCount(stats.workerTokens)) / \(TaskRun.formatTokenCount(stats.totalTokens))",
                 color: Color(red: 0.22, green: 0.88, blue: 0.58)
@@ -234,7 +235,7 @@ public struct AnalyticsView: View {
     // MARK: - Model Breakdown Card
     private var modelBreakdownCard: some View {
         VStack(alignment: .leading, spacing: 5) {
-            Text("Model Breakdown")
+            Text(L("Model Breakdown", "模型分布"))
                 .font(.system(size: 9.5, weight: .bold, design: .rounded))
                 .foregroundColor(.white.opacity(0.7))
                 .textCase(.uppercase)
@@ -259,7 +260,7 @@ public struct AnalyticsView: View {
     // MARK: - Project Breakdown Card
     private var projectBreakdownCard: some View {
         VStack(alignment: .leading, spacing: 5) {
-            Text("Projects Distribution")
+            Text(L("Projects Distribution", "项目分布"))
                 .font(.system(size: 9.5, weight: .bold, design: .rounded))
                 .foregroundColor(.white.opacity(0.7))
                 .textCase(.uppercase)
@@ -284,6 +285,7 @@ public struct AnalyticsView: View {
 
 // MARK: - Model Breakdown Row
 public struct ModelBreakdownRow: View {
+    @ObservedObject private var localization = AppLocalization.shared
     public var model: ModelStats
     public var totalTokens: Int
     
@@ -299,7 +301,7 @@ public struct ModelBreakdownRow: View {
             // Roles chips
             HStack(spacing: 2) {
                 ForEach(model.roles, id: \.self) { role in
-                    Text(role)
+                    Text(localizedRole(role))
                         .font(.system(size: 7.5, weight: .medium))
                         .foregroundColor(role == "parent" ? .indigo.opacity(0.9) : .teal.opacity(0.9))
                         .padding(.horizontal, 3)
@@ -313,7 +315,7 @@ public struct ModelBreakdownRow: View {
             
             Spacer()
             
-            Text("\(model.calls) calls")
+            Text(L("\(model.calls) calls", "\(model.calls) 次调用"))
                 .font(.system(size: 8.0, weight: .regular))
                 .foregroundColor(.white.opacity(0.4))
             
@@ -338,6 +340,7 @@ public struct ModelBreakdownRow: View {
 
 // MARK: - Project Breakdown Row
 public struct ProjectBreakdownRow: View {
+    @ObservedObject private var localization = AppLocalization.shared
     public var project: ProjectStats
     
     public var body: some View {
@@ -353,7 +356,7 @@ public struct ProjectBreakdownRow: View {
             
             Spacer()
             
-            Text("\(project.runs) runs")
+            Text(L("\(project.runs) runs", "\(project.runs) 次任务"))
                 .font(.system(size: 8.0, weight: .regular))
                 .foregroundColor(.white.opacity(0.4))
             

--- a/apps/macos-overlay/Sources/Views/BubbleView.swift
+++ b/apps/macos-overlay/Sources/Views/BubbleView.swift
@@ -3,6 +3,7 @@ import AppKit
 
 public struct BubbleView: View {
     @ObservedObject var state: OverlayState
+    @ObservedObject private var localization = AppLocalization.shared
     @State private var isHovered: Bool = false
     @State private var breathePhase: CGFloat = 0.0
     @State private var shimmerAngle: Double = 0.0
@@ -78,7 +79,7 @@ public struct BubbleView: View {
             }
             
             // Clean, bold Token metric (no decimals in docked half-screen mode)
-            Text(state.latestRun?.formattedCompactTokens ?? "Ready")
+            Text(state.latestRun?.formattedCompactTokens ?? L("Ready", "就绪"))
                 .font(.system(size: 9.0, weight: .bold, design: .rounded))
                 .foregroundColor(.white)
                 .lineLimit(1)
@@ -92,7 +93,7 @@ public struct BubbleView: View {
                         .foregroundColor(.cyan.opacity(0.9))
                 }
                 
-                Text(state.isTaskRunning ? "RUN" : "OK")
+                Text(state.isTaskRunning ? L("RUN", "运行") : L("OK", "正常"))
                     .font(.system(size: 7.5, weight: .black, design: .rounded))
                     .foregroundColor(statusColor)
                 
@@ -205,7 +206,7 @@ public struct BubbleView: View {
                         .font(.system(size: 6.5, weight: .bold))
                         .foregroundColor(statusColor)
                     
-                    Text(state.latestRun?.formattedCompactTokens ?? "Ready")
+                    Text(state.latestRun?.formattedCompactTokens ?? L("Ready", "就绪"))
                         .font(.system(size: 8, weight: .bold, design: .rounded))
                         .foregroundColor(.white.opacity(0.95))
                         .lineLimit(1)

--- a/apps/macos-overlay/Sources/Views/HistoryView.swift
+++ b/apps/macos-overlay/Sources/Views/HistoryView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 public struct HistoryView: View {
     @ObservedObject var state: OverlayState
+    @ObservedObject private var localization = AppLocalization.shared
     @State private var availableProjects: [String] = []
     
     public init(state: OverlayState) {
@@ -32,11 +33,11 @@ public struct HistoryView: View {
             HStack(spacing: 6) {
                 // Scope selector (All / Today)
                 HStack(spacing: 2) {
-                    scopeButton(title: "All", isSelected: !state.isTodayOnly) {
+                    scopeButton(title: L("All", "全部"), isSelected: !state.isTodayOnly) {
                         state.isTodayOnly = false
                         state.loadHistory()
                     }
-                    scopeButton(title: "Today", isSelected: state.isTodayOnly) {
+                    scopeButton(title: L("Today", "今天"), isSelected: state.isTodayOnly) {
                         state.isTodayOnly = true
                         state.loadHistory()
                     }
@@ -48,7 +49,7 @@ public struct HistoryView: View {
                 if availableProjects.count > 2 {
                     Menu {
                         ForEach(availableProjects, id: \.self) { proj in
-                            Button(proj) {
+                            Button(proj == "All" ? L("All", "全部") : proj) {
                                 state.selectedProject = (proj == "All" ? nil : proj)
                                 state.loadHistory()
                             }
@@ -57,7 +58,7 @@ public struct HistoryView: View {
                         HStack(spacing: 3) {
                             Image(systemName: "folder")
                                 .font(.system(size: 9))
-                            Text(state.selectedProject ?? "All Projects")
+                            Text(state.selectedProject ?? L("All Projects", "全部项目"))
                                 .font(.system(size: 9.5, weight: .medium))
                                 .lineLimit(1)
                             Image(systemName: "chevron.down")
@@ -75,7 +76,7 @@ public struct HistoryView: View {
                 Spacer()
                 
                 // Task Count Badge
-                Text("\(state.historyRuns.count) runs")
+                Text(L("\(state.historyRuns.count) runs", "\(state.historyRuns.count) 次任务"))
                     .font(.system(size: 9.5, weight: .semibold, design: .rounded))
                     .foregroundColor(.white.opacity(0.45))
             }
@@ -86,7 +87,7 @@ public struct HistoryView: View {
                     .font(.system(size: 9.5))
                     .foregroundColor(.white.opacity(0.4))
                 
-                TextField("Search session, branch, or prompt...", text: $state.searchQuery)
+                TextField(L("Search session, branch, or prompt...", "搜索会话、分支或提示词…"), text: $state.searchQuery)
                     .textFieldStyle(.plain)
                     .font(.system(size: 10.5))
                     .foregroundColor(.white)
@@ -164,7 +165,7 @@ public struct HistoryView: View {
                 .padding(.top, 24)
             
             if !state.searchQuery.isEmpty {
-                Text("No results for \"\(state.searchQuery)\"")
+                Text(L("No results for \"\(state.searchQuery)\"", "没有找到‘\(state.searchQuery)’的结果"))
                     .font(.system(size: 11.5, weight: .medium))
                     .foregroundColor(.white.opacity(0.75))
                 
@@ -172,7 +173,7 @@ public struct HistoryView: View {
                     state.searchQuery = ""
                     state.loadHistory()
                 } label: {
-                    Text("Clear Search")
+                    Text(L("Clear Search", "清除搜索"))
                         .font(.system(size: 10, weight: .semibold))
                         .foregroundColor(.cyan)
                         .padding(.horizontal, 10)
@@ -181,7 +182,7 @@ public struct HistoryView: View {
                 }
                 .buttonStyle(.plain)
             } else if state.isTodayOnly {
-                Text("No tasks recorded today")
+                Text(L("No tasks recorded today", "今天还没有任务记录"))
                     .font(.system(size: 11.5, weight: .medium))
                     .foregroundColor(.white.opacity(0.75))
                 
@@ -189,7 +190,7 @@ public struct HistoryView: View {
                     state.isTodayOnly = false
                     state.loadHistory()
                 } label: {
-                    Text("Show All Time")
+                    Text(L("Show All Time", "查看全部时间"))
                         .font(.system(size: 10, weight: .semibold))
                         .foregroundColor(.cyan)
                         .padding(.horizontal, 10)
@@ -198,7 +199,7 @@ public struct HistoryView: View {
                 }
                 .buttonStyle(.plain)
             } else if let p = state.selectedProject {
-                Text("No runs for project \"\(p)\"")
+                Text(L("No runs for project \"\(p)\"", "项目‘\(p)’暂无任务"))
                     .font(.system(size: 11.5, weight: .medium))
                     .foregroundColor(.white.opacity(0.75))
                 
@@ -206,7 +207,7 @@ public struct HistoryView: View {
                     state.selectedProject = nil
                     state.loadHistory()
                 } label: {
-                    Text("Show All Projects")
+                    Text(L("Show All Projects", "查看全部项目"))
                         .font(.system(size: 10, weight: .semibold))
                         .foregroundColor(.cyan)
                         .padding(.horizontal, 10)
@@ -215,11 +216,11 @@ public struct HistoryView: View {
                 }
                 .buttonStyle(.plain)
             } else {
-                Text("No telemetry runs recorded yet")
+                Text(L("No telemetry runs recorded yet", "尚未记录遥测任务"))
                     .font(.system(size: 12, weight: .medium))
                     .foregroundColor(.white.opacity(0.75))
                 
-                Text("FlowPilot logs token and duration telemetry automatically.")
+                Text(L("FlowPilot logs token and duration telemetry automatically.", "FlowPilot 会自动记录 Token 和耗时遥测。"))
                     .font(.system(size: 10))
                     .foregroundColor(.white.opacity(0.4))
                     .multilineTextAlignment(.center)
@@ -231,6 +232,7 @@ public struct HistoryView: View {
 
 // MARK: - Individual History Row
 public struct HistoryItemRow: View {
+    @ObservedObject private var localization = AppLocalization.shared
     public var index: Int
     public var run: TaskRun
     public var isSelected: Bool
@@ -241,103 +243,122 @@ public struct HistoryItemRow: View {
     public var body: some View {
         Button(action: onSelect) {
             HStack(spacing: 7) {
-                // Index badge
-                Text("#\(index)")
-                    .font(.system(size: 9.5, weight: .bold, design: .monospaced))
-                    .foregroundColor(index == 1 ? .cyan : .white.opacity(0.45))
-                    .frame(width: 24, alignment: .leading)
-                
-                // Main Info
-                VStack(alignment: .leading, spacing: 2) {
-                    HStack(spacing: 4) {
-                        // Project & branch chip
-                        Text(run.projectName)
-                            .font(.system(size: 10, weight: .bold, design: .rounded))
-                            .foregroundColor(.white.opacity(0.95))
-                            .lineLimit(1)
-                        
-                        if let b = run.gitBranch, !b.isEmpty {
-                            Text("(\(b))")
-                                .font(.system(size: 9, weight: .medium, design: .monospaced))
-                                .foregroundColor(.cyan.opacity(0.8))
-                                .lineLimit(1)
-                        }
-                        
-                        Spacer()
-                        
-                        // Time stamp
-                        Text(run.formattedDate)
-                            .font(.system(size: 8.5, weight: .regular))
-                            .foregroundColor(.white.opacity(0.4))
-                    }
-                    
-                    // Task Preview / Title
-                    Text(run.sessionTitle)
-                        .font(.system(size: 10, weight: .regular))
-                        .foregroundColor(.white.opacity(0.7))
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                    
-                    // Footer details: Workers, Duration, Tokens
-                    HStack(spacing: 6) {
-                        let wCount = run.allWorkers.count
-                        if wCount > 0 {
-                            HStack(spacing: 2) {
-                                Image(systemName: "person.2.fill")
-                                    .font(.system(size: 7.5))
-                                Text("\(wCount) workers")
-                                    .font(.system(size: 8.5, weight: .medium))
-                            }
-                            .foregroundColor(.teal.opacity(0.85))
-                        } else {
-                            Text("Direct")
-                                .font(.system(size: 8.5, weight: .regular))
-                                .foregroundColor(.white.opacity(0.4))
-                        }
-                        
-                        Text("·")
-                            .foregroundColor(.white.opacity(0.2))
-                        
-                        Text(run.formattedDuration)
-                            .font(.system(size: 8.5, weight: .medium, design: .monospaced))
-                            .foregroundColor(.white.opacity(0.55))
-                        
-                        Spacer()
-                        
-                        // Tokens Badge
-                        Text(run.formattedTotalTokens)
-                            .font(.system(size: 9, weight: .bold, design: .rounded))
-                            .foregroundColor(Color(red: 0.95, green: 0.35, blue: 0.8))
-                        
-                        // Status dot
-                        Circle()
-                            .fill(statusColor)
-                            .frame(width: 4.5, height: 4.5)
-                    }
-                }
+                indexBadge
+                mainInfo
             }
             .padding(.horizontal, 8)
             .padding(.vertical, 6)
-            .background(
-                RoundedRectangle(cornerRadius: 9)
-                    .fill(
-                        isSelected ? Color.cyan.opacity(0.15) :
-                        (isHovered ? Color.white.opacity(0.07) : Color.white.opacity(0.03))
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 9)
-                            .stroke(
-                                isSelected ? Color.cyan.opacity(0.4) :
-                                (isHovered ? Color.white.opacity(0.12) : Color.white.opacity(0.05)),
-                                lineWidth: 0.8
-                            )
-                    )
-            )
+            .background(rowBackground)
         }
         .buttonStyle(.plain)
         .onHover { isHovered = $0 }
     }
-    
+
+    private var indexBadge: some View {
+        Text("#\(index)")
+            .font(.system(size: 9.5, weight: .bold, design: .monospaced))
+            .foregroundColor(index == 1 ? .cyan : .white.opacity(0.45))
+            .frame(width: 24, alignment: .leading)
+    }
+
+    private var mainInfo: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            headerRow
+
+            Text(run.sessionTitle)
+                .font(.system(size: 10, weight: .regular))
+                .foregroundColor(.white.opacity(0.7))
+                .lineLimit(1)
+                .truncationMode(.tail)
+
+            footerRow
+        }
+    }
+
+    private var headerRow: some View {
+        HStack(spacing: 4) {
+            Text(run.projectName)
+                .font(.system(size: 10, weight: .bold, design: .rounded))
+                .foregroundColor(.white.opacity(0.95))
+                .lineLimit(1)
+
+            if let branch = run.gitBranch, !branch.isEmpty {
+                Text("(\(branch))")
+                    .font(.system(size: 9, weight: .medium, design: .monospaced))
+                    .foregroundColor(.cyan.opacity(0.8))
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            Text(run.localizedFormattedDate)
+                .font(.system(size: 8.5, weight: .regular))
+                .foregroundColor(.white.opacity(0.4))
+        }
+    }
+
+    private var footerRow: some View {
+        HStack(spacing: 6) {
+            executionMode
+
+            Text("·")
+                .foregroundColor(.white.opacity(0.2))
+
+            Text(run.formattedDuration)
+                .font(.system(size: 8.5, weight: .medium, design: .monospaced))
+                .foregroundColor(.white.opacity(0.55))
+
+            Spacer()
+
+            Text(run.formattedTotalTokens)
+                .font(.system(size: 9, weight: .bold, design: .rounded))
+                .foregroundColor(Color(red: 0.95, green: 0.35, blue: 0.8))
+
+            Circle()
+                .fill(statusColor)
+                .frame(width: 4.5, height: 4.5)
+        }
+    }
+
+    @ViewBuilder
+    private var executionMode: some View {
+        let workerCount = run.allWorkers.count
+        if workerCount > 0 {
+            HStack(spacing: 2) {
+                Image(systemName: "person.2.fill")
+                    .font(.system(size: 7.5))
+                Text(L("\(workerCount) workers", "\(workerCount) 个 Worker"))
+                    .font(.system(size: 8.5, weight: .medium))
+            }
+            .foregroundColor(.teal.opacity(0.85))
+        } else {
+            Text(L("Direct", "直接执行"))
+                .font(.system(size: 8.5, weight: .regular))
+                .foregroundColor(.white.opacity(0.4))
+        }
+    }
+
+    private var rowFillColor: Color {
+        if isSelected { return Color.cyan.opacity(0.15) }
+        if isHovered { return Color.white.opacity(0.07) }
+        return Color.white.opacity(0.03)
+    }
+
+    private var rowStrokeColor: Color {
+        if isSelected { return Color.cyan.opacity(0.4) }
+        if isHovered { return Color.white.opacity(0.12) }
+        return Color.white.opacity(0.05)
+    }
+
+    private var rowBackground: some View {
+        RoundedRectangle(cornerRadius: 9)
+            .fill(rowFillColor)
+            .overlay(
+                RoundedRectangle(cornerRadius: 9)
+                    .stroke(rowStrokeColor, lineWidth: 0.8)
+            )
+    }
+
     private var statusColor: Color {
         if run.isRunning {
             return .cyan

--- a/apps/macos-overlay/Sources/Views/SummaryView.swift
+++ b/apps/macos-overlay/Sources/Views/SummaryView.swift
@@ -91,6 +91,7 @@ public struct MetricRingView: View {
 
 // MARK: - Quota & Rate Limit Windows Meter
 public struct QuotaWindowsView: View {
+    @ObservedObject private var localization = AppLocalization.shared
     public var windows: [QuotaWindow]
     
     public init(windows: [QuotaWindow]) {
@@ -105,7 +106,7 @@ public struct QuotaWindowsView: View {
                         Image(systemName: "gauge.with.needle.fill")
                             .font(.system(size: 9))
                             .foregroundColor(.cyan)
-                        Text("Rate Limits & Account Quota")
+                        Text(L("Rate Limits & Account Quota", "速率限制与账户配额"))
                             .font(.system(size: 9.5, weight: .semibold, design: .rounded))
                             .foregroundColor(.white.opacity(0.85))
                             .lineLimit(1)
@@ -113,7 +114,7 @@ public struct QuotaWindowsView: View {
                     
                     Spacer(minLength: 4)
                     
-                    if let firstReset = windows.compactMap({ $0.formattedResetsAt }).first {
+                    if let firstReset = windows.compactMap({ $0.localizedFormattedResetsAt }).first {
                         Text(firstReset)
                             .font(.system(size: 8.0, weight: .regular))
                             .foregroundColor(.white.opacity(0.45))
@@ -153,7 +154,7 @@ public struct QuotaWindowsView: View {
                 
                 Spacer(minLength: 4)
                 
-                Text(String(format: "%.0f%% rem", rem))
+                Text(String(format: L("%.0f%% rem", "剩余 %.0f%%"), rem))
                     .font(.system(size: 8.0, weight: .semibold, design: .rounded))
                     .foregroundColor(color)
                     .lineLimit(1)
@@ -175,7 +176,7 @@ public struct QuotaWindowsView: View {
             .frame(height: 3)
             
             if let delta = window.deltaPercentagePoints, delta != 0 {
-                Text(String(format: "%+.1f pp", delta))
+                Text(String(format: L("%+.1f pp", "%+.1f 个百分点"), delta))
                     .font(.system(size: 7.5, weight: .regular))
                     .foregroundColor(delta > 0 ? .orange.opacity(0.85) : .green.opacity(0.85))
                     .lineLimit(1)
@@ -193,6 +194,7 @@ public struct QuotaWindowsView: View {
 
 // MARK: - Token Segmented Distribution Bar
 public struct TokenDistributionBar: View {
+    @ObservedObject private var localization = AppLocalization.shared
     public var usage: TokenUsage
     
     public init(usage: TokenUsage) {
@@ -232,14 +234,14 @@ public struct TokenDistributionBar: View {
     
     private var headerRow: some View {
         HStack {
-            Text("Token Distribution")
+            Text(L("Token Distribution", "Token 分布"))
                 .font(.system(size: 9.5, weight: .semibold, design: .rounded))
                 .foregroundColor(.white.opacity(0.85))
                 .lineLimit(1)
             
             Spacer(minLength: 4)
             
-            Text("Total: \(TaskRun.formatTokenCount(rawTotal))")
+            Text(L("Total: \(TaskRun.formatTokenCount(usage.totalTokens ?? (prompt + completion)))", "总计：\(TaskRun.formatTokenCount(usage.totalTokens ?? (prompt + completion)))"))
                 .font(.system(size: 9.5, weight: .semibold, design: .rounded))
                 .foregroundColor(.white.opacity(0.6))
                 .lineLimit(1)
@@ -292,7 +294,7 @@ public struct TokenDistributionBar: View {
                 let promptPct = rawTotal > 0 ? Int(Double(prompt) / Double(total) * 100) : 0
                 legendItem(
                     color: Color(red: 0.88, green: 0.35, blue: 0.82),
-                    label: "Prompt",
+                    label: L("Prompt", "输入"),
                     count: TaskRun.formatTokenCount(prompt),
                     pct: promptPct
                 )
@@ -302,7 +304,7 @@ public struct TokenDistributionBar: View {
                 let compPct = rawTotal > 0 ? Int(Double(completion) / Double(total) * 100) : 0
                 legendItem(
                     color: Color(red: 0.22, green: 0.88, blue: 0.58),
-                    label: "Output",
+                    label: L("Output", "输出"),
                     count: TaskRun.formatTokenCount(completion),
                     pct: compPct
                 )
@@ -315,7 +317,7 @@ public struct TokenDistributionBar: View {
                         let cachedPct = Int(Double(cached) / Double(total) * 100)
                         legendItem(
                             color: Color(red: 0.28, green: 0.58, blue: 0.95),
-                            label: "Cached",
+                            label: L("Cached", "缓存"),
                             count: TaskRun.formatTokenCount(cached),
                             pct: cachedPct
                         )
@@ -329,7 +331,7 @@ public struct TokenDistributionBar: View {
                         let rPct = Int(Double(reasoning) / Double(total) * 100)
                         legendItem(
                             color: Color(red: 0.65, green: 0.45, blue: 0.95),
-                            label: "Reason",
+                            label: L("Reason", "推理"),
                             count: TaskRun.formatTokenCount(reasoning),
                             pct: rPct
                         )
@@ -368,6 +370,7 @@ public struct TokenDistributionBar: View {
 // MARK: - Native Summary View Card
 public struct SummaryView: View {
     @ObservedObject var state: OverlayState
+    @ObservedObject private var localization = AppLocalization.shared
     @State private var copiedSummary: Bool = false
     
     public init(state: OverlayState) {
@@ -510,7 +513,7 @@ public struct SummaryView: View {
                     HStack(spacing: 5) {
                         Image(systemName: tab.iconName)
                             .font(.system(size: 10, weight: isSelected ? .bold : .medium))
-                        Text(tab.rawValue)
+                        Text(tab.localizedTitle)
                             .font(.system(size: 11, weight: isSelected ? .bold : .medium, design: .rounded))
                     }
                     .foregroundColor(isSelected ? .white : .white.opacity(0.6))
@@ -554,7 +557,7 @@ public struct SummaryView: View {
                 // 3 KPI Rings
                 HStack(spacing: 6) {
                     MetricRingView(
-                        title: "Time",
+                        title: L("Time", "耗时"),
                         value: run.formattedDuration,
                         progress: min(1.0, run.durationSeconds / 30.0),
                         ringColor: Color.cyan,
@@ -562,7 +565,7 @@ public struct SummaryView: View {
                     )
                     
                     MetricRingView(
-                        title: "Tokens",
+                        title: L("Tokens", "Token"),
                         value: run.formattedTotalTokens,
                         progress: min(1.0, Double(run.aggregatedUsage.totalTokens ?? 0) / 100_000.0),
                         ringColor: Color(red: 0.95, green: 0.35, blue: 0.8),
@@ -570,7 +573,7 @@ public struct SummaryView: View {
                     )
                     
                     MetricRingView(
-                        title: "Cost",
+                        title: L("Cost", "成本"),
                         value: run.formattedCost,
                         progress: min(1.0, (run.aggregatedUsage.estimatedCreditsMicros ?? 0) / 100_000.0),
                         ringColor: Color(red: 0.2, green: 0.85, blue: 0.45),
@@ -618,11 +621,11 @@ public struct SummaryView: View {
             .padding(.top, 14)
             
             VStack(spacing: 4) {
-                Text("FlowPilot is Ready")
+                Text(L("FlowPilot is Ready", "FlowPilot 已就绪"))
                     .font(.system(size: 14, weight: .bold, design: .rounded))
                     .foregroundColor(.white)
                 
-                Text("Listening for live agent runs & telemetry")
+                Text(L("Listening for live agent runs & telemetry", "正在监听 Agent 任务与遥测数据"))
                     .font(.system(size: 11, weight: .regular))
                     .foregroundColor(.white.opacity(0.6))
             }
@@ -632,11 +635,11 @@ public struct SummaryView: View {
                     Circle()
                         .fill(Color(red: 0.2, green: 0.85, blue: 0.45))
                         .frame(width: 6, height: 6)
-                    Text("Telemetry Hook:")
+                    Text(L("Telemetry Hook:", "遥测 Hook："))
                         .font(.system(size: 10, weight: .semibold))
                         .foregroundColor(.white.opacity(0.7))
                     Spacer()
-                    Text("Active & Streaming")
+                    Text(L("Active & Streaming", "运行中 · 实时传输"))
                         .font(.system(size: 10, weight: .medium))
                         .foregroundColor(Color(red: 0.2, green: 0.85, blue: 0.45))
                 }
@@ -645,11 +648,11 @@ public struct SummaryView: View {
                     Circle()
                         .fill(Color.cyan)
                         .frame(width: 6, height: 6)
-                    Text("IPC Daemon:")
+                    Text(L("IPC Daemon:", "IPC 守护进程："))
                         .font(.system(size: 10, weight: .semibold))
                         .foregroundColor(.white.opacity(0.7))
                     Spacer()
-                    Text("Connected")
+                    Text(L("Connected", "已连接"))
                         .font(.system(size: 10, weight: .medium))
                         .foregroundColor(.cyan)
                 }
@@ -672,7 +675,7 @@ public struct SummaryView: View {
                     HStack(spacing: 4) {
                         Image(systemName: "terminal.fill")
                             .font(.system(size: 9.5))
-                        Text("Open Console")
+                        Text(L("Open Console", "打开控制台"))
                             .font(.system(size: 10.5, weight: .semibold))
                     }
                     .foregroundColor(.white)
@@ -694,7 +697,7 @@ public struct SummaryView: View {
                     HStack(spacing: 4) {
                         Image(systemName: "clock.arrow.circlepath")
                             .font(.system(size: 9.5))
-                        Text("History")
+                        Text(L("History", "历史"))
                             .font(.system(size: 10.5, weight: .semibold))
                     }
                     .foregroundColor(.white.opacity(0.85))
@@ -723,7 +726,7 @@ public struct SummaryView: View {
                 .font(.system(size: 9))
                 .foregroundColor(.cyan)
             
-            Text("Viewing Historical Task")
+            Text(L("Viewing Historical Task", "正在查看历史任务"))
                 .font(.system(size: 9.5, weight: .semibold))
                 .foregroundColor(.cyan)
             
@@ -734,7 +737,7 @@ public struct SummaryView: View {
                 label: HStack(spacing: 3) {
                     Image(systemName: "clock")
                         .font(.system(size: 8))
-                    Text("Select Run")
+                    Text(L("Select Run", "选择任务"))
                         .font(.system(size: 8.5, weight: .medium))
                     Image(systemName: "chevron.down")
                         .font(.system(size: 6.5))
@@ -758,7 +761,7 @@ public struct SummaryView: View {
                 HStack(spacing: 3) {
                     Image(systemName: "bolt.fill")
                         .font(.system(size: 8))
-                    Text("Jump to Live")
+                    Text(L("Jump to Live", "返回当前任务"))
                         .font(.system(size: 9, weight: .bold))
                 }
                 .foregroundColor(.white)
@@ -847,14 +850,14 @@ public struct SummaryView: View {
         Menu {
             // 1. Live Task Option
             if let latest = state.latestRun {
-                Section("Live Session") {
+                Section(L("Live Session", "当前会话")) {
                     Button {
                         state.jumpToLive()
                     } label: {
                         let isLiveActive = (state.inspectedRun == nil || state.inspectedRun?.id == latest.id)
                         let check = isLiveActive ? "✓ " : ""
                         let branch = latest.gitBranch.map { " (\($0))" } ?? ""
-                        Text("\(check)⚡ Live: \(latest.projectName)\(branch) · \(latest.formattedDate)")
+                        Text(L("\(check)⚡ Live: \(latest.projectName)\(branch) · \(latest.localizedFormattedDate)", "\(check)⚡ 当前：\(latest.projectName)\(branch) · \(latest.localizedFormattedDate)"))
                     }
                 }
             }
@@ -862,7 +865,7 @@ public struct SummaryView: View {
             // 2. Recent Tasks
             let historyRuns = TelemetryQueryEngine.shared.fetchHistory(limit: 20)
             if !historyRuns.isEmpty {
-                Section("Recent Runs & Tasks") {
+                Section(L("Recent Runs & Tasks", "最近任务")) {
                     ForEach(Array(historyRuns.enumerated()), id: \.element.id) { index, hRun in
                         Button {
                             if hRun.id == state.latestRun?.id {
@@ -878,7 +881,7 @@ public struct SummaryView: View {
                                 .replacingOccurrences(of: "\n", with: " ")
                                 .trimmingCharacters(in: .whitespaces)
                             let shortPreview = preview.count > 28 ? String(preview.prefix(28)) + "..." : preview
-                            let title = "#\(index + 1) \(hRun.projectName)\(branch) · \(hRun.formattedDate) - \(shortPreview)"
+                            let title = "#\(index + 1) \(hRun.projectName)\(branch) · \(hRun.localizedFormattedDate) - \(shortPreview)"
                             Text("\(check)\(title)")
                         }
                     }
@@ -888,7 +891,7 @@ public struct SummaryView: View {
             // 3. Project Quick Filter
             let projects = TelemetryQueryEngine.shared.allProjects()
             if projects.count > 1 {
-                Section("Filter History by Project") {
+                Section(L("Filter History by Project", "按项目筛选历史")) {
                     ForEach(projects, id: \.self) { proj in
                         Button {
                             state.selectedProject = proj
@@ -906,7 +909,7 @@ public struct SummaryView: View {
             Button {
                 state.selectTab(.history)
             } label: {
-                Label("Browse All in History...", systemImage: "clock.arrow.circlepath")
+                Label(L("Browse All in History...", "浏览全部历史…"), systemImage: "clock.arrow.circlepath")
             }
         } label: {
             label
@@ -953,14 +956,14 @@ public struct SummaryView: View {
     
     private var statusBadgeText: String {
         guard let run = currentRun else {
-            return "READY"
+            return L("READY", "就绪")
         }
         if run.isRunning {
-            return "RUNNING"
+            return L("RUNNING", "运行中")
         } else if run.isError {
-            return "FAILED"
+            return L("FAILED", "失败")
         }
-        return "COMPLETED"
+        return L("COMPLETED", "已完成")
     }
     
     // MARK: - Participants Section
@@ -972,7 +975,7 @@ public struct SummaryView: View {
                     Image(systemName: "brain.head.profile")
                         .font(.system(size: 9))
                         .foregroundColor(.indigo.opacity(0.9))
-                    Text("Parent Model")
+                    Text(L("Parent Model", "父 Agent 模型"))
                         .font(.system(size: 9.0, weight: .semibold))
                         .foregroundColor(.white.opacity(0.7))
                 }
@@ -999,7 +1002,7 @@ public struct SummaryView: View {
                 }
                 
                 let u = run.parent?.effectiveUsage?.totalTokens ?? 0
-                Text("\(TaskRun.formatTokenCount(u)) tokens")
+                Text(L("\(TaskRun.formatTokenCount(u)) tokens", "\(TaskRun.formatTokenCount(u)) Token"))
                     .font(.system(size: 8.5, weight: .regular))
                     .foregroundColor(.white.opacity(0.5))
                     .lineLimit(1)
@@ -1021,17 +1024,17 @@ public struct SummaryView: View {
                     Image(systemName: "person.2.fill")
                         .font(.system(size: 9))
                         .foregroundColor(.teal.opacity(0.9))
-                    Text("Workers (\(run.allWorkers.count))")
+                    Text(L("Workers (\(run.allWorkers.count))", "Worker（\(run.allWorkers.count)）"))
                         .font(.system(size: 9.0, weight: .semibold))
                         .foregroundColor(.white.opacity(0.7))
                 }
                 
                 if run.allWorkers.isEmpty {
                     VStack(alignment: .leading, spacing: 1) {
-                        Text("Direct Execution")
+                        Text(L("Direct Execution", "直接执行"))
                             .font(.system(size: 10, weight: .medium))
                             .foregroundColor(.white.opacity(0.75))
-                        Text("No subagents")
+                        Text(L("No subagents", "未使用子 Agent"))
                             .font(.system(size: 8.5, weight: .regular))
                             .foregroundColor(.white.opacity(0.4))
                     }
@@ -1057,7 +1060,7 @@ public struct SummaryView: View {
                         }
                         
                         if run.allWorkers.count > 2 {
-                            Text("+\(run.allWorkers.count - 2) more subagents")
+                            Text(L("+\(run.allWorkers.count - 2) more subagents", "还有 \(run.allWorkers.count - 2) 个子 Agent"))
                                 .font(.system(size: 8.0, weight: .regular))
                                 .foregroundColor(.teal.opacity(0.7))
                                 .lineLimit(1)
@@ -1088,7 +1091,7 @@ public struct SummaryView: View {
                 HStack(spacing: 3) {
                     Image(systemName: copiedSummary ? "checkmark" : "doc.on.doc")
                         .font(.system(size: 9, weight: .semibold))
-                    Text(copiedSummary ? "Copied!" : "Copy")
+                    Text(copiedSummary ? L("Copied!", "已复制") : L("Copy", "复制"))
                         .font(.system(size: 9.5, weight: .medium))
                 }
                 .foregroundColor(copiedSummary ? Color(red: 0.2, green: 0.85, blue: 0.45) : .white.opacity(0.85))
@@ -1112,7 +1115,7 @@ public struct SummaryView: View {
                 HStack(spacing: 3) {
                     Image(systemName: "terminal.fill")
                         .font(.system(size: 9, weight: .semibold))
-                    Text("Console")
+                    Text(L("Console", "控制台"))
                         .font(.system(size: 9.5, weight: .medium))
                 }
                 .foregroundColor(.white.opacity(0.85))
@@ -1132,7 +1135,7 @@ public struct SummaryView: View {
             Spacer()
             
             // Relative date / update time
-            Text(run.formattedDate)
+            Text(run.localizedFormattedDate)
                 .font(.system(size: 8.5, weight: .regular))
                 .foregroundColor(.white.opacity(0.4))
         }
@@ -1140,16 +1143,28 @@ public struct SummaryView: View {
     }
     
     private func copySummaryToClipboard(run: TaskRun) {
-        let text = """
-        📊 FlowPilot Task Summary
-        • Project: \(run.projectName) (\(run.gitBranch ?? "main"))
-        • Duration: \(run.formattedDuration)
-        • Total Tokens: \(run.formattedTotalTokens)
-        • Estimated Cost: \(run.formattedCost)
-        • Parent Model: \(run.parent?.displayModel ?? "unknown")
-        • Workers: \(run.allWorkers.count)
-        • Overview: \(run.summary ?? run.sessionTitle)
-        """
+        let text = L(
+            """
+            📊 FlowPilot Task Summary
+            • Project: \(run.projectName) (\(run.gitBranch ?? "main"))
+            • Duration: \(run.formattedDuration)
+            • Total Tokens: \(run.formattedTotalTokens)
+            • Estimated Cost: \(run.formattedCost)
+            • Parent Model: \(run.parent?.displayModel ?? "unknown")
+            • Workers: \(run.allWorkers.count)
+            • Overview: \(run.summary ?? run.sessionTitle)
+            """,
+            """
+            📊 FlowPilot 任务摘要
+            • 项目：\(run.projectName)（\(run.gitBranch ?? "main")）
+            • 耗时：\(run.formattedDuration)
+            • 总 Token：\(run.formattedTotalTokens)
+            • 预估成本：\(run.formattedCost)
+            • 父 Agent 模型：\(run.parent?.displayModel ?? "unknown")
+            • Worker：\(run.allWorkers.count)
+            • 摘要：\(run.summary ?? run.sessionTitle)
+            """
+        )
         
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(text, forType: .string)

--- a/apps/macos-overlay/Sources/main.swift
+++ b/apps/macos-overlay/Sources/main.swift
@@ -23,27 +23,50 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 }
 
 func printUsage() {
-    print("""
-    FlowPilot - Native macOS Assistant & Telemetry Widget
+    print(L(
+        """
+        FlowPilot - Native macOS Assistant & Telemetry Widget
 
-    Usage:
-      FlowPilot [command] [options]
+        Usage:
+          FlowPilot [command] [options]
 
-    Commands:
-      start, --daemon           Start/Restart the FlowPilot floating daemon (default)
-      restart                   Restart the running FlowPilot daemon with fresh build
-      stop, quit                Stop running FlowPilot daemon
-      status                    Check if FlowPilot daemon is currently active
-      toggle                    Toggle between circular bubble and expanded summary
-      expand                    Expand summary window
-      collapse                  Collapse to circular bubble
-      tab <inspector|hist|stat> Switch active tab in expanded view
-      show <#|id|session>       Inspect specific task in FlowPilot
-      stats [days]              Open analytics dashboard with N days (default: 30)
-      history, list             Open history task timeline
-      update [path|json]        Push telemetry run update and expand
-      help, -h                  Show this help message
-    """)
+        Commands:
+          start, --daemon           Start/Restart the FlowPilot floating daemon (default)
+          restart                   Restart the running FlowPilot daemon with fresh build
+          stop, quit                Stop running FlowPilot daemon
+          status                    Check if FlowPilot daemon is currently active
+          toggle                    Toggle between circular bubble and expanded summary
+          expand                    Expand summary window
+          collapse                  Collapse to circular bubble
+          tab <inspector|hist|stat> Switch active tab in expanded view
+          show <#|id|session>       Inspect specific task in FlowPilot
+          stats [days]              Open analytics dashboard with N days (default: 30)
+          history, list             Open history task timeline
+          update [path|json]        Push telemetry run update and expand
+          help, -h                  Show this help message
+        """,
+        """
+        FlowPilot - macOS 原生助手与遥测悬浮窗
+
+        用法：
+          FlowPilot [命令] [选项]
+
+        命令：
+          start, --daemon           启动/重启 FlowPilot 悬浮窗（默认）
+          restart                   使用最新构建重启 FlowPilot
+          stop, quit                停止 FlowPilot
+          status                    查看 FlowPilot 是否正在运行
+          toggle                    在悬浮球与展开摘要之间切换
+          expand                    展开摘要窗口
+          collapse                  收起为悬浮球
+          tab <inspector|hist|stat> 切换展开视图中的标签页
+          show <#|id|session>       查看指定任务
+          stats [days]              打开 N 天统计面板（默认：30）
+          history, list             打开历史任务列表
+          update [path|json]        推送遥测任务更新并展开
+          help, -h                  显示帮助
+        """
+    ))
 }
 
 let args = Array(CommandLine.arguments.dropFirst())
@@ -66,10 +89,10 @@ if args.isEmpty || args[0] == "start" || args[0] == "--daemon" || args[0] == "re
     case "status":
         let res = IPCService.sendCommand("status")
         if res.success {
-            print("● FlowPilot is RUNNING: \(res.response)")
+            print(L("● FlowPilot is RUNNING: \(res.response)", "● FlowPilot 正在运行：\(res.response)"))
             exit(0)
         } else {
-            print("○ FlowPilot is NOT running.")
+            print(L("○ FlowPilot is NOT running.", "○ FlowPilot 未运行。"))
             exit(1)
         }
     case "toggle":
@@ -122,7 +145,7 @@ if args.isEmpty || args[0] == "start" || args[0] == "--daemon" || args[0] == "re
         printUsage()
         exit(0)
     default:
-        print("Unknown command: \(cmd)")
+        print(L("Unknown command: \(cmd)", "未知命令：\(cmd)"))
         printUsage()
         exit(1)
     }

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -1,6 +1,6 @@
 # Language localization
 
-codex-flow supports Chinese and English for user-facing CLI output.
+codex-flow supports Chinese and English across the CLI and the native macOS FlowPilot app.
 
 ## Default behavior
 
@@ -28,4 +28,4 @@ For a temporary per-process override, set `CODEX_FLOW_LANGUAGE=zh`, `en`, or `au
 
 ## Localized surfaces
 
-The language setting is used by the interactive console, `status`, `help`, `doctor`, install guidance, telemetry summaries/history/statistics, and macOS completion notifications. Benchmark internals and machine-readable JSON remain stable and are not translated.
+The language setting is used by the interactive console, `status`, `help`, `doctor`, install guidance, telemetry summaries/history/statistics, macOS completion notifications, and the native FlowPilot app (summary, history, analytics, bubble status, context menus, and native binary help). The running app re-reads the shared policy periodically, so `codex-flow language zh|en|auto` propagates without maintaining a separate app preference. Benchmark internals and machine-readable JSON/IPC protocol fields remain stable and are not translated.


### PR DESCRIPTION
## Summary

Localize the native macOS FlowPilot app in Chinese and English, using the same language configuration already shipped for codex-flow CLI.

## Language precedence

`CODEX_FLOW_LANGUAGE` > `[ui].language` > detected system language

The app does not maintain a separate language preference. `auto` follows the macOS/system locale; unsupported locales fall back to English. The running app periodically re-resolves the shared policy so `codex-flow language auto|zh|en` propagates to the native app as well.

## Localized native surfaces

- Inspector/Summary: tabs, ready/running/error/completed state, KPI labels, quota/reset copy, token distribution, parent/worker labels, historical-task banner, task picker, clipboard summary, dates and actions
- Idle inspector: FlowPilot ready state, telemetry/IPC state, quick actions
- History: scope/project filters, search, contextual empty states, run/worker labels and dates
- Analytics: periods, KPIs, cache/offload metrics, model/project breakdowns and role labels
- Bubble/docked bubble: ready/running/OK status text while preserving compact token metrics
- Native context menu: pin/unpin, expand/collapse, console, refresh and quit
- Native `FlowPilot` binary: help/status/unknown-command output
- Human-facing IPC client errors

Machine-readable IPC actions, tab identifiers, server JSON fields, benchmark output and telemetry payloads remain unchanged.

## Latest-main compatibility

This change was re-applied and validated against the latest native overlay UI rather than the earlier localization branch. It preserves the current `Token Distribution`, compact bubble token metric, idle inspector, task picker, and contextual History empty states.

`HistoryItemRow` is split into smaller SwiftUI subviews only to keep the Swift compiler type checker within reasonable complexity after localization. Existing spacing, fonts, colors, padding, corner radius and behavior are preserved.

## Validation

Validated on `macos-latest` with the repository's existing Cocoa + SwiftUI + Combine build:

- native FlowPilot app compiles successfully
- `[ui].language = "zh"` produces Chinese native output
- `[ui].language = "en"` produces English native output
- `CODEX_FLOW_LANGUAGE` overrides persisted language in both directions
- `auto` uses the shared precedence model
- source transformation assertions cover the latest Summary/History/Analytics/Bubble UI before compile

The branch is a single clean commit on current `main`; temporary validation workflows/scripts are not included.