### PR TITLE
fix: stabilize overlay telemetry and Stop lifecycle

### DIFF
--- a/.github/workflows/macos-overlay.yml
+++ b/.github/workflows/macos-overlay.yml
@@ -1,0 +1,19 @@
+name: macos-overlay
+
+on:
+  push:
+    paths:
+      - 'apps/macos-overlay/**'
+      - '.github/workflows/macos-overlay.yml'
+  pull_request:
+    paths:
+      - 'apps/macos-overlay/**'
+      - '.github/workflows/macos-overlay.yml'
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compile native overlay
+        run: bash apps/macos-overlay/build.sh

--- a/apps/macos-overlay/Sources/Services/IPCServer.swift
+++ b/apps/macos-overlay/Sources/Services/IPCServer.swift
@@ -80,6 +80,14 @@ public class IPCService {
             }
             
             guard clientSocket >= 0 else { return }
+            var noSigPipe: Int32 = 1
+            _ = setsockopt(
+                clientSocket,
+                SOL_SOCKET,
+                SO_NOSIGPIPE,
+                &noSigPipe,
+                socklen_t(MemoryLayout<Int32>.size)
+            )
             
             var buffer = [UInt8](repeating: 0, count: 4096)
             let bytesRead = read(clientSocket, &buffer, buffer.count)
@@ -151,7 +159,8 @@ public class IPCService {
                     let codexHome = ProcessInfo.processInfo.environment["CODEX_HOME"] ?? home.appendingPathComponent(".codex").path
                     let lastUrl = URL(fileURLWithPath: codexHome).appendingPathComponent("codex-flow").appendingPathComponent("telemetry").appendingPathComponent("last.json")
                     if let data = try? Data(contentsOf: lastUrl),
-                       let run = try? JSONDecoder().decode(TaskRun.self, from: data) {
+                       var run = try? JSONDecoder().decode(TaskRun.self, from: data) {
+                        TelemetryQueryEngine.shared.enrichRunIfNeeded(&run)
                         state.update(run: run)
                         state.expand()
                         return "{\"ok\": true, \"updatedFrom\": \"last.json\"}\n"
@@ -160,12 +169,14 @@ public class IPCService {
                     return "{\"ok\": true, \"action\": \"expanded\"}\n"
                 } else {
                     if let fileData = try? Data(contentsOf: URL(fileURLWithPath: payload)),
-                       let run = try? JSONDecoder().decode(TaskRun.self, from: fileData) {
+                       var run = try? JSONDecoder().decode(TaskRun.self, from: fileData) {
+                        TelemetryQueryEngine.shared.enrichRunIfNeeded(&run)
                         state.update(run: run)
                         state.expand()
                         return "{\"ok\": true, \"updatedFrom\": \"file\"}\n"
                     } else if let json = payload.data(using: .utf8),
-                              let run = try? JSONDecoder().decode(TaskRun.self, from: json) {
+                              var run = try? JSONDecoder().decode(TaskRun.self, from: json) {
+                        TelemetryQueryEngine.shared.enrichRunIfNeeded(&run)
                         state.update(run: run)
                         state.expand()
                         return "{\"ok\": true, \"updatedFrom\": \"json\"}\n"
@@ -198,6 +209,14 @@ public class IPCService {
             return (false, L("Failed to create client socket.", "创建客户端 socket 失败。"))
         }
         defer { close(clientSocket) }
+        var noSigPipe: Int32 = 1
+        _ = setsockopt(
+            clientSocket,
+            SOL_SOCKET,
+            SO_NOSIGPIPE,
+            &noSigPipe,
+            socklen_t(MemoryLayout<Int32>.size)
+        )
         
         var addr = sockaddr_un()
         addr.sun_family = sa_family_t(AF_UNIX)

--- a/apps/macos-overlay/Sources/Services/TelemetryWatcher.swift
+++ b/apps/macos-overlay/Sources/Services/TelemetryWatcher.swift
@@ -69,8 +69,14 @@ public class TelemetryWatcher {
                     queue: DispatchQueue.global(qos: .utility)
                 )
                 
-                source.setEventHandler { [weak self] in
-                    self?.handleFileOrDirChanged()
+                source.setEventHandler { [weak self, weak source] in
+                    guard let self = self else { return }
+                    let flags = source?.data ?? []
+                    if flags.contains(.rename) || flags.contains(.delete) {
+                        self.fileSource?.cancel()
+                        self.fileSource = nil
+                    }
+                    self.handleFileOrDirChanged()
                 }
                 
                 source.setCancelHandler {
@@ -120,7 +126,8 @@ public class TelemetryWatcher {
         do {
             let data = try Data(contentsOf: telemetryURL)
             let decoder = JSONDecoder()
-            let run = try decoder.decode(TaskRun.self, from: data)
+            var run = try decoder.decode(TaskRun.self, from: data)
+            TelemetryQueryEngine.shared.enrichRunIfNeeded(&run)
             state.update(run: run)
         } catch {
             // If decode fails, retain existing state

--- a/apps/macos-overlay/Sources/Services/TelemetryWatcher.swift
+++ b/apps/macos-overlay/Sources/Services/TelemetryWatcher.swift
@@ -69,14 +69,8 @@ public class TelemetryWatcher {
                     queue: DispatchQueue.global(qos: .utility)
                 )
                 
-                source.setEventHandler { [weak self, weak source] in
-                    guard let self = self else { return }
-                    let flags = source?.data ?? []
-                    if flags.contains(.rename) || flags.contains(.delete) {
-                        self.fileSource?.cancel()
-                        self.fileSource = nil
-                    }
-                    self.handleFileOrDirChanged()
+                source.setEventHandler { [weak self] in
+                    self?.handleFileOrDirChanged()
                 }
                 
                 source.setCancelHandler {

--- a/scripts/telemetry.py
+++ b/scripts/telemetry.py
@@ -5,19 +5,28 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import socket
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from telemetry_core import *  # noqa: F401,F403
 from telemetry_core import (
+    AppServer,
+    LAST_FILE,
     aggregate_usage_value,
+    atomic_json,
     collect_hook,
+    enrich_run_metadata,
+    extract_transcript_insights,
     fmt_duration_ms,
     fmt_tokens,
+    iter_run_files,
     numeric_ms,
+    read_json_object,
     run_context,
     show_last,
     show_list,
@@ -34,6 +43,32 @@ LANG = resolve_language(Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"
 
 def T(en: str, zh: str) -> str:
     return tr(en, zh, lang=LANG)
+
+
+def _same_run(left: dict | None, right: dict) -> bool:
+    if not isinstance(left, dict):
+        return False
+    return (
+        str(left.get("session_id") or "") == str(right.get("session_id") or "")
+        and str(left.get("turn_id") or "") == str(right.get("turn_id") or "")
+    )
+
+
+def _persist_enriched_run(run: dict) -> None:
+    """Make the persisted run self-contained before UI/CLI consumers reload it."""
+    insights = extract_transcript_insights(run.get("transcript_path"), run.get("turn_id"))
+    if insights:
+        for key, value in insights.items():
+            if value is not None and not run.get(key):
+                run[key] = value
+    enrich_run_metadata(run)
+
+    atomic_json(LAST_FILE, run)
+    for path in iter_run_files():
+        candidate = read_json_object(path)
+        if _same_run(candidate, run):
+            atomic_json(path, run)
+            break
 
 
 def _localized_notification_body(run: dict) -> str:
@@ -60,8 +95,28 @@ def _localized_notification_body(run: dict) -> str:
     return " · ".join(parts)
 
 
+def _notify_overlay_safely() -> None:
+    """Push an update and wait for the daemon response before closing the socket."""
+    codex_home = os.environ.get("CODEX_HOME", os.path.expanduser("~/.codex"))
+    sock_path = os.path.join(codex_home, "codex-flow", "overlay.sock")
+    if not os.path.exists(sock_path):
+        return
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.settimeout(0.75)
+            client.connect(sock_path)
+            client.sendall(b"update\n")
+            try:
+                client.recv(4096)
+            except socket.timeout:
+                pass
+    except (OSError, TimeoutError):
+        pass
+
+
 def _localized_send_system_notification(run: dict) -> None:
-    _collector.notify_overlay_if_active(run)
+    _persist_enriched_run(run)
+    _notify_overlay_safely()
     telemetry_mod = sys.modules.get("telemetry")
     sub_mod = getattr(telemetry_mod, "subprocess", subprocess) if telemetry_mod else subprocess
     shutil_mod = getattr(telemetry_mod, "shutil", shutil) if telemetry_mod else shutil
@@ -88,7 +143,37 @@ def _localized_send_system_notification(run: dict) -> None:
         return
 
 
+# Quota snapshots are observational, but a transient app-server miss should not
+# permanently erase the task delta. Retry only the read operation; never invent data.
+_ORIGINAL_RATE_LIMITS = AppServer.rate_limits
+
+
+def _rate_limits_with_retry(self: AppServer):
+    last = None
+    for attempt in range(3):
+        last = _ORIGINAL_RATE_LIMITS(self)
+        if isinstance(last, dict) and isinstance(last.get("rateLimits"), dict):
+            return last
+        if attempt < 2:
+            time.sleep(0.08 * (attempt + 1))
+    return last
+
+
+AppServer.rate_limits = _rate_limits_with_retry
+_collector.AppServer.rate_limits = _rate_limits_with_retry
+
+# Enrich and persist before the Stop summary is rendered. This makes last.json
+# and the per-run file authoritative for live view, restart, history, and CLI.
+_ORIGINAL_RENDER_SUMMARY = _collector.render_summary
+
+
+def _render_summary_with_enrichment(run: dict) -> str:
+    _persist_enriched_run(run)
+    return _ORIGINAL_RENDER_SUMMARY(run)
+
+
 # collect_hook resolves these names from telemetry_core.collector at runtime.
+_collector.render_summary = _render_summary_with_enrichment
 _collector.notification_body = _localized_notification_body
 _collector.send_system_notification = _localized_send_system_notification
 


### PR DESCRIPTION
## Summary

Fix the Stop-time telemetry/overlay regressions observed after rebuilding the macOS floating app:

- persist transcript insights before the final telemetry summary and before notifying the Overlay, so `last.json` and per-run files retain task summary, skills/tools, trajectory, and logs;
- enrich `last.json` again in the live file watcher / IPC update path as a defensive fallback, so restarting the app does not make the Task-tab detail cards disappear;
- retry transient `account/rateLimits/read` misses before giving up, reducing missing quota deltas without inventing telemetry;
- make the Python overlay notification wait for the IPC response before closing;
- set `SO_NOSIGPIPE` on accepted/client Unix sockets so a disconnected peer cannot terminate the macOS app;
- add a macOS Overlay compile workflow so Swift regressions are caught in CI.

## Root causes addressed

1. Live/restarted Task tab consumed raw `latestRun` while History inspection performed transcript enrichment, causing task summary, Tools, Trajectory, and Logs to vanish depending on navigation/restart state.
2. Stop hook sent `update\n` and immediately closed the socket while the Overlay server still wrote a response, leaving a SIGPIPE crash path.
3. Quota before/after snapshots were single-shot reads, so one transient app-server miss made `delta_percentage_points` unavailable for the run.

## Validation

- Existing Linux FlowPilot telemetry test passes on this branch.
- Existing installer / CLI smoke suites are running through normal CI.
- New `macos-overlay` workflow compiles the native SwiftUI overlay on macOS.