### PR TITLE
feat(overlay): expand account, strategy, history and analytics UX

### DIFF
--- a/apps/macos-overlay/Sources/Controllers/OverlayWindowController.swift
+++ b/apps/macos-overlay/Sources/Controllers/OverlayWindowController.swift
@@ -17,7 +17,7 @@ public class OverlayState: ObservableObject {
     @Published public var dockEdge: DockEdge = .right
     @Published public var latestRun: TaskRun? = nil
     @Published public var isPrivacyMode: Bool = false
-    
+
     // Tab & Explorer State
     @Published public var activeTab: OverlayTab = .inspector
     @Published public var inspectedRun: TaskRun? = nil
@@ -31,9 +31,15 @@ public class OverlayState: ObservableObject {
     @Published public var searchQuery: String = ""
     @Published public var recentChats: [ChatSession] = []
     @Published public var allProjectsList: [String] = []
-    
+
     public weak var windowController: OverlayWindowController?
-    
+
+    // All mutations to these request generations are marshalled onto the main
+    // queue. They prevent slower, older queries from overwriting a newer filter
+    // or time-range selection after the background work completes.
+    private var historyLoadGeneration = 0
+    private var statsLoadGeneration = 0
+
     public init() {
         if let latest = TelemetryQueryEngine.shared.loadLatestRun() {
             self.latestRun = latest
@@ -41,7 +47,7 @@ public class OverlayState: ObservableObject {
         }
         self.loadMenuData()
     }
-    
+
     public func loadMenuData() {
         DispatchQueue.global(qos: .userInitiated).async {
             let chats = TelemetryQueryEngine.shared.fetchChatHistory(limit: 15)
@@ -52,7 +58,7 @@ public class OverlayState: ObservableObject {
             }
         }
     }
-    
+
     public func expand() {
         guard !isExpanded else { return }
         self.loadMenuData()
@@ -62,7 +68,7 @@ public class OverlayState: ObservableObject {
             self.windowController?.updateWindowFrame(animated: true)
         }
     }
-    
+
     public func collapse() {
         guard isExpanded else { return }
         DispatchQueue.main.async {
@@ -72,7 +78,7 @@ public class OverlayState: ObservableObject {
             self.windowController?.scheduleTuck()
         }
     }
-    
+
     public func toggle() {
         if isExpanded {
             collapse()
@@ -80,7 +86,7 @@ public class OverlayState: ObservableObject {
             expand()
         }
     }
-    
+
     public func selectTab(_ tab: OverlayTab) {
         DispatchQueue.main.async {
             self.activeTab = tab
@@ -92,7 +98,7 @@ public class OverlayState: ObservableObject {
             self.windowController?.updateWindowFrame(animated: true)
         }
     }
-    
+
     public func inspect(run: TaskRun) {
         var r = run
         DispatchQueue.main.async {
@@ -100,7 +106,7 @@ public class OverlayState: ObservableObject {
             self.activeTab = .inspector
             self.windowController?.updateWindowFrame(animated: true)
         }
-        if r.trajectory == nil || r.skillsUsed == nil {
+        if r.trajectory == nil || r.skillsUsed == nil || r.toolsUsed == nil || r.logs == nil {
             DispatchQueue.global(qos: .userInitiated).async {
                 TelemetryQueryEngine.shared.enrichRunIfNeeded(&r)
                 DispatchQueue.main.async {
@@ -111,7 +117,7 @@ public class OverlayState: ObservableObject {
             }
         }
     }
-    
+
     public func jumpToLive() {
         DispatchQueue.main.async {
             self.inspectedRun = nil
@@ -119,7 +125,7 @@ public class OverlayState: ObservableObject {
             self.windowController?.updateWindowFrame(animated: true)
         }
     }
-    
+
     public func toggleChatExpansion(_ id: String) {
         if expandedChatIds.contains(id) {
             expandedChatIds.remove(id)
@@ -128,26 +134,34 @@ public class OverlayState: ObservableObject {
         }
         self.windowController?.updateWindowFrame(animated: true)
     }
-    
+
     public func isChatExpanded(_ id: String) -> Bool {
         return expandedChatIds.contains(id)
     }
-    
+
     public func expandAllChats() {
         let allIds = historyChats.map { $0.sessionId }
         expandedChatIds = Set(allIds)
         self.windowController?.updateWindowFrame(animated: true)
     }
-    
+
     public func collapseAllChats() {
         expandedChatIds.removeAll()
         self.windowController?.updateWindowFrame(animated: true)
     }
-    
+
     public func loadHistory() {
-        let proj = self.selectedProject
-        let today = self.isTodayOnly
-        let search = self.searchQuery
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { self.loadHistory() }
+            return
+        }
+
+        historyLoadGeneration += 1
+        let generation = historyLoadGeneration
+        let proj = selectedProject
+        let today = isTodayOnly
+        let search = searchQuery
+
         DispatchQueue.global(qos: .userInitiated).async {
             let chats = TelemetryQueryEngine.shared.fetchChatHistory(
                 limit: 60,
@@ -162,39 +176,48 @@ public class OverlayState: ObservableObject {
                 search: search
             )
             DispatchQueue.main.async {
+                guard generation == self.historyLoadGeneration else { return }
                 self.historyChats = chats
                 self.historyRuns = runs
-                // Auto-expand first chat if none expanded and chats available
                 if self.expandedChatIds.isEmpty, let first = chats.first {
                     self.expandedChatIds.insert(first.sessionId)
                 }
             }
         }
     }
-    
+
     public func loadStats() {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { self.loadStats() }
+            return
+        }
+
+        statsLoadGeneration += 1
+        let generation = statsLoadGeneration
+        let days = statsDays
+        let project = selectedProject
+
         DispatchQueue.global(qos: .userInitiated).async {
             let stats = TelemetryQueryEngine.shared.computeStats(
-                days: self.statsDays,
-                project: self.selectedProject
+                days: days,
+                project: project
             )
             DispatchQueue.main.async {
+                guard generation == self.statsLoadGeneration else { return }
                 self.statsData = stats
             }
         }
     }
-    
+
     public func update(run: TaskRun) {
         DispatchQueue.main.async {
             self.latestRun = run
             self.isTaskRunning = run.isRunning
-            // Refresh history/stats if in those tabs
             if self.activeTab == .history {
                 self.loadHistory()
             } else if self.activeTab == .analytics {
                 self.loadStats()
             }
-            // Update window frame size if expanded to accommodate new data
             if self.isExpanded {
                 self.windowController?.updateWindowFrame(animated: true)
             }
@@ -205,11 +228,11 @@ public class OverlayState: ObservableObject {
 // MARK: - Main Root Container View
 public struct OverlayRootView: View {
     @ObservedObject var state: OverlayState
-    
+
     public init(state: OverlayState) {
         self.state = state
     }
-    
+
     public var body: some View {
         ZStack(alignment: .topTrailing) {
             if state.isExpanded {
@@ -242,27 +265,27 @@ public struct OverlayRootView: View {
 class TrackingHostingView<Content: View>: NSHostingView<Content> {
     weak var windowController: OverlayWindowController?
     private var trackingArea: NSTrackingArea?
-    
+
     required public init(rootView: Content) {
         super.init(rootView: rootView)
         self.wantsLayer = true
         self.layer?.backgroundColor = NSColor.clear.cgColor
         self.layer?.isOpaque = false
     }
-    
+
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         self.wantsLayer = true
         self.layer?.backgroundColor = NSColor.clear.cgColor
         self.layer?.isOpaque = false
     }
-    
+
     override func updateTrackingAreas() {
         super.updateTrackingAreas()
         if let existing = trackingArea {
             removeTrackingArea(existing)
         }
-        
+
         let options: NSTrackingArea.Options = [
             .mouseEnteredAndExited,
             .mouseMoved,
@@ -273,28 +296,28 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
         addTrackingArea(area)
         self.trackingArea = area
     }
-    
+
     override func mouseEntered(with event: NSEvent) {
         super.mouseEntered(with: event)
         windowController?.handleMouseEntered()
     }
-    
+
     override func mouseMoved(with event: NSEvent) {
         super.mouseMoved(with: event)
         windowController?.handleMouseMoved()
     }
-    
+
     override func mouseExited(with event: NSEvent) {
         super.mouseExited(with: event)
         windowController?.handleMouseExited()
     }
-    
+
     // MARK: - Dragging & Magnetic Edge Snapping
     private var initialLocation: NSPoint = .zero
     private var isDragging: Bool = false
     private let snapMargin: CGFloat = 8.0
     private let snapThreshold: CGFloat = 36.0
-    
+
     override func mouseDown(with event: NSEvent) {
         initialLocation = event.locationInWindow
         isDragging = false
@@ -302,7 +325,7 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
         windowController?.isInteractingOrDragging = true
         super.mouseDown(with: event)
     }
-    
+
     override func mouseDragged(with event: NSEvent) {
         guard let window = self.window else {
             super.mouseDragged(with: event)
@@ -316,40 +339,36 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
             isDragging = true
             windowController?.cancelDwellTimer()
             windowController?.isInteractingOrDragging = true
-            
+
             var newOrigin = window.frame.origin
             newOrigin.x += deltaX
             newOrigin.y += deltaY
-            
-            // Clamp to screen bounds during live drag
+
             if let screen = window.screen ?? NSScreen.main {
                 let visible = screen.visibleFrame
                 newOrigin.x = max(visible.minX, min(newOrigin.x, visible.maxX - window.frame.width))
                 newOrigin.y = max(visible.minY, min(newOrigin.y, visible.maxY - window.frame.height))
             }
-            
+
             window.setFrameOrigin(newOrigin)
         } else {
             super.mouseDragged(with: event)
         }
     }
-    
+
     override func mouseUp(with event: NSEvent) {
         guard let window = self.window else {
             super.mouseUp(with: event)
             return
         }
-        
+
         if isDragging {
             performMagneticSnap(for: window)
-            // Suppress hover-expand briefly after dropping
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { [weak self] in
                 self?.windowController?.isInteractingOrDragging = false
             }
         } else {
             windowController?.isInteractingOrDragging = false
-            // Only clicking on the collapsed circular bubble should trigger expand.
-            // When already expanded, interactive clicks belong to SwiftUI tabs/buttons.
             if let state = windowController?.state, !state.isExpanded {
                 state.expand()
             }
@@ -357,22 +376,21 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
         isDragging = false
         super.mouseUp(with: event)
     }
-    
+
     private func performMagneticSnap(for window: NSWindow) {
         guard let screen = window.screen ?? NSScreen.main else { return }
         let visible = screen.visibleFrame
         let frame = window.frame
         var targetOrigin = frame.origin
-        
+
         let distLeft = abs(frame.minX - visible.minX)
         let distRight = abs(visible.maxX - frame.maxX)
         let distTop = abs(visible.maxY - frame.maxY)
         let distBottom = abs(frame.minY - visible.minY)
-        
+
         let isExpanded = windowController?.state.isExpanded ?? false
-        
+
         if isExpanded {
-            // Summary Card: Snap to closest edge if within threshold
             if distLeft < snapThreshold {
                 targetOrigin.x = visible.minX + snapMargin
             } else if distRight < snapThreshold {
@@ -384,7 +402,6 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
                 targetOrigin.y = visible.minY + snapMargin
             }
         } else {
-            // Circular Bubble: Auto snap to the nearest horizontal screen edge (Left or Right)
             if distLeft < distRight {
                 targetOrigin.x = visible.minX + snapMargin
                 windowController?.state.dockEdge = .left
@@ -392,8 +409,7 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
                 targetOrigin.x = visible.maxX - frame.width - snapMargin
                 windowController?.state.dockEdge = .right
             }
-            
-            // Keep within vertical bounds with margin
+
             if distTop < snapThreshold {
                 targetOrigin.y = visible.maxY - frame.height - snapMargin
             } else if distBottom < snapThreshold {
@@ -402,8 +418,7 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
                 targetOrigin.y = max(visible.minY + snapMargin, min(targetOrigin.y, visible.maxY - frame.height - snapMargin))
             }
         }
-        
-        // Smooth magnetic spring snap animation
+
         let targetFrame = NSRect(origin: targetOrigin, size: frame.size)
         NSAnimationContext.runAnimationGroup({ context in
             context.duration = 0.16
@@ -413,14 +428,13 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
         }, completionHandler: { [weak self] in
             guard let self = self else { return }
             self.windowController?.saveWindowPosition(targetOrigin)
-            // Auto-schedule half tuck when idling at edge
             self.windowController?.scheduleTuck()
         })
     }
-    
+
     override func rightMouseDown(with event: NSEvent) {
         let menu = NSMenu()
-        
+
         if let state = windowController?.state {
             if state.isExpanded {
                 let pinItem = NSMenuItem(
@@ -430,7 +444,7 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
                 )
                 pinItem.target = self
                 menu.addItem(pinItem)
-                
+
                 let collapseItem = NSMenuItem(
                     title: L("Collapse to Bubble", "收起为悬浮球"),
                     action: #selector(collapseBubble),
@@ -448,9 +462,9 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
                 menu.addItem(expandItem)
             }
         }
-        
+
         menu.addItem(NSMenuItem.separator())
-        
+
         let consoleItem = NSMenuItem(
             title: L("Open FlowPilot Console", "打开 FlowPilot 控制台"),
             action: #selector(openConsole),
@@ -458,7 +472,7 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
         )
         consoleItem.target = self
         menu.addItem(consoleItem)
-        
+
         let refreshItem = NSMenuItem(
             title: L("Refresh Telemetry", "刷新遥测数据"),
             action: #selector(refreshData),
@@ -466,9 +480,9 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
         )
         refreshItem.target = self
         menu.addItem(refreshItem)
-        
+
         menu.addItem(NSMenuItem.separator())
-        
+
         let quitItem = NSMenuItem(
             title: L("Quit FlowPilot", "退出 FlowPilot"),
             action: #selector(quitApp),
@@ -476,22 +490,22 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
         )
         quitItem.target = self
         menu.addItem(quitItem)
-        
+
         NSMenu.popUpContextMenu(menu, with: event, for: self)
     }
-    
+
     @objc private func togglePin() {
         windowController?.state.isPinned.toggle()
     }
-    
+
     @objc private func expandSummary() {
         windowController?.state.expand()
     }
-    
+
     @objc private func collapseBubble() {
         windowController?.state.collapse()
     }
-    
+
     @objc private func openConsole() {
         let script = """
         tell application "Terminal"
@@ -504,11 +518,11 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
             appleScript.executeAndReturnError(&error)
         }
     }
-    
+
     @objc private func refreshData() {
         windowController?.refreshTelemetry()
     }
-    
+
     @objc private func quitApp() {
         NSApplication.shared.terminate(nil)
     }
@@ -519,30 +533,30 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
     public let state: OverlayState
     public var window: NSPanel!
     public var isInteractingOrDragging: Bool = false
-    
+
     private var hoverDwellTimer: Timer?
     private var collapseTimer: Timer?
     private var tuckTimer: Timer?
     private let bubbleSize = NSSize(width: 76, height: 76)
     private let summarySize = NSSize(width: 384, height: 490)
-    
+
     public init(state: OverlayState) {
         self.state = state
         super.init()
         state.windowController = self
         setupWindow()
     }
-    
+
     private func setupWindow() {
         let initialRect = loadSavedPosition() ?? defaultPosition(for: bubbleSize)
-        
+
         window = NSPanel(
             contentRect: initialRect,
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
         )
-        
+
         window.level = .floating
         window.isFloatingPanel = true
         window.isOpaque = false
@@ -551,26 +565,25 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
         window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
         window.isMovableByWindowBackground = false
         window.delegate = self
-        
+
         let rootView = OverlayRootView(state: state)
         let hostingView = TrackingHostingView(rootView: rootView)
         hostingView.windowController = self
         window.contentView = hostingView
-        
+
         window.orderFront(nil)
-        
-        // Initial tuck after launch
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) { [weak self] in
             self?.scheduleTuck()
         }
     }
-    
+
     // MARK: - Edge Half-Tuck Support
     public func cancelTuckTimer() {
         tuckTimer?.invalidate()
         tuckTimer = nil
     }
-    
+
     public func scheduleTuck() {
         cancelTuckTimer()
         guard !state.isExpanded, !state.isPinned, !isInteractingOrDragging, state.dockEdge != .none, !state.isDocked else { return }
@@ -578,25 +591,23 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
             self?.tuckBubble(animated: true)
         }
     }
-    
+
     public func tuckBubble(animated: Bool = true) {
         guard let window = self.window else { return }
         guard !state.isExpanded, !state.isPinned, !isInteractingOrDragging, state.dockEdge != .none, !state.isDocked else { return }
         guard let screen = window.screen ?? NSScreen.main else { return }
         let visible = screen.visibleFrame
-        
+
         var targetX = window.frame.origin.x
         if state.dockEdge == .right {
-            // Place window flush with right screen edge (pill is right-aligned)
             targetX = visible.maxX - bubbleSize.width
         } else if state.dockEdge == .left {
-            // Place window flush with left screen edge (pill is left-aligned)
             targetX = visible.minX
         }
-        
+
         let targetFrame = NSRect(origin: NSPoint(x: targetX, y: window.frame.origin.y), size: bubbleSize)
         state.isDocked = true
-        
+
         if animated {
             NSAnimationContext.runAnimationGroup { context in
                 context.duration = 0.18
@@ -608,24 +619,24 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
             window.setFrame(targetFrame, display: true)
         }
     }
-    
+
     public func unTuckBubble(animated: Bool = true) {
         cancelTuckTimer()
         guard let window = self.window else { return }
         guard state.isDocked else { return }
         guard let screen = window.screen ?? NSScreen.main else { return }
         let visible = screen.visibleFrame
-        
+
         var targetX = window.frame.origin.x
         if state.dockEdge == .right {
             targetX = visible.maxX - bubbleSize.width - 8.0
         } else if state.dockEdge == .left {
             targetX = visible.minX + 8.0
         }
-        
+
         let targetFrame = NSRect(origin: NSPoint(x: targetX, y: window.frame.origin.y), size: bubbleSize)
         state.isDocked = false
-        
+
         if animated {
             NSAnimationContext.runAnimationGroup({ context in
                 context.duration = 0.14
@@ -640,49 +651,47 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
             saveWindowPosition(NSPoint(x: targetX, y: window.frame.origin.y))
         }
     }
-    
+
     // MARK: - Hover-Dwell 0.4s Detection
     public func cancelDwellTimer() {
         hoverDwellTimer?.invalidate()
         hoverDwellTimer = nil
     }
-    
+
     public func handleMouseEntered() {
         cancelTuckTimer()
         collapseTimer?.invalidate()
         collapseTimer = nil
-        
+
         if state.isDocked {
             unTuckBubble(animated: true)
         }
-        
+
         guard !state.isExpanded, !isInteractingOrDragging else { return }
         resetDwellTimer()
     }
-    
+
     public func handleMouseMoved() {
         if state.isDocked {
             unTuckBubble(animated: true)
         }
-        
+
         guard !state.isExpanded, !isInteractingOrDragging else { return }
         resetDwellTimer()
     }
-    
+
     private func resetDwellTimer() {
         cancelDwellTimer()
         guard !isInteractingOrDragging else { return }
-        // Dwell requirement: cursor stops moving for 0.4 second on the bubble
         hoverDwellTimer = Timer.scheduledTimer(withTimeInterval: 0.4, repeats: false) { [weak self] _ in
             guard let self = self, !self.state.isExpanded, !self.isInteractingOrDragging else { return }
             self.state.expand()
         }
     }
-    
+
     public func handleMouseExited() {
         cancelDwellTimer()
-        
-        // Auto-collapse after grace period if expanded and not pinned
+
         if state.isExpanded && !state.isPinned && !isInteractingOrDragging {
             collapseTimer?.invalidate()
             collapseTimer = Timer.scheduledTimer(withTimeInterval: 0.8, repeats: false) { [weak self] _ in
@@ -693,28 +702,26 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
             scheduleTuck()
         }
     }
-    
+
     // MARK: - Frame Resizing & Animation
     public func updateWindowFrame(animated: Bool = true) {
         guard let window = self.window else { return }
         let targetSize = state.isExpanded ? summarySize : bubbleSize
         let currentFrame = window.frame
-        
-        // Keep top-right corner stable during expand/collapse
+
         var newOrigin = NSPoint(
             x: currentFrame.maxX - targetSize.width,
             y: currentFrame.maxY - targetSize.height
         )
-        
-        // Clamp to screen bounds
+
         if let screen = window.screen ?? NSScreen.main {
             let visible = screen.visibleFrame
             newOrigin.x = max(visible.minX, min(newOrigin.x, visible.maxX - targetSize.width))
             newOrigin.y = max(visible.minY, min(newOrigin.y, visible.maxY - targetSize.height))
         }
-        
+
         let newFrame = NSRect(origin: newOrigin, size: targetSize)
-        
+
         if animated {
             NSAnimationContext.runAnimationGroup { context in
                 context.duration = 0.16
@@ -726,15 +733,15 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
             window.setFrame(newFrame, display: true)
         }
     }
-    
+
     // MARK: - Position Persistence
     private let positionKey = "CodexFlowOverlayWindowPosition"
-    
+
     public func saveWindowPosition(_ origin: NSPoint) {
         let dict: [String: Double] = ["x": Double(origin.x), "y": Double(origin.y)]
         UserDefaults.standard.set(dict, forKey: positionKey)
     }
-    
+
     private func loadSavedPosition() -> NSRect? {
         guard let dict = UserDefaults.standard.dictionary(forKey: positionKey) as? [String: Double],
               let x = dict["x"], let y = dict["y"] else {
@@ -742,14 +749,14 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
         }
         return NSRect(x: CGFloat(x), y: CGFloat(y), width: bubbleSize.width, height: bubbleSize.height)
     }
-    
+
     private func defaultPosition(for size: NSSize) -> NSRect {
         let screen = NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
         let x = screen.maxX - size.width - 32
         let y = screen.maxY - size.height - 32
         return NSRect(x: x, y: y, width: size.width, height: size.height)
     }
-    
+
     public func refreshTelemetry() {
         DispatchQueue.global(qos: .userInitiated).async {
             let latest = TelemetryQueryEngine.shared.loadLatestRun()

--- a/apps/macos-overlay/Sources/Localization.swift
+++ b/apps/macos-overlay/Sources/Localization.swift
@@ -103,9 +103,44 @@ public final class AppLocalization: ObservableObject {
     }
 }
 
+private enum FlowPilotDateFormatters {
+    static let lock = NSLock()
+    static let clock = make("HH:mm")
+    static let dateTime = make("MM-dd HH:mm")
+    static let fullDateTime = make("yyyy-MM-dd HH:mm")
+
+    private static func make(_ format: String) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateFormat = format
+        return formatter
+    }
+
+    static func string(from date: Date, format: DateFormatter) -> String {
+        lock.lock()
+        defer { lock.unlock() }
+        // Locale and time zone can change while a long-running menu-bar app is
+        // alive, so refresh those lightweight properties while reusing the
+        // expensive formatter instances themselves.
+        format.locale = Locale.current
+        format.timeZone = TimeZone.current
+        return format.string(from: date)
+    }
+}
+
 @inline(__always)
 public func L(_ english: String, _ chinese: String) -> String {
     AppLocalization.shared.text(english, chinese)
+}
+
+/// User-facing local date/time with a calendar date. Same-year timestamps stay
+/// compact; cross-year timestamps include the year to avoid ambiguity.
+public func formatLocalDateTime(_ date: Date) -> String {
+    let currentYear = Calendar.current.component(.year, from: Date())
+    let targetYear = Calendar.current.component(.year, from: date)
+    let formatter = currentYear == targetYear
+        ? FlowPilotDateFormatters.dateTime
+        : FlowPilotDateFormatters.fullDateTime
+    return FlowPilotDateFormatters.string(from: date, format: formatter)
 }
 
 public func localizedRole(_ role: String) -> String {
@@ -137,13 +172,7 @@ public extension QuotaWindow {
             return L("resets now", "立即重置")
         }
 
-        let formatter = DateFormatter()
-        formatter.locale = Locale.current
-        formatter.timeZone = TimeZone.current
-        let currentYear = Calendar.current.component(.year, from: Date())
-        let resetYear = Calendar.current.component(.year, from: date)
-        formatter.dateFormat = currentYear == resetYear ? "MM-dd HH:mm" : "yyyy-MM-dd HH:mm"
-        let value = formatter.string(from: date)
+        let value = formatLocalDateTime(date)
         return L("resets \(value)", "\(value) 重置")
     }
 }
@@ -152,13 +181,11 @@ public extension TaskRun {
     var localizedFormattedDate: String {
         guard let s = startedAtMs else { return "--:--" }
         let date = Date(timeIntervalSince1970: s / 1000.0)
-        let formatter = DateFormatter()
         if Calendar.current.isDateInToday(date) {
-            formatter.dateFormat = "HH:mm"
-            return L("Today \(formatter.string(from: date))", "今天 \(formatter.string(from: date))")
+            let value = FlowPilotDateFormatters.string(from: date, format: FlowPilotDateFormatters.clock)
+            return L("Today \(value)", "今天 \(value)")
         }
-        formatter.dateFormat = "MM-dd HH:mm"
-        return formatter.string(from: date)
+        return FlowPilotDateFormatters.string(from: date, format: FlowPilotDateFormatters.dateTime)
     }
 }
 

--- a/apps/macos-overlay/Sources/Localization.swift
+++ b/apps/macos-overlay/Sources/Localization.swift
@@ -127,25 +127,24 @@ public extension OverlayTab {
 }
 
 public extension QuotaWindow {
+    /// User-facing reset time deliberately includes a calendar date. A bare
+    /// clock time is ambiguous for weekly windows and was especially confusing
+    /// around midnight/year boundaries.
     var localizedFormattedResetsAt: String? {
         guard let r = resetsAt, r > 0 else { return nil }
         let date = Date(timeIntervalSince1970: r > 1_000_000_000_000 ? r / 1000.0 : r)
-        let interval = date.timeIntervalSince(Date())
-        if interval <= 0 {
+        if date <= Date() {
             return L("resets now", "立即重置")
-        } else if interval < 86400 {
-            let mins = Int(interval) / 60
-            if mins < 60 {
-                let displayMins = max(1, mins)
-                return L("resets in \(displayMins)m", "\(displayMins) 分钟后重置")
-            }
-            let hours = mins / 60
-            let remMins = mins % 60
-            return L("resets in \(hours)h \(remMins)m", "\(hours) 小时 \(remMins) 分钟后重置")
         }
+
         let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm"
-        return L("resets at \(formatter.string(from: date))", "\(formatter.string(from: date)) 重置")
+        formatter.locale = Locale.current
+        formatter.timeZone = TimeZone.current
+        let currentYear = Calendar.current.component(.year, from: Date())
+        let resetYear = Calendar.current.component(.year, from: date)
+        formatter.dateFormat = currentYear == resetYear ? "MM-dd HH:mm" : "yyyy-MM-dd HH:mm"
+        let value = formatter.string(from: date)
+        return L("resets \(value)", "\(value) 重置")
     }
 }
 
@@ -169,4 +168,3 @@ public extension ChatSession {
         return count == 1 ? L("1 session", "1 次会话") : L("\(count) sessions", "\(count) 轮会话")
     }
 }
-

--- a/apps/macos-overlay/Sources/Services/AccountSnapshotService.swift
+++ b/apps/macos-overlay/Sources/Services/AccountSnapshotService.swift
@@ -66,15 +66,13 @@ public struct AccountSnapshot {
     public var orderedWindows: [AccountQuotaWindow] {
         var result: [AccountQuotaWindow] = []
         if let fiveHourWindow { result.append(fiveHourWindow) }
-        if let weeklyWindow { result.append(weeklyHourWindow) }
+        if let weeklyWindow { result.append(weeklyWindow) }
         let knownIds = Set(result.map(\.id))
         result.append(contentsOf: quotaWindows.filter { !knownIds.contains($0.id) }.sorted {
             ($0.durationMinutes ?? Int.max) < ($1.durationMinutes ?? Int.max)
         })
         return result
     }
-
-    private var weeklyHourWindow: AccountQuotaWindow? { weeklyWindow }
 
     public var nearestResetCreditExpiry: Date? {
         resetCredits.compactMap(\.expiresAt).filter { $0 > Date() }.min()

--- a/apps/macos-overlay/Sources/Services/AccountSnapshotService.swift
+++ b/apps/macos-overlay/Sources/Services/AccountSnapshotService.swift
@@ -336,11 +336,5 @@ public enum AccountSnapshotService {
 }
 
 public func formatAccountDate(_ date: Date) -> String {
-    let formatter = DateFormatter()
-    formatter.locale = Locale.current
-    formatter.timeZone = TimeZone.current
-    let currentYear = Calendar.current.component(.year, from: Date())
-    let targetYear = Calendar.current.component(.year, from: date)
-    formatter.dateFormat = currentYear == targetYear ? "MM-dd HH:mm" : "yyyy-MM-dd HH:mm"
-    return formatter.string(from: date)
+    formatLocalDateTime(date)
 }

--- a/apps/macos-overlay/Sources/Services/AccountSnapshotService.swift
+++ b/apps/macos-overlay/Sources/Services/AccountSnapshotService.swift
@@ -1,0 +1,301 @@
+import Foundation
+
+public struct AccountQuotaWindow: Identifiable {
+    public let id: String
+    public let durationMinutes: Int?
+    public let usedPercent: Double?
+    public let resetsAt: Date?
+
+    public var remainingPercent: Double? {
+        guard let usedPercent else { return nil }
+        return max(0, min(100, 100 - usedPercent))
+    }
+
+    public var displayName: String {
+        guard let mins = durationMinutes else { return L("Usage window", "额度窗口") }
+        switch mins {
+        case 300: return L("5 hour limit", "5 小时额度")
+        case 10080: return L("Weekly limit", "每周额度")
+        default:
+            if mins < 60 { return "\(mins)m" }
+            if mins < 1440 { return "\(mins / 60)h" }
+            return "\(mins / 1440)d"
+        }
+    }
+
+    public var compactName: String {
+        guard let mins = durationMinutes else { return "—" }
+        if mins == 300 { return "5h" }
+        if mins == 10080 { return L("Weekly", "每周") }
+        if mins < 60 { return "\(mins)m" }
+        if mins < 1440 { return "\(mins / 60)h" }
+        return "\(mins / 1440)d"
+    }
+}
+
+public struct AccountResetCredit: Identifiable {
+    public let id: String
+    public let status: String?
+    public let expiresAt: Date?
+    public let title: String?
+}
+
+public struct AccountSnapshot {
+    public let accountType: String?
+    public let email: String?
+    public let planType: String?
+    public let requiresOpenAIAuth: Bool?
+    public let quotaWindows: [AccountQuotaWindow]
+    public let resetCreditCount: Int?
+    public let resetCredits: [AccountResetCredit]
+    public let hasCredits: Bool?
+    public let unlimitedCredits: Bool?
+    public let creditsBalance: String?
+    public let spendControlReached: Bool?
+    public let rateLimitReachedType: String?
+    public let fetchedAt: Date
+
+    public var fiveHourWindow: AccountQuotaWindow? {
+        quotaWindows.first { $0.durationMinutes == 300 }
+    }
+
+    public var weeklyWindow: AccountQuotaWindow? {
+        quotaWindows.first { $0.durationMinutes == 10080 }
+    }
+
+    public var orderedWindows: [AccountQuotaWindow] {
+        var result: [AccountQuotaWindow] = []
+        if let fiveHourWindow { result.append(fiveHourWindow) }
+        if let weeklyWindow { result.append(weeklyWindow) }
+        let knownIds = Set(result.map(\.id))
+        result.append(contentsOf: quotaWindows.filter { !knownIds.contains($0.id) }.sorted {
+            ($0.durationMinutes ?? Int.max) < ($1.durationMinutes ?? Int.max)
+        })
+        return result
+    }
+
+    public var nearestResetCreditExpiry: Date? {
+        resetCredits.compactMap(\.expiresAt).filter { $0 > Date() }.min()
+    }
+}
+
+private final class AccountAppServerRPC {
+    private struct Pending {
+        let semaphore: DispatchSemaphore
+        var result: [String: Any]?
+    }
+
+    private let process = Process()
+    private let input = Pipe()
+    private let output = Pipe()
+    private let lock = NSLock()
+    private var nextId = 1
+    private var pending: [Int: Pending] = [:]
+    private var buffer = Data()
+    private var started = false
+
+    init() throws {
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["codex", "app-server"]
+        process.standardInput = input
+        process.standardOutput = output
+        process.standardError = FileHandle.nullDevice
+        output.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty else { return }
+            self?.receive(data)
+        }
+        try process.run()
+        started = true
+    }
+
+    deinit { close() }
+
+    func initialize() -> Bool {
+        let response = request(
+            method: "initialize",
+            params: [
+                "clientInfo": ["name": "codex-flow", "title": "FlowPilot Account", "version": "1"],
+                "capabilities": ["experimentalApi": true]
+            ],
+            timeout: 4.0
+        )
+        guard response != nil else { return false }
+        notify(method: "initialized", params: nil)
+        return true
+    }
+
+    func request(method: String, params: [String: Any]?, timeout: TimeInterval = 4.0) -> [String: Any]? {
+        lock.lock()
+        let id = nextId
+        nextId += 1
+        let semaphore = DispatchSemaphore(value: 0)
+        pending[id] = Pending(semaphore: semaphore, result: nil)
+        lock.unlock()
+
+        var payload: [String: Any] = ["id": id, "method": method]
+        if let params { payload["params"] = params }
+        guard send(payload) else {
+            lock.lock(); pending.removeValue(forKey: id); lock.unlock()
+            return nil
+        }
+
+        guard semaphore.wait(timeout: .now() + timeout) == .success else {
+            lock.lock(); pending.removeValue(forKey: id); lock.unlock()
+            return nil
+        }
+
+        lock.lock()
+        let result = pending.removeValue(forKey: id)?.result
+        lock.unlock()
+        return result
+    }
+
+    func notify(method: String, params: [String: Any]?) {
+        var payload: [String: Any] = ["method": method]
+        if let params { payload["params"] = params }
+        _ = send(payload)
+    }
+
+    func close() {
+        guard started else { return }
+        started = false
+        output.fileHandleForReading.readabilityHandler = nil
+        if process.isRunning { process.terminate() }
+    }
+
+    private func send(_ object: [String: Any]) -> Bool {
+        guard JSONSerialization.isValidJSONObject(object),
+              var data = try? JSONSerialization.data(withJSONObject: object) else { return false }
+        data.append(0x0A)
+        do {
+            try input.fileHandleForWriting.write(contentsOf: data)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    private func receive(_ data: Data) {
+        lock.lock()
+        buffer.append(data)
+        let newline = Data([0x0A])
+        var lines: [Data] = []
+        while let range = buffer.range(of: newline) {
+            lines.append(buffer.subdata(in: buffer.startIndex..<range.lowerBound))
+            buffer.removeSubrange(buffer.startIndex...range.lowerBound)
+        }
+        lock.unlock()
+
+        for line in lines where !line.isEmpty {
+            guard let object = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
+                  let idNumber = object["id"] as? NSNumber else { continue }
+            let id = idNumber.intValue
+            let result = object["result"] as? [String: Any]
+            lock.lock()
+            if var item = pending[id] {
+                item.result = result
+                pending[id] = item
+                item.semaphore.signal()
+            }
+            lock.unlock()
+        }
+    }
+}
+
+public enum AccountSnapshotService {
+    public static func load() throws -> AccountSnapshot {
+        let rpc = try AccountAppServerRPC()
+        defer { rpc.close() }
+
+        guard rpc.initialize() else {
+            throw error(L("Codex app-server did not respond.", "Codex app-server 未响应。"), code: 1)
+        }
+
+        let accountResponse = rpc.request(method: "account/read", params: ["refreshToken": false])
+        let limitsResponse = rpc.request(method: "account/rateLimits/read", params: nil)
+        guard accountResponse != nil || limitsResponse != nil else {
+            throw error(L("Account data is unavailable from Codex.", "Codex 暂未返回账户数据。"), code: 2)
+        }
+
+        let account = accountResponse?["account"] as? [String: Any]
+        let requiresAuth = (accountResponse?["requiresOpenaiAuth"] as? NSNumber)?.boolValue
+        let fallbackSnapshot = limitsResponse?["rateLimits"] as? [String: Any]
+        let byId = limitsResponse?["rateLimitsByLimitId"] as? [String: Any]
+        let codexSnapshot = (byId?["codex"] as? [String: Any]) ?? fallbackSnapshot ?? [:]
+
+        var windows: [AccountQuotaWindow] = []
+        for slot in ["primary", "secondary"] {
+            guard let raw = codexSnapshot[slot] as? [String: Any] else { continue }
+            let duration = intValue(raw["windowDurationMins"] ?? raw["windowMinutes"])
+            windows.append(AccountQuotaWindow(
+                id: "\(slot)-\(duration ?? 0)",
+                durationMinutes: duration,
+                usedPercent: doubleValue(raw["usedPercent"]),
+                resetsAt: dateValue(raw["resetsAt"])
+            ))
+        }
+
+        let resetSummary = limitsResponse?["rateLimitResetCredits"] as? [String: Any]
+        let resetCount = intValue(resetSummary?["availableCount"])
+        let rawCredits = resetSummary?["credits"] as? [[String: Any]] ?? []
+        let resetCredits = rawCredits.compactMap { raw -> AccountResetCredit? in
+            guard let id = raw["id"] as? String else { return nil }
+            return AccountResetCredit(
+                id: id,
+                status: raw["status"] as? String,
+                expiresAt: dateValue(raw["expiresAt"]),
+                title: raw["title"] as? String
+            )
+        }
+
+        let credits = codexSnapshot["credits"] as? [String: Any]
+        let plan = (account?["planType"] as? String) ?? (codexSnapshot["planType"] as? String)
+        return AccountSnapshot(
+            accountType: account?["type"] as? String,
+            email: account?["email"] as? String,
+            planType: plan,
+            requiresOpenAIAuth: requiresAuth,
+            quotaWindows: windows,
+            resetCreditCount: resetCount,
+            resetCredits: resetCredits,
+            hasCredits: (credits?["hasCredits"] as? NSNumber)?.boolValue,
+            unlimitedCredits: (credits?["unlimited"] as? NSNumber)?.boolValue,
+            creditsBalance: credits?["balance"] as? String,
+            spendControlReached: (codexSnapshot["spendControlReached"] as? NSNumber)?.boolValue,
+            rateLimitReachedType: codexSnapshot["rateLimitReachedType"] as? String,
+            fetchedAt: Date()
+        )
+    }
+
+    private static func intValue(_ value: Any?) -> Int? {
+        if let number = value as? NSNumber { return number.intValue }
+        if let value = value as? String { return Int(value) }
+        return nil
+    }
+
+    private static func doubleValue(_ value: Any?) -> Double? {
+        if let number = value as? NSNumber { return number.doubleValue }
+        if let value = value as? String { return Double(value) }
+        return nil
+    }
+
+    private static func dateValue(_ value: Any?) -> Date? {
+        guard let raw = doubleValue(value), raw > 0 else { return nil }
+        return Date(timeIntervalSince1970: raw > 1_000_000_000_000 ? raw / 1000.0 : raw)
+    }
+
+    private static func error(_ message: String, code: Int) -> NSError {
+        NSError(domain: "FlowPilot.Account", code: code, userInfo: [NSLocalizedDescriptionKey: message])
+    }
+}
+
+public func formatAccountDate(_ date: Date) -> String {
+    let formatter = DateFormatter()
+    formatter.locale = Locale.current
+    formatter.timeZone = TimeZone.current
+    let currentYear = Calendar.current.component(.year, from: Date())
+    let targetYear = Calendar.current.component(.year, from: date)
+    formatter.dateFormat = currentYear == targetYear ? "MM-dd HH:mm" : "yyyy-MM-dd HH:mm"
+    return formatter.string(from: date)
+}

--- a/apps/macos-overlay/Sources/Services/AccountSnapshotService.swift
+++ b/apps/macos-overlay/Sources/Services/AccountSnapshotService.swift
@@ -66,13 +66,15 @@ public struct AccountSnapshot {
     public var orderedWindows: [AccountQuotaWindow] {
         var result: [AccountQuotaWindow] = []
         if let fiveHourWindow { result.append(fiveHourWindow) }
-        if let weeklyWindow { result.append(weeklyWindow) }
+        if let weeklyWindow { result.append(weeklyHourWindow) }
         let knownIds = Set(result.map(\.id))
         result.append(contentsOf: quotaWindows.filter { !knownIds.contains($0.id) }.sorted {
             ($0.durationMinutes ?? Int.max) < ($1.durationMinutes ?? Int.max)
         })
         return result
     }
+
+    private var weeklyHourWindow: AccountQuotaWindow? { weeklyWindow }
 
     public var nearestResetCreditExpiry: Date? {
         resetCredits.compactMap(\.expiresAt).filter { $0 > Date() }.min()
@@ -172,7 +174,9 @@ private final class AccountAppServerRPC {
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !override.isEmpty {
             process.executableURL = URL(fileURLWithPath: "/bin/sh")
-            process.arguments = ["-lc", override]
+            // Avoid a login shell here: startup files can print to stdout and
+            // corrupt the JSONL app-server stream before the first RPC reply.
+            process.arguments = ["-c", override]
             return
         }
 

--- a/apps/macos-overlay/Sources/Services/AccountSnapshotService.swift
+++ b/apps/macos-overlay/Sources/Services/AccountSnapshotService.swift
@@ -95,8 +95,7 @@ private final class AccountAppServerRPC {
     private var started = false
 
     init() throws {
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        process.arguments = ["codex", "app-server"]
+        Self.configureProcess(process)
         process.standardInput = input
         process.standardOutput = output
         process.standardError = FileHandle.nullDevice
@@ -162,6 +161,52 @@ private final class AccountAppServerRPC {
         started = false
         output.fileHandleForReading.readabilityHandler = nil
         if process.isRunning { process.terminate() }
+    }
+
+    private static func configureProcess(_ process: Process) {
+        let environment = ProcessInfo.processInfo.environment
+
+        // Keep parity with the Python telemetry app-server adapter. This is
+        // especially useful for tests and non-standard Codex installations.
+        if let override = environment["CODEX_FLOW_APP_SERVER_COMMAND"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !override.isEmpty {
+            process.executableURL = URL(fileURLWithPath: "/bin/sh")
+            process.arguments = ["-lc", override]
+            return
+        }
+
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let codexHome = environment["CODEX_HOME"]
+            .map(URL.init(fileURLWithPath:))
+            ?? home.appendingPathComponent(".codex")
+
+        // Finder and Login Items normally inherit a minimal PATH. Honor any
+        // explicit PATH entries first, then probe the common installation
+        // locations used by Homebrew, npm/pnpm, Volta, Bun, and local installs.
+        var candidates: [URL] = []
+        if let path = environment["PATH"] {
+            candidates.append(contentsOf: path.split(separator: ":").map {
+                URL(fileURLWithPath: String($0)).appendingPathComponent("codex")
+            })
+        }
+        candidates.append(home.appendingPathComponent(".local/bin/codex"))
+        candidates.append(home.appendingPathComponent(".npm-global/bin/codex"))
+        candidates.append(home.appendingPathComponent("Library/pnpm/codex"))
+        candidates.append(home.appendingPathComponent(".volta/bin/codex"))
+        candidates.append(home.appendingPathComponent(".bun/bin/codex"))
+        candidates.append(home.appendingPathComponent(".nvm/current/bin/codex"))
+        candidates.append(codexHome.appendingPathComponent("bin/codex"))
+        candidates.append(URL(fileURLWithPath: "/opt/homebrew/bin/codex"))
+        candidates.append(URL(fileURLWithPath: "/usr/local/bin/codex"))
+
+        if let installedCodex = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0.path) }) {
+            process.executableURL = installedCodex
+            process.arguments = ["app-server"]
+        } else {
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            process.arguments = ["codex", "app-server"]
+        }
     }
 
     private func send(_ object: [String: Any]) -> Bool {

--- a/apps/macos-overlay/Sources/Views/AccountView.swift
+++ b/apps/macos-overlay/Sources/Views/AccountView.swift
@@ -170,10 +170,11 @@ public struct AccountView: View {
     }
 
     private func quotaRow(_ window: AccountQuotaWindow) -> some View {
-        let used = max(0, min(100, window.usedPercent ?? 0))
+        let used = window.usedPercent.map { max(0, min(100, $0)) }
         let remaining = window.remainingPercent
         let remainingFraction = max(0, min(1, (remaining ?? 0) / 100.0))
-        let accent: Color = used >= 85 ? .orange : (used >= 60 ? .yellow : .cyan)
+        let pressure = used ?? 0
+        let accent: Color = pressure >= 85 ? .orange : (pressure >= 60 ? .yellow : .cyan)
 
         return VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 5) {
@@ -190,23 +191,33 @@ public struct AccountView: View {
                         .font(.system(size: 9, weight: .bold, design: .rounded))
                         .foregroundColor(accent)
                 } else {
-                    Text("—").foregroundColor(.white.opacity(0.35))
+                    Text(L("Not reported", "未返回"))
+                        .font(.system(size: 8, weight: .medium))
+                        .foregroundColor(.white.opacity(0.35))
                 }
             }
 
             GeometryReader { proxy in
                 ZStack(alignment: .leading) {
                     Capsule().fill(Color.white.opacity(0.08))
-                    Capsule().fill(accent)
-                        .frame(width: proxy.size.width * CGFloat(remainingFraction))
+                    if remaining != nil {
+                        Capsule().fill(accent)
+                            .frame(width: proxy.size.width * CGFloat(remainingFraction))
+                    }
                 }
             }
             .frame(height: 4)
 
             HStack {
-                Text(String(format: L("Used %.0f%%", "已用 %.0f%%"), used))
-                    .font(.system(size: 7.8))
-                    .foregroundColor(.white.opacity(0.4))
+                if let used {
+                    Text(String(format: L("Used %.0f%%", "已用 %.0f%%"), used))
+                        .font(.system(size: 7.8))
+                        .foregroundColor(.white.opacity(0.4))
+                } else {
+                    Text(L("Usage not reported", "用量未返回"))
+                        .font(.system(size: 7.8))
+                        .foregroundColor(.white.opacity(0.4))
+                }
                 Spacer()
                 Text(window.resetsAt.map { L("Resets \(formatAccountDate($0))", "\(formatAccountDate($0)) 重置") } ?? L("Reset time unavailable", "重置时间未返回"))
                     .font(.system(size: 7.8, weight: .medium, design: .monospaced))

--- a/apps/macos-overlay/Sources/Views/AccountView.swift
+++ b/apps/macos-overlay/Sources/Views/AccountView.swift
@@ -19,6 +19,7 @@ public struct AccountView: View {
         let content = VStack(spacing: 9) {
             accountHeader
             StrategyModeCard()
+            AutostartCard()
 
             if isLoading && snapshot == nil {
                 loadingState

--- a/apps/macos-overlay/Sources/Views/AccountView.swift
+++ b/apps/macos-overlay/Sources/Views/AccountView.swift
@@ -1,0 +1,662 @@
+import SwiftUI
+import Foundation
+
+// MARK: - Deterministic account snapshot from Codex app-server
+
+public struct AccountQuotaWindow: Identifiable {
+    public let id: String
+    public let durationMinutes: Int?
+    public let usedPercent: Double?
+    public let resetsAt: Date?
+
+    public var remainingPercent: Double? {
+        guard let usedPercent else { return nil }
+        return max(0, min(100, 100 - usedPercent))
+    }
+
+    public var displayName: String {
+        guard let mins = durationMinutes else { return L("Usage window", "额度窗口") }
+        switch mins {
+        case 300:
+            return L("5 hour limit", "5 小时额度")
+        case 10080:
+            return L("Weekly limit", "每周额度")
+        default:
+            if mins < 60 { return "\(mins)m" }
+            if mins < 1440 { return "\(mins / 60)h" }
+            return "\(mins / 1440)d"
+        }
+    }
+
+    public var compactName: String {
+        guard let mins = durationMinutes else { return "—" }
+        if mins == 300 { return "5h" }
+        if mins == 10080 { return L("Weekly", "Weekly") }
+        if mins < 60 { return "\(mins)m" }
+        if mins < 1440 { return "\(mins / 60)h" }
+        return "\(mins / 1440)d"
+    }
+}
+
+public struct AccountResetCredit: Identifiable {
+    public let id: String
+    public let status: String?
+    public let expiresAt: Date?
+    public let title: String?
+}
+
+public struct AccountSnapshot {
+    public let accountType: String?
+    public let email: String?
+    public let planType: String?
+    public let requiresOpenAIAuth: Bool?
+    public let quotaWindows: [AccountQuotaWindow]
+    public let resetCreditCount: Int?
+    public let resetCredits: [AccountResetCredit]
+    public let hasCredits: Bool?
+    public let unlimitedCredits: Bool?
+    public let creditsBalance: String?
+    public let spendControlReached: Bool?
+    public let rateLimitReachedType: String?
+    public let fetchedAt: Date
+
+    public var fiveHourWindow: AccountQuotaWindow? {
+        quotaWindows.first { $0.durationMinutes == 300 }
+    }
+
+    public var weeklyWindow: AccountQuotaWindow? {
+        quotaWindows.first { $0.durationMinutes == 10080 }
+    }
+
+    public var orderedWindows: [AccountQuotaWindow] {
+        var result: [AccountQuotaWindow] = []
+        if let fiveHourWindow { result.append(fiveHourWindow) }
+        if let weeklyWindow { result.append(weeklyWindow) }
+        let knownIds = Set(result.map(\.id))
+        result.append(contentsOf: quotaWindows.filter { !knownIds.contains($0.id) }.sorted {
+            ($0.durationMinutes ?? Int.max) < ($1.durationMinutes ?? Int.max)
+        })
+        return result
+    }
+
+    public var nearestResetCreditExpiry: Date? {
+        resetCredits.compactMap(\.expiresAt).filter { $0 > Date() }.min()
+    }
+}
+
+private final class AppServerRPC {
+    private struct Pending {
+        let semaphore: DispatchSemaphore
+        var result: [String: Any]?
+    }
+
+    private let process = Process()
+    private let input = Pipe()
+    private let output = Pipe()
+    private let lock = NSLock()
+    private var nextId = 1
+    private var pending: [Int: Pending] = [:]
+    private var buffer = Data()
+    private var started = false
+
+    init() throws {
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["codex", "app-server"]
+        process.standardInput = input
+        process.standardOutput = output
+        process.standardError = FileHandle.nullDevice
+
+        output.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty else { return }
+            self?.receive(data)
+        }
+
+        try process.run()
+        started = true
+    }
+
+    deinit {
+        close()
+    }
+
+    func initialize() -> Bool {
+        let response = request(
+            method: "initialize",
+            params: [
+                "clientInfo": [
+                    "name": "codex-flow",
+                    "title": "FlowPilot Account",
+                    "version": "1"
+                ],
+                "capabilities": ["experimentalApi": true]
+            ],
+            timeout: 4.0
+        )
+        guard response != nil else { return false }
+        notify(method: "initialized", params: nil)
+        return true
+    }
+
+    func request(method: String, params: [String: Any]?, timeout: TimeInterval = 4.0) -> [String: Any]? {
+        lock.lock()
+        let id = nextId
+        nextId += 1
+        let semaphore = DispatchSemaphore(value: 0)
+        pending[id] = Pending(semaphore: semaphore, result: nil)
+        lock.unlock()
+
+        var payload: [String: Any] = ["id": id, "method": method]
+        if let params { payload["params"] = params }
+        guard send(payload) else {
+            lock.lock()
+            pending.removeValue(forKey: id)
+            lock.unlock()
+            return nil
+        }
+
+        guard semaphore.wait(timeout: .now() + timeout) == .success else {
+            lock.lock()
+            pending.removeValue(forKey: id)
+            lock.unlock()
+            return nil
+        }
+
+        lock.lock()
+        let result = pending.removeValue(forKey: id)?.result
+        lock.unlock()
+        return result
+    }
+
+    func notify(method: String, params: [String: Any]?) {
+        var payload: [String: Any] = ["method": method]
+        if let params { payload["params"] = params }
+        _ = send(payload)
+    }
+
+    func close() {
+        guard started else { return }
+        started = false
+        output.fileHandleForReading.readabilityHandler = nil
+        if process.isRunning {
+            process.terminate()
+        }
+    }
+
+    private func send(_ object: [String: Any]) -> Bool {
+        guard JSONSerialization.isValidJSONObject(object),
+              var data = try? JSONSerialization.data(withJSONObject: object) else { return false }
+        data.append(0x0A)
+        do {
+            try input.fileHandleForWriting.write(contentsOf: data)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    private func receive(_ data: Data) {
+        lock.lock()
+        buffer.append(data)
+        let newline = Data([0x0A])
+        var lines: [Data] = []
+        while let range = buffer.range(of: newline) {
+            lines.append(buffer.subdata(in: buffer.startIndex..<range.lowerBound))
+            buffer.removeSubrange(buffer.startIndex...range.lowerBound)
+        }
+        lock.unlock()
+
+        for line in lines where !line.isEmpty {
+            guard let object = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
+                  let idNumber = object["id"] as? NSNumber else { continue }
+            let id = idNumber.intValue
+            let result = object["result"] as? [String: Any]
+
+            lock.lock()
+            if var item = pending[id] {
+                item.result = result
+                pending[id] = item
+                item.semaphore.signal()
+            }
+            lock.unlock()
+        }
+    }
+}
+
+public enum AccountSnapshotService {
+    public static func load() throws -> AccountSnapshot {
+        let rpc = try AppServerRPC()
+        defer { rpc.close() }
+
+        guard rpc.initialize() else {
+            throw NSError(domain: "FlowPilot.Account", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: L("Codex app-server did not respond.", "Codex app-server 未响应。")
+            ])
+        }
+
+        let accountResponse = rpc.request(method: "account/read", params: ["refreshToken": false])
+        let limitsResponse = rpc.request(method: "account/rateLimits/read", params: nil)
+
+        guard accountResponse != nil || limitsResponse != nil else {
+            throw NSError(domain: "FlowPilot.Account", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: L("Account data is unavailable from Codex.", "Codex 暂未返回账户数据。")
+            ])
+        }
+
+        let account = accountResponse?["account"] as? [String: Any]
+        let requiresAuth = (accountResponse?["requiresOpenaiAuth"] as? NSNumber)?.boolValue
+
+        let fallbackSnapshot = limitsResponse?["rateLimits"] as? [String: Any]
+        let byId = limitsResponse?["rateLimitsByLimitId"] as? [String: Any]
+        let codexSnapshot = (byId?["codex"] as? [String: Any]) ?? fallbackSnapshot ?? [:]
+
+        var windows: [AccountQuotaWindow] = []
+        for slot in ["primary", "secondary"] {
+            guard let raw = codexSnapshot[slot] as? [String: Any] else { continue }
+            let duration = intValue(raw["windowDurationMins"] ?? raw["windowMinutes"])
+            let used = doubleValue(raw["usedPercent"])
+            let reset = dateValue(raw["resetsAt"])
+            windows.append(AccountQuotaWindow(
+                id: "\(slot)-\(duration ?? 0)",
+                durationMinutes: duration,
+                usedPercent: used,
+                resetsAt: reset
+            ))
+        }
+
+        let resetSummary = limitsResponse?["rateLimitResetCredits"] as? [String: Any]
+        let resetCount = intValue(resetSummary?["availableCount"])
+        let rawCredits = resetSummary?["credits"] as? [[String: Any]] ?? []
+        let resetCredits = rawCredits.compactMap { raw -> AccountResetCredit? in
+            guard let id = raw["id"] as? String else { return nil }
+            return AccountResetCredit(
+                id: id,
+                status: raw["status"] as? String,
+                expiresAt: dateValue(raw["expiresAt"]),
+                title: raw["title"] as? String
+            )
+        }
+
+        let credits = codexSnapshot["credits"] as? [String: Any]
+        let plan = (account?["planType"] as? String) ?? (codexSnapshot["planType"] as? String)
+
+        return AccountSnapshot(
+            accountType: account?["type"] as? String,
+            email: account?["email"] as? String,
+            planType: plan,
+            requiresOpenAIAuth: requiresAuth,
+            quotaWindows: windows,
+            resetCreditCount: resetCount,
+            resetCredits: resetCredits,
+            hasCredits: (credits?["hasCredits"] as? NSNumber)?.boolValue,
+            unlimitedCredits: (credits?["unlimited"] as? NSNumber)?.boolValue,
+            creditsBalance: credits?["balance"] as? String,
+            spendControlReached: (codexSnapshot["spendControlReached"] as? NSNumber)?.boolValue,
+            rateLimitReachedType: codexSnapshot["rateLimitReachedType"] as? String,
+            fetchedAt: Date()
+        )
+    }
+
+    private static func intValue(_ value: Any?) -> Int? {
+        if let number = value as? NSNumber { return number.intValue }
+        if let value = value as? String { return Int(value) }
+        return nil
+    }
+
+    private static func doubleValue(_ value: Any?) -> Double? {
+        if let number = value as? NSNumber { return number.doubleValue }
+        if let value = value as? String { return Double(value) }
+        return nil
+    }
+
+    private static func dateValue(_ value: Any?) -> Date? {
+        guard let raw = doubleValue(value), raw > 0 else { return nil }
+        return Date(timeIntervalSince1970: raw > 1_000_000_000_000 ? raw / 1000.0 : raw)
+    }
+}
+
+// MARK: - Account UI
+
+public struct AccountView: View {
+    @ObservedObject var state: OverlayState
+    @ObservedObject private var localization = AppLocalization.shared
+    public var isFullHeight: Bool = false
+
+    @State private var snapshot: AccountSnapshot?
+    @State private var isLoading = false
+    @State private var errorMessage: String?
+
+    public init(state: OverlayState, isFullHeight: Bool = false) {
+        self.state = state
+        self.isFullHeight = isFullHeight
+    }
+
+    public var body: some View {
+        let content = VStack(spacing: 9) {
+            accountHeader
+
+            if isLoading && snapshot == nil {
+                loadingState
+            } else if let snapshot {
+                identityCard(snapshot)
+                quotaCard(snapshot)
+                resetCard(snapshot)
+                accountFactsCard(snapshot)
+            } else {
+                unavailableState
+            }
+        }
+        .padding(.vertical, 2)
+
+        return Group {
+            if isFullHeight {
+                content
+            } else {
+                ScrollView(.vertical, showsIndicators: true) {
+                    content
+                }
+                .frame(maxHeight: 390)
+            }
+        }
+        .onAppear(perform: refresh)
+    }
+
+    private var accountHeader: some View {
+        HStack(spacing: 9) {
+            FlowPilotLogoView(size: 42, showGlow: true, withBolt: false, text: "FP")
+                .frame(width: 42, height: 42)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(L("Account & Limits", "账户与额度"))
+                    .font(.system(size: 12, weight: .bold, design: .rounded))
+                    .foregroundColor(.white)
+                Text(L("Live data from Codex app-server", "数据直接来自 Codex app-server"))
+                    .font(.system(size: 8.5, weight: .regular))
+                    .foregroundColor(.white.opacity(0.45))
+            }
+
+            Spacer()
+
+            Button(action: refresh) {
+                Image(systemName: "arrow.clockwise")
+                    .font(.system(size: 9.5, weight: .semibold))
+                    .foregroundColor(.cyan)
+                    .frame(width: 24, height: 24)
+                    .background(Circle().fill(Color.cyan.opacity(0.12)))
+            }
+            .buttonStyle(.plain)
+            .disabled(isLoading)
+        }
+    }
+
+    private var loadingState: some View {
+        VStack(spacing: 8) {
+            ProgressView()
+                .controlSize(.small)
+            Text(L("Reading account status…", "正在读取账户状态…"))
+                .font(.system(size: 10))
+                .foregroundColor(.white.opacity(0.55))
+        }
+        .frame(maxWidth: .infinity, minHeight: 180)
+    }
+
+    private var unavailableState: some View {
+        VStack(spacing: 7) {
+            Image(systemName: "person.crop.circle.badge.exclamationmark")
+                .font(.system(size: 22))
+                .foregroundColor(.orange.opacity(0.8))
+            Text(errorMessage ?? L("Account data unavailable", "账户数据暂不可用"))
+                .font(.system(size: 10, weight: .medium))
+                .foregroundColor(.white.opacity(0.72))
+                .multilineTextAlignment(.center)
+            Text(L("FlowPilot will not estimate plan or quota values when Codex does not report them.", "Codex 未返回的数据，FlowPilot 不会进行估算。"))
+                .font(.system(size: 8.5))
+                .foregroundColor(.white.opacity(0.4))
+                .multilineTextAlignment(.center)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, minHeight: 180)
+        .background(cardBackground)
+    }
+
+    private func identityCard(_ value: AccountSnapshot) -> some View {
+        HStack(spacing: 8) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(L("CURRENT PLAN", "当前 PLAN"))
+                    .font(.system(size: 8, weight: .bold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.42))
+                Text(planDisplayName(value.planType))
+                    .font(.system(size: 16, weight: .heavy, design: .rounded))
+                    .foregroundStyle(LinearGradient(colors: [.cyan, .indigo], startPoint: .leading, endPoint: .trailing))
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: 3) {
+                Text(accountTypeDisplayName(value.accountType))
+                    .font(.system(size: 8.5, weight: .bold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.7))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Capsule().fill(Color.white.opacity(0.07)))
+
+                if let email = value.email, !email.isEmpty {
+                    HoverRevealText(
+                        email,
+                        font: .system(size: 8.5, weight: .regular),
+                        foregroundColor: .white.opacity(0.48),
+                        lineLimit: 1,
+                        privacyBlur: state.isPrivacyMode,
+                        popoverWidth: 300
+                    )
+                    .frame(maxWidth: 190, alignment: .trailing)
+                }
+            }
+        }
+        .padding(9)
+        .background(cardBackground)
+    }
+
+    private func quotaCard(_ value: AccountSnapshot) -> some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack {
+                Label(L("Current quota", "当前额度"), systemImage: "gauge.with.needle.fill")
+                    .font(.system(size: 9.5, weight: .bold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.82))
+                Spacer()
+                if value.quotaWindows.isEmpty {
+                    Text(L("Not reported", "未返回"))
+                        .font(.system(size: 8))
+                        .foregroundColor(.white.opacity(0.4))
+                }
+            }
+
+            if value.quotaWindows.isEmpty {
+                Text(L("Codex did not return a rate-limit window for this account.", "Codex 当前没有返回该账户的额度窗口。"))
+                    .font(.system(size: 8.5))
+                    .foregroundColor(.white.opacity(0.45))
+            } else {
+                ForEach(value.orderedWindows) { window in
+                    quotaRow(window)
+                }
+            }
+        }
+        .padding(9)
+        .background(cardBackground)
+    }
+
+    private func quotaRow(_ window: AccountQuotaWindow) -> some View {
+        let used = max(0, min(100, window.usedPercent ?? 0))
+        let remaining = window.remainingPercent
+        let accent: Color = used >= 85 ? .orange : (used >= 60 ? .yellow : .cyan)
+
+        return VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 5) {
+                Text(window.compactName)
+                    .font(.system(size: 9, weight: .heavy, design: .monospaced))
+                    .foregroundColor(accent)
+                    .frame(width: 48, alignment: .leading)
+
+                Text(window.displayName)
+                    .font(.system(size: 8.5, weight: .semibold))
+                    .foregroundColor(.white.opacity(0.72))
+
+                Spacer()
+
+                if let remaining {
+                    Text(String(format: L("%.0f%% left", "剩余 %.0f%%"), remaining))
+                        .font(.system(size: 9, weight: .bold, design: .rounded))
+                        .foregroundColor(accent)
+                } else {
+                    Text("—")
+                        .foregroundColor(.white.opacity(0.35))
+                }
+            }
+
+            GeometryReader { proxy in
+                ZStack(alignment: .leading) {
+                    Capsule().fill(Color.white.opacity(0.08))
+                    Capsule()
+                        .fill(accent)
+                        .frame(width: proxy.size.width * CGFloat(used / 100.0))
+                }
+            }
+            .frame(height: 4)
+
+            HStack {
+                Text(String(format: L("Used %.0f%%", "已用 %.0f%%"), used))
+                    .font(.system(size: 7.8))
+                    .foregroundColor(.white.opacity(0.4))
+                Spacer()
+                Text(window.resetsAt.map { L("Resets \(formatAccountDate($0))", "\(formatAccountDate($0)) 重置") } ?? L("Reset time unavailable", "重置时间未返回"))
+                    .font(.system(size: 7.8, weight: .medium, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.52))
+            }
+        }
+        .padding(7)
+        .background(RoundedRectangle(cornerRadius: 7).fill(Color.white.opacity(0.025)))
+    }
+
+    private func resetCard(_ value: AccountSnapshot) -> some View {
+        HStack(spacing: 8) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(L("USAGE RESETS", "额度重置次数"))
+                    .font(.system(size: 8, weight: .bold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.42))
+                Text(value.resetCreditCount.map(String.init) ?? "—")
+                    .font(.system(size: 15, weight: .heavy, design: .rounded))
+                    .foregroundColor(value.resetCreditCount ?? 0 > 0 ? .cyan : .white.opacity(0.8))
+            }
+
+            Divider().frame(height: 30).overlay(Color.white.opacity(0.08))
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(L("RESET CREDIT EXPIRY", "重置额度到期"))
+                    .font(.system(size: 8, weight: .bold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.42))
+                Text(value.nearestResetCreditExpiry.map(formatAccountDate) ?? L("No expiry reported", "未返回到期时间"))
+                    .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.75))
+            }
+
+            Spacer()
+        }
+        .padding(9)
+        .background(cardBackground)
+    }
+
+    private func accountFactsCard(_ value: AccountSnapshot) -> some View {
+        VStack(spacing: 5) {
+            factRow(L("Credits", "Credits"), creditsDisplay(value))
+            factRow(L("Rate limit state", "限额状态"), value.rateLimitReachedType ?? L("Available", "可用"))
+            factRow(L("Spend control", "消费控制"), value.spendControlReached == true ? L("Reached", "已触发") : L("Normal / not reported", "正常 / 未返回"))
+            factRow(L("Last refreshed", "最后刷新"), formatAccountDate(value.fetchedAt))
+        }
+        .padding(9)
+        .background(cardBackground)
+    }
+
+    private func factRow(_ title: String, _ value: String) -> some View {
+        HStack {
+            Text(title)
+                .font(.system(size: 8.5, weight: .medium))
+                .foregroundColor(.white.opacity(0.45))
+            Spacer()
+            Text(value)
+                .font(.system(size: 8.5, weight: .semibold, design: .rounded))
+                .foregroundColor(.white.opacity(0.78))
+                .lineLimit(1)
+        }
+    }
+
+    private var cardBackground: some View {
+        RoundedRectangle(cornerRadius: 10)
+            .fill(Color.white.opacity(0.04))
+            .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.white.opacity(0.08), lineWidth: 0.8))
+    }
+
+    private func refresh() {
+        guard !isLoading else { return }
+        isLoading = true
+        errorMessage = nil
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                let value = try AccountSnapshotService.load()
+                DispatchQueue.main.async {
+                    snapshot = value
+                    isLoading = false
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    errorMessage = error.localizedDescription
+                    isLoading = false
+                }
+            }
+        }
+    }
+
+    private func planDisplayName(_ raw: String?) -> String {
+        switch raw?.lowercased() {
+        case "free": return "Free"
+        case "go": return "Go"
+        case "plus": return "Plus"
+        case "pro": return "Pro"
+        case "prolite": return "Pro Lite"
+        case "team": return "Team"
+        case "business", "self_serve_business_prolite", "self_serve_business_usage_based": return "Business"
+        case "enterprise", "enterprise_cbp_automation", "enterprise_cbp_usage_based", "ent26": return "Enterprise"
+        case "edu": return "Edu"
+        case "edu_plus": return "Edu Plus"
+        case "edu_pro": return "Edu Pro"
+        case "unknown": return L("Unknown", "未知")
+        case .some(let value): return value.replacingOccurrences(of: "_", with: " ").capitalized
+        case .none: return L("Not reported", "未返回")
+        }
+    }
+
+    private func accountTypeDisplayName(_ raw: String?) -> String {
+        switch raw {
+        case "chatgpt": return "ChatGPT"
+        case "apiKey": return "API Key"
+        case "amazonBedrock": return "Bedrock"
+        default: return raw ?? L("Account", "账户")
+        }
+    }
+
+    private func creditsDisplay(_ value: AccountSnapshot) -> String {
+        if value.unlimitedCredits == true { return L("Unlimited", "无限") }
+        if let balance = value.creditsBalance { return balance }
+        if value.hasCredits == false { return L("No credit balance", "无 Credits 余额") }
+        return L("Not reported", "未返回")
+    }
+}
+
+public func formatAccountDate(_ date: Date) -> String {
+    let formatter = DateFormatter()
+    formatter.locale = Locale.current
+    formatter.timeZone = TimeZone.current
+    let currentYear = Calendar.current.component(.year, from: Date())
+    let targetYear = Calendar.current.component(.year, from: date)
+    formatter.dateFormat = currentYear == targetYear ? "MM-dd HH:mm" : "yyyy-MM-dd HH:mm"
+    return formatter.string(from: date)
+}

--- a/apps/macos-overlay/Sources/Views/AccountView.swift
+++ b/apps/macos-overlay/Sources/Views/AccountView.swift
@@ -1,324 +1,6 @@
 import SwiftUI
 import Foundation
 
-// MARK: - Deterministic account snapshot from Codex app-server
-
-public struct AccountQuotaWindow: Identifiable {
-    public let id: String
-    public let durationMinutes: Int?
-    public let usedPercent: Double?
-    public let resetsAt: Date?
-
-    public var remainingPercent: Double? {
-        guard let usedPercent else { return nil }
-        return max(0, min(100, 100 - usedPercent))
-    }
-
-    public var displayName: String {
-        guard let mins = durationMinutes else { return L("Usage window", "额度窗口") }
-        switch mins {
-        case 300:
-            return L("5 hour limit", "5 小时额度")
-        case 10080:
-            return L("Weekly limit", "每周额度")
-        default:
-            if mins < 60 { return "\(mins)m" }
-            if mins < 1440 { return "\(mins / 60)h" }
-            return "\(mins / 1440)d"
-        }
-    }
-
-    public var compactName: String {
-        guard let mins = durationMinutes else { return "—" }
-        if mins == 300 { return "5h" }
-        if mins == 10080 { return L("Weekly", "每周") }
-        if mins < 60 { return "\(mins)m" }
-        if mins < 1440 { return "\(mins / 60)h" }
-        return "\(mins / 1440)d"
-    }
-}
-
-public struct AccountResetCredit: Identifiable {
-    public let id: String
-    public let status: String?
-    public let expiresAt: Date?
-    public let title: String?
-}
-
-public struct AccountSnapshot {
-    public let accountType: String?
-    public let email: String?
-    public let planType: String?
-    public let requiresOpenAIAuth: Bool?
-    public let quotaWindows: [AccountQuotaWindow]
-    /// Backend `rateLimitResetCredits.availableCount`: available reset credits,
-    /// not a historical count of resets already consumed.
-    public let resetCreditCount: Int?
-    public let resetCredits: [AccountResetCredit]
-    public let hasCredits: Bool?
-    public let unlimitedCredits: Bool?
-    public let creditsBalance: String?
-    public let spendControlReached: Bool?
-    public let rateLimitReachedType: String?
-    public let fetchedAt: Date
-
-    public var fiveHourWindow: AccountQuotaWindow? {
-        quotaWindows.first { $0.durationMinutes == 300 }
-    }
-
-    public var weeklyWindow: AccountQuotaWindow? {
-        quotaWindows.first { $0.durationMinutes == 10080 }
-    }
-
-    public var orderedWindows: [AccountQuotaWindow] {
-        var result: [AccountQuotaWindow] = []
-        if let fiveHourWindow { result.append(fiveHourWindow) }
-        if let weeklyWindow { result.append(weeklyWindow) }
-        let knownIds = Set(result.map(\.id))
-        result.append(contentsOf: quotaWindows.filter { !knownIds.contains($0.id) }.sorted {
-            ($0.durationMinutes ?? Int.max) < ($1.durationMinutes ?? Int.max)
-        })
-        return result
-    }
-
-    public var nearestResetCreditExpiry: Date? {
-        resetCredits.compactMap(\.expiresAt).filter { $0 > Date() }.min()
-    }
-}
-
-private final class AppServerRPC {
-    private struct Pending {
-        let semaphore: DispatchSemaphore
-        var result: [String: Any]?
-    }
-
-    private let process = Process()
-    private let input = Pipe()
-    private let output = Pipe()
-    private let lock = NSLock()
-    private var nextId = 1
-    private var pending: [Int: Pending] = [:]
-    private var buffer = Data()
-    private var started = false
-
-    init() throws {
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        process.arguments = ["codex", "app-server"]
-        process.standardInput = input
-        process.standardOutput = output
-        process.standardError = FileHandle.nullDevice
-
-        output.fileHandleForReading.readabilityHandler = { [weak self] handle in
-            let data = handle.availableData
-            guard !data.isEmpty else { return }
-            self?.receive(data)
-        }
-
-        try process.run()
-        started = true
-    }
-
-    deinit {
-        close()
-    }
-
-    func initialize() -> Bool {
-        let response = request(
-            method: "initialize",
-            params: [
-                "clientInfo": [
-                    "name": "codex-flow",
-                    "title": "FlowPilot Account",
-                    "version": "1"
-                ],
-                "capabilities": ["experimentalApi": true]
-            ],
-            timeout: 4.0
-        )
-        guard response != nil else { return false }
-        notify(method: "initialized", params: nil)
-        return true
-    }
-
-    func request(method: String, params: [String: Any]?, timeout: TimeInterval = 4.0) -> [String: Any]? {
-        lock.lock()
-        let id = nextId
-        nextId += 1
-        let semaphore = DispatchSemaphore(value: 0)
-        pending[id] = Pending(semaphore: semaphore, result: nil)
-        lock.unlock()
-
-        var payload: [String: Any] = ["id": id, "method": method]
-        if let params { payload["params"] = params }
-        guard send(payload) else {
-            lock.lock()
-            pending.removeValue(forKey: id)
-            lock.unlock()
-            return nil
-        }
-
-        guard semaphore.wait(timeout: .now() + timeout) == .success else {
-            lock.lock()
-            pending.removeValue(forKey: id)
-            lock.unlock()
-            return nil
-        }
-
-        lock.lock()
-        let result = pending.removeValue(forKey: id)?.result
-        lock.unlock()
-        return result
-    }
-
-    func notify(method: String, params: [String: Any]?) {
-        var payload: [String: Any] = ["method": method]
-        if let params { payload["params"] = params }
-        _ = send(payload)
-    }
-
-    func close() {
-        guard started else { return }
-        started = false
-        output.fileHandleForReading.readabilityHandler = nil
-        if process.isRunning {
-            process.terminate()
-        }
-    }
-
-    private func send(_ object: [String: Any]) -> Bool {
-        guard JSONSerialization.isValidJSONObject(object),
-              var data = try? JSONSerialization.data(withJSONObject: object) else { return false }
-        data.append(0x0A)
-        do {
-            try input.fileHandleForWriting.write(contentsOf: data)
-            return true
-        } catch {
-            return false
-        }
-    }
-
-    private func receive(_ data: Data) {
-        lock.lock()
-        buffer.append(data)
-        let newline = Data([0x0A])
-        var lines: [Data] = []
-        while let range = buffer.range(of: newline) {
-            lines.append(buffer.subdata(in: buffer.startIndex..<range.lowerBound))
-            buffer.removeSubrange(buffer.startIndex...range.lowerBound)
-        }
-        lock.unlock()
-
-        for line in lines where !line.isEmpty {
-            guard let object = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
-                  let idNumber = object["id"] as? NSNumber else { continue }
-            let id = idNumber.intValue
-            let result = object["result"] as? [String: Any]
-
-            lock.lock()
-            if var item = pending[id] {
-                item.result = result
-                pending[id] = item
-                item.semaphore.signal()
-            }
-            lock.unlock()
-        }
-    }
-}
-
-public enum AccountSnapshotService {
-    public static func load() throws -> AccountSnapshot {
-        let rpc = try AppServerRPC()
-        defer { rpc.close() }
-
-        guard rpc.initialize() else {
-            throw NSError(domain: "FlowPilot.Account", code: 1, userInfo: [
-                NSLocalizedDescriptionKey: L("Codex app-server did not respond.", "Codex app-server 未响应。")
-            ])
-        }
-
-        let accountResponse = rpc.request(method: "account/read", params: ["refreshToken": false])
-        let limitsResponse = rpc.request(method: "account/rateLimits/read", params: nil)
-
-        guard accountResponse != nil || limitsResponse != nil else {
-            throw NSError(domain: "FlowPilot.Account", code: 2, userInfo: [
-                NSLocalizedDescriptionKey: L("Account data is unavailable from Codex.", "Codex 暂未返回账户数据。")
-            ])
-        }
-
-        let account = accountResponse?["account"] as? [String: Any]
-        let requiresAuth = (accountResponse?["requiresOpenaiAuth"] as? NSNumber)?.boolValue
-
-        let fallbackSnapshot = limitsResponse?["rateLimits"] as? [String: Any]
-        let byId = limitsResponse?["rateLimitsByLimitId"] as? [String: Any]
-        let codexSnapshot = (byId?["codex"] as? [String: Any]) ?? fallbackSnapshot ?? [:]
-
-        var windows: [AccountQuotaWindow] = []
-        for slot in ["primary", "secondary"] {
-            guard let raw = codexSnapshot[slot] as? [String: Any] else { continue }
-            let duration = intValue(raw["windowDurationMins"] ?? raw["windowMinutes"])
-            let used = doubleValue(raw["usedPercent"])
-            let reset = dateValue(raw["resetsAt"])
-            windows.append(AccountQuotaWindow(
-                id: "\(slot)-\(duration ?? 0)",
-                durationMinutes: duration,
-                usedPercent: used,
-                resetsAt: reset
-            ))
-        }
-
-        let resetSummary = limitsResponse?["rateLimitResetCredits"] as? [String: Any]
-        let resetCount = intValue(resetSummary?["availableCount"])
-        let rawCredits = resetSummary?["credits"] as? [[String: Any]] ?? []
-        let resetCredits = rawCredits.compactMap { raw -> AccountResetCredit? in
-            guard let id = raw["id"] as? String else { return nil }
-            return AccountResetCredit(
-                id: id,
-                status: raw["status"] as? String,
-                expiresAt: dateValue(raw["expiresAt"]),
-                title: raw["title"] as? String
-            )
-        }
-
-        let credits = codexSnapshot["credits"] as? [String: Any]
-        let plan = (account?["planType"] as? String) ?? (codexSnapshot["planType"] as? String)
-
-        return AccountSnapshot(
-            accountType: account?["type"] as? String,
-            email: account?["email"] as? String,
-            planType: plan,
-            requiresOpenAIAuth: requiresAuth,
-            quotaWindows: windows,
-            resetCreditCount: resetCount,
-            resetCredits: resetCredits,
-            hasCredits: (credits?["hasCredits"] as? NSNumber)?.boolValue,
-            unlimitedCredits: (credits?["unlimited"] as? NSNumber)?.boolValue,
-            creditsBalance: credits?["balance"] as? String,
-            spendControlReached: (codexSnapshot["spendControlReached"] as? NSNumber)?.boolValue,
-            rateLimitReachedType: codexSnapshot["rateLimitReachedType"] as? String,
-            fetchedAt: Date()
-        )
-    }
-
-    private static func intValue(_ value: Any?) -> Int? {
-        if let number = value as? NSNumber { return number.intValue }
-        if let value = value as? String { return Int(value) }
-        return nil
-    }
-
-    private static func doubleValue(_ value: Any?) -> Double? {
-        if let number = value as? NSNumber { return number.doubleValue }
-        if let value = value as? String { return Double(value) }
-        return nil
-    }
-
-    private static func dateValue(_ value: Any?) -> Date? {
-        guard let raw = doubleValue(value), raw > 0 else { return nil }
-        return Date(timeIntervalSince1970: raw > 1_000_000_000_000 ? raw / 1000.0 : raw)
-    }
-}
-
-// MARK: - Account UI
-
 public struct AccountView: View {
     @ObservedObject var state: OverlayState
     @ObservedObject private var localization = AppLocalization.shared
@@ -336,6 +18,7 @@ public struct AccountView: View {
     public var body: some View {
         let content = VStack(spacing: 9) {
             accountHeader
+            StrategyModeCard()
 
             if isLoading && snapshot == nil {
                 loadingState
@@ -360,9 +43,7 @@ public struct AccountView: View {
                 .frame(maxHeight: 390)
             }
         }
-        .onAppear {
-            refresh()
-        }
+        .onAppear(perform: refresh)
     }
 
     private var accountHeader: some View {
@@ -374,7 +55,7 @@ public struct AccountView: View {
                 Text(L("Account & Limits", "账户与额度"))
                     .font(.system(size: 12, weight: .bold, design: .rounded))
                     .foregroundColor(.white)
-                Text(L("Live data from Codex app-server", "数据直接来自 Codex app-server"))
+                Text(L("Account data from Codex · strategy from FlowPilot policy", "账户数据来自 Codex · 策略来自 FlowPilot 配置"))
                     .font(.system(size: 8.5, weight: .regular))
                     .foregroundColor(.white.opacity(0.45))
             }
@@ -395,13 +76,12 @@ public struct AccountView: View {
 
     private var loadingState: some View {
         VStack(spacing: 8) {
-            ProgressView()
-                .controlSize(.small)
+            ProgressView().controlSize(.small)
             Text(L("Reading account status…", "正在读取账户状态…"))
                 .font(.system(size: 10))
                 .foregroundColor(.white.opacity(0.55))
         }
-        .frame(maxWidth: .infinity, minHeight: 180)
+        .frame(maxWidth: .infinity, minHeight: 120)
     }
 
     private var unavailableState: some View {
@@ -419,7 +99,7 @@ public struct AccountView: View {
                 .multilineTextAlignment(.center)
         }
         .padding(14)
-        .frame(maxWidth: .infinity, minHeight: 180)
+        .frame(maxWidth: .infinity, minHeight: 120)
         .background(cardBackground)
     }
 
@@ -447,7 +127,7 @@ public struct AccountView: View {
                 if let email = value.email, !email.isEmpty {
                     HoverRevealText(
                         email,
-                        font: .system(size: 8.5, weight: .regular),
+                        font: .system(size: 8.5),
                         foregroundColor: .white.opacity(0.48),
                         lineLimit: 1,
                         privacyBlur: state.isPrivacyMode,
@@ -500,28 +180,23 @@ public struct AccountView: View {
                     .font(.system(size: 9, weight: .heavy, design: .monospaced))
                     .foregroundColor(accent)
                     .frame(width: 48, alignment: .leading)
-
                 Text(window.displayName)
                     .font(.system(size: 8.5, weight: .semibold))
                     .foregroundColor(.white.opacity(0.72))
-
                 Spacer()
-
                 if let remaining {
                     Text(String(format: L("%.0f%% left", "剩余 %.0f%%"), remaining))
                         .font(.system(size: 9, weight: .bold, design: .rounded))
                         .foregroundColor(accent)
                 } else {
-                    Text("—")
-                        .foregroundColor(.white.opacity(0.35))
+                    Text("—").foregroundColor(.white.opacity(0.35))
                 }
             }
 
             GeometryReader { proxy in
                 ZStack(alignment: .leading) {
                     Capsule().fill(Color.white.opacity(0.08))
-                    Capsule()
-                        .fill(accent)
+                    Capsule().fill(accent)
                         .frame(width: proxy.size.width * CGFloat(used / 100.0))
                 }
             }
@@ -549,7 +224,7 @@ public struct AccountView: View {
                     .foregroundColor(.white.opacity(0.42))
                 Text(value.resetCreditCount.map(String.init) ?? "—")
                     .font(.system(size: 15, weight: .heavy, design: .rounded))
-                    .foregroundColor(value.resetCreditCount ?? 0 > 0 ? .cyan : .white.opacity(0.8))
+                    .foregroundColor((value.resetCreditCount ?? 0) > 0 ? .cyan : .white.opacity(0.8))
             }
 
             Divider().frame(height: 30).overlay(Color.white.opacity(0.08))
@@ -562,7 +237,6 @@ public struct AccountView: View {
                     .font(.system(size: 9, weight: .semibold, design: .monospaced))
                     .foregroundColor(.white.opacity(0.75))
             }
-
             Spacer()
         }
         .padding(9)
@@ -573,7 +247,7 @@ public struct AccountView: View {
         VStack(spacing: 5) {
             factRow(L("Credits", "Credits"), creditsDisplay(value))
             factRow(L("Rate limit state", "限额状态"), rateLimitStateDisplay(value))
-            factRow(L("Spend control", "消费控制"), spendControlDisplay(value.spendControlReached))
+            factRow(L("Spend control", "消费控制"), booleanStatus(value.spendControlReached, trueText: L("Reached", "已触发"), falseText: L("Normal", "正常")))
             factRow(L("OpenAI auth", "OpenAI 认证"), booleanStatus(value.requiresOpenAIAuth, trueText: L("Required", "需要"), falseText: L("Not required", "不需要")))
             factRow(L("Last refreshed", "最后刷新"), formatAccountDate(value.fetchedAt))
         }
@@ -666,22 +340,8 @@ public struct AccountView: View {
         return state.replacingOccurrences(of: "_", with: " ")
     }
 
-    private func spendControlDisplay(_ value: Bool?) -> String {
-        booleanStatus(value, trueText: L("Reached", "已触发"), falseText: L("Normal", "正常"))
-    }
-
     private func booleanStatus(_ value: Bool?, trueText: String, falseText: String) -> String {
         guard let value else { return L("Not reported", "未返回") }
         return value ? trueText : falseText
     }
-}
-
-public func formatAccountDate(_ date: Date) -> String {
-    let formatter = DateFormatter()
-    formatter.locale = Locale.current
-    formatter.timeZone = TimeZone.current
-    let currentYear = Calendar.current.component(.year, from: Date())
-    let targetYear = Calendar.current.component(.year, from: date)
-    formatter.dateFormat = currentYear == targetYear ? "MM-dd HH:mm" : "yyyy-MM-dd HH:mm"
-    return formatter.string(from: date)
 }

--- a/apps/macos-overlay/Sources/Views/AccountView.swift
+++ b/apps/macos-overlay/Sources/Views/AccountView.swift
@@ -31,7 +31,7 @@ public struct AccountQuotaWindow: Identifiable {
     public var compactName: String {
         guard let mins = durationMinutes else { return "—" }
         if mins == 300 { return "5h" }
-        if mins == 10080 { return L("Weekly", "Weekly") }
+        if mins == 10080 { return L("Weekly", "每周") }
         if mins < 60 { return "\(mins)m" }
         if mins < 1440 { return "\(mins / 60)h" }
         return "\(mins / 1440)d"
@@ -51,6 +51,8 @@ public struct AccountSnapshot {
     public let planType: String?
     public let requiresOpenAIAuth: Bool?
     public let quotaWindows: [AccountQuotaWindow]
+    /// Backend `rateLimitResetCredits.availableCount`: available reset credits,
+    /// not a historical count of resets already consumed.
     public let resetCreditCount: Int?
     public let resetCredits: [AccountResetCredit]
     public let hasCredits: Bool?
@@ -358,7 +360,9 @@ public struct AccountView: View {
                 .frame(maxHeight: 390)
             }
         }
-        .onAppear(perform: refresh)
+        .onAppear {
+            refresh()
+        }
     }
 
     private var accountHeader: some View {
@@ -540,7 +544,7 @@ public struct AccountView: View {
     private func resetCard(_ value: AccountSnapshot) -> some View {
         HStack(spacing: 8) {
             VStack(alignment: .leading, spacing: 3) {
-                Text(L("USAGE RESETS", "额度重置次数"))
+                Text(L("RESET CREDITS AVAILABLE", "可用重置次数"))
                     .font(.system(size: 8, weight: .bold, design: .rounded))
                     .foregroundColor(.white.opacity(0.42))
                 Text(value.resetCreditCount.map(String.init) ?? "—")
@@ -551,7 +555,7 @@ public struct AccountView: View {
             Divider().frame(height: 30).overlay(Color.white.opacity(0.08))
 
             VStack(alignment: .leading, spacing: 3) {
-                Text(L("RESET CREDIT EXPIRY", "重置额度到期"))
+                Text(L("NEXT CREDIT EXPIRY", "重置次数到期"))
                     .font(.system(size: 8, weight: .bold, design: .rounded))
                     .foregroundColor(.white.opacity(0.42))
                 Text(value.nearestResetCreditExpiry.map(formatAccountDate) ?? L("No expiry reported", "未返回到期时间"))
@@ -568,8 +572,9 @@ public struct AccountView: View {
     private func accountFactsCard(_ value: AccountSnapshot) -> some View {
         VStack(spacing: 5) {
             factRow(L("Credits", "Credits"), creditsDisplay(value))
-            factRow(L("Rate limit state", "限额状态"), value.rateLimitReachedType ?? L("Available", "可用"))
-            factRow(L("Spend control", "消费控制"), value.spendControlReached == true ? L("Reached", "已触发") : L("Normal / not reported", "正常 / 未返回"))
+            factRow(L("Rate limit state", "限额状态"), rateLimitStateDisplay(value))
+            factRow(L("Spend control", "消费控制"), spendControlDisplay(value.spendControlReached))
+            factRow(L("OpenAI auth", "OpenAI 认证"), booleanStatus(value.requiresOpenAIAuth, trueText: L("Required", "需要"), falseText: L("Not required", "不需要")))
             factRow(L("Last refreshed", "最后刷新"), formatAccountDate(value.fetchedAt))
         }
         .padding(9)
@@ -582,10 +587,14 @@ public struct AccountView: View {
                 .font(.system(size: 8.5, weight: .medium))
                 .foregroundColor(.white.opacity(0.45))
             Spacer()
-            Text(value)
-                .font(.system(size: 8.5, weight: .semibold, design: .rounded))
-                .foregroundColor(.white.opacity(0.78))
-                .lineLimit(1)
+            HoverRevealText(
+                value,
+                font: .system(size: 8.5, weight: .semibold, design: .rounded),
+                foregroundColor: .white.opacity(0.78),
+                lineLimit: 1,
+                popoverWidth: 300
+            )
+            .frame(maxWidth: 190, alignment: .trailing)
         }
     }
 
@@ -648,6 +657,22 @@ public struct AccountView: View {
         if let balance = value.creditsBalance { return balance }
         if value.hasCredits == false { return L("No credit balance", "无 Credits 余额") }
         return L("Not reported", "未返回")
+    }
+
+    private func rateLimitStateDisplay(_ value: AccountSnapshot) -> String {
+        guard let state = value.rateLimitReachedType, !state.isEmpty else {
+            return L("Not reported", "未返回")
+        }
+        return state.replacingOccurrences(of: "_", with: " ")
+    }
+
+    private func spendControlDisplay(_ value: Bool?) -> String {
+        booleanStatus(value, trueText: L("Reached", "已触发"), falseText: L("Normal", "正常"))
+    }
+
+    private func booleanStatus(_ value: Bool?, trueText: String, falseText: String) -> String {
+        guard let value else { return L("Not reported", "未返回") }
+        return value ? trueText : falseText
     }
 }
 

--- a/apps/macos-overlay/Sources/Views/AccountView.swift
+++ b/apps/macos-overlay/Sources/Views/AccountView.swift
@@ -172,6 +172,7 @@ public struct AccountView: View {
     private func quotaRow(_ window: AccountQuotaWindow) -> some View {
         let used = max(0, min(100, window.usedPercent ?? 0))
         let remaining = window.remainingPercent
+        let remainingFraction = max(0, min(1, (remaining ?? 0) / 100.0))
         let accent: Color = used >= 85 ? .orange : (used >= 60 ? .yellow : .cyan)
 
         return VStack(alignment: .leading, spacing: 4) {
@@ -197,7 +198,7 @@ public struct AccountView: View {
                 ZStack(alignment: .leading) {
                     Capsule().fill(Color.white.opacity(0.08))
                     Capsule().fill(accent)
-                        .frame(width: proxy.size.width * CGFloat(used / 100.0))
+                        .frame(width: proxy.size.width * CGFloat(remainingFraction))
                 }
             }
             .frame(height: 4)
@@ -337,7 +338,20 @@ public struct AccountView: View {
         guard let state = value.rateLimitReachedType, !state.isEmpty else {
             return L("Not reported", "未返回")
         }
-        return state.replacingOccurrences(of: "_", with: " ")
+        switch state.lowercased() {
+        case "rate_limit_reached":
+            return L("Rate limit reached", "已达到额度上限")
+        case "workspace_owner_credits_depleted":
+            return L("Workspace credits depleted", "工作区 Credits 已用尽")
+        case "workspace_member_credits_depleted":
+            return L("Member credits depleted", "成员 Credits 已用尽")
+        case "workspace_owner_usage_limit_reached":
+            return L("Workspace usage limit reached", "工作区用量上限已达到")
+        case "workspace_member_usage_limit_reached":
+            return L("Member usage limit reached", "成员用量上限已达到")
+        default:
+            return state.replacingOccurrences(of: "_", with: " ")
+        }
     }
 
     private func booleanStatus(_ value: Bool?, trueText: String, falseText: String) -> String {

--- a/apps/macos-overlay/Sources/Views/AnalyticsView.swift
+++ b/apps/macos-overlay/Sources/Views/AnalyticsView.swift
@@ -4,43 +4,41 @@ public struct AnalyticsView: View {
     @ObservedObject var state: OverlayState
     @ObservedObject private var localization = AppLocalization.shared
     public var isFullHeight: Bool = false
-    
+
+    @State private var trendRuns: [TaskRun] = []
+    @State private var trendLoading = false
+
     public init(state: OverlayState, isFullHeight: Bool = false) {
         self.state = state
         self.isFullHeight = isFullHeight
     }
-    
+
     private var stats: TelemetryStats {
-        return state.statsData ?? TelemetryStats()
+        state.statsData ?? TelemetryStats()
     }
-    
+
     public var body: some View {
         let content = VStack(spacing: 9) {
-            // MARK: 1. Header & Period Selector
             periodHeader
-            
+
             if stats.totalRuns == 0 {
                 emptyStatsState
             } else {
-                // MARK: 2. Core KPIs Row
                 kpiSummaryGrid
-                
-                // MARK: 3. Efficiency Rings / Bars (Cache & Offload)
+                usageTrendCard
                 efficiencyCard
-                
-                // MARK: 4. Model Breakdown List
+
                 if !stats.models.isEmpty {
                     modelBreakdownCard
                 }
-                
-                // MARK: 5. Project Breakdown List
+
                 if !stats.projects.isEmpty {
                     projectBreakdownCard
                 }
             }
         }
-        .padding(.vertical, 2)
-        
+        .padding(.vertical, 7)
+
         return Group {
             if isFullHeight {
                 content
@@ -48,23 +46,36 @@ public struct AnalyticsView: View {
                 ScrollView(.vertical, showsIndicators: true) {
                     content
                 }
-                .frame(maxHeight: 345)
+                .frame(maxHeight: 405)
             }
         }
         .onAppear {
             state.loadStats()
+            loadTrendRuns()
+        }
+        .onChange(of: state.statsDays) { _ in
+            loadTrendRuns()
+        }
+        .onChange(of: state.selectedProject) { _ in
+            loadTrendRuns()
         }
     }
-    
-    // MARK: - Period Header
+
+    // MARK: - Period
+
     private var periodHeader: some View {
         HStack {
-            Text(L("Aggregation Summary", "聚合统计"))
-                .font(.system(size: 10.5, weight: .bold, design: .rounded))
-                .foregroundColor(.white.opacity(0.85))
-            
+            VStack(alignment: .leading, spacing: 1) {
+                Text(L("Aggregation Summary", "聚合统计"))
+                    .font(.system(size: 10.5, weight: .bold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.86))
+                Text(L("Deterministic telemetry only", "仅展示确定性遥测数据"))
+                    .font(.system(size: 7.5))
+                    .foregroundColor(.white.opacity(0.36))
+            }
+
             Spacer()
-            
+
             HStack(spacing: 2) {
                 dayButton(days: 7, title: L("7 Days", "7 天"))
                 dayButton(days: 30, title: L("30 Days", "30 天"))
@@ -73,344 +84,480 @@ public struct AnalyticsView: View {
             .background(Capsule().fill(Color.white.opacity(0.06)))
         }
     }
-    
+
     private func dayButton(days: Int, title: String) -> some View {
         Button {
-            withAnimation(.easeInOut(duration: 0.15)) {
+            withAnimation(.easeInOut(duration: 0.14)) {
                 state.statsDays = days
                 state.loadStats()
             }
         } label: {
             Text(title)
-                .font(.system(size: 9, weight: state.statsDays == days ? .bold : .medium, design: .rounded))
-                .foregroundColor(state.statsDays == days ? .white : .white.opacity(0.55))
+                .font(.system(size: 8.4, weight: state.statsDays == days ? .bold : .medium, design: .rounded))
+                .foregroundColor(state.statsDays == days ? .white : .white.opacity(0.48))
                 .padding(.horizontal, 7)
                 .padding(.vertical, 3)
-                .contentShape(Capsule())
-                .background(
-                    Capsule()
-                        .fill(state.statsDays == days ? Color.cyan.opacity(0.3) : Color.white.opacity(0.001))
-                )
+                .background(Capsule().fill(state.statsDays == days ? Color.cyan.opacity(0.28) : Color.clear))
         }
         .buttonStyle(.plain)
     }
-    
-    // MARK: - Empty Stats State
+
+    // MARK: - Empty
+
     private var emptyStatsState: some View {
         VStack(spacing: 8) {
-            Image(systemName: "chart.bar.xaxis")
+            Image(systemName: "chart.xyaxis.line")
                 .font(.system(size: 24))
-                .foregroundColor(.white.opacity(0.3))
+                .foregroundColor(.white.opacity(0.28))
                 .padding(.top, 28)
-            
-            Text("No activity in past \(state.statsDays) days")
-                .font(.system(size: 11.5, weight: .medium))
-                .foregroundColor(.white.opacity(0.75))
-            
-            Text("Multi-model usage, cache efficiencies, and worker offload metrics will appear here automatically.")
-                .font(.system(size: 10))
+            Text(L("No activity in this period", "当前周期暂无活动"))
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(.white.opacity(0.72))
+            Text(L("Task, token and efficiency trends will appear after telemetry is recorded.", "记录遥测后会显示任务、Token 与效率趋势。"))
+                .font(.system(size: 8.8))
                 .foregroundColor(.white.opacity(0.4))
                 .multilineTextAlignment(.center)
-                .padding(.horizontal, 16)
+                .padding(.horizontal, 15)
         }
-        .frame(maxWidth: .infinity, minHeight: 220)
+        .frame(maxWidth: .infinity, minHeight: 225)
     }
-    
-    // MARK: - Core KPI Summary Grid
+
+    // MARK: - KPIs
+
     private var kpiSummaryGrid: some View {
         HStack(spacing: 6) {
-            kpiCard(
+            analyticsKPI(
                 title: L("Tasks", "任务"),
                 value: "\(stats.totalRuns)",
                 subtext: L("\(stats.delegatedRuns) delegated", "委派 \(stats.delegatedRuns) 次"),
                 icon: "sparkles",
-                accentColor: .cyan
+                accent: .cyan
             )
-            
-            kpiCard(
+
+            analyticsKPI(
                 title: L("Active Time", "活跃时长"),
                 value: stats.formattedTotalDuration,
-                subtext: L("\(stats.days)d total", "累计 \(stats.days) 天"),
+                subtext: L("past \(stats.days)d", "近 \(stats.days) 天"),
                 icon: "timer",
-                accentColor: .indigo
+                accent: .indigo
             )
-            
-            kpiCard(
+
+            // No monetary "Cost" here: token counts are deterministic, while
+            // estimated credits are optional and are not equivalent to USD.
+            analyticsKPI(
                 title: L("Tokens", "Token"),
                 value: TaskRun.formatTokenCount(stats.totalTokens),
-                subtext: stats.formattedCost,
+                subtext: L(
+                    "out \(TaskRun.formatTokenCount(stats.outputTokens))",
+                    "输出 \(TaskRun.formatTokenCount(stats.outputTokens))"
+                ),
                 icon: "circle.grid.cross.fill",
-                accentColor: Color(red: 0.95, green: 0.35, blue: 0.8)
+                accent: Color(red: 0.95, green: 0.35, blue: 0.8)
             )
         }
     }
-    
-    private func kpiCard(title: String, value: String, subtext: String, icon: String, accentColor: Color) -> some View {
+
+    private func analyticsKPI(title: String, value: String, subtext: String, icon: String, accent: Color) -> some View {
         VStack(spacing: 2.5) {
             HStack(spacing: 3) {
                 Image(systemName: icon)
-                    .font(.system(size: 8))
-                    .foregroundColor(accentColor)
+                    .font(.system(size: 7.5))
+                    .foregroundColor(accent)
                 Text(title)
-                    .font(.system(size: 8.5, weight: .medium, design: .rounded))
-                    .foregroundColor(.white.opacity(0.5))
+                    .font(.system(size: 7.8, weight: .medium, design: .rounded))
+                    .foregroundColor(.white.opacity(0.46))
                     .textCase(.uppercase)
             }
-            
+
             Text(value)
-                .font(.system(size: 12.5, weight: .bold, design: .rounded))
+                .font(.system(size: 12, weight: .bold, design: .rounded))
                 .foregroundColor(.white)
                 .lineLimit(1)
-            
+
             Text(subtext)
-                .font(.system(size: 8.0, weight: .regular, design: .rounded))
-                .foregroundColor(.white.opacity(0.45))
+                .font(.system(size: 7.3, design: .rounded))
+                .foregroundColor(.white.opacity(0.4))
                 .lineLimit(1)
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 6)
-        .background(
-            RoundedRectangle(cornerRadius: 9)
-                .fill(Color.white.opacity(0.04))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 9)
-                        .stroke(Color.white.opacity(0.07), lineWidth: 0.8)
-                )
-        )
+        .background(analyticsCardBackground)
     }
-    
-    // MARK: - Efficiency & Offload Card
+
+    // MARK: - Trend curve
+
+    private var usageTrendCard: some View {
+        let points = UsageTrendPoint.make(runs: trendRuns, days: state.statsDays)
+        return VStack(alignment: .leading, spacing: 5) {
+            HStack {
+                HStack(spacing: 4) {
+                    Image(systemName: "chart.xyaxis.line")
+                        .font(.system(size: 8))
+                        .foregroundColor(.cyan)
+                    Text(L("Usage Trend", "用量趋势"))
+                        .font(.system(size: 8.8, weight: .bold, design: .rounded))
+                        .foregroundColor(.white.opacity(0.72))
+                }
+                Spacer()
+                if trendLoading {
+                    ProgressView().controlSize(.mini)
+                } else {
+                    Text(L("tokens / day", "Token / 天"))
+                        .font(.system(size: 7.2))
+                        .foregroundColor(.white.opacity(0.34))
+                }
+            }
+
+            UsageTrendChart(points: points)
+                .frame(height: 104)
+        }
+        .padding(8)
+        .background(analyticsCardBackground)
+    }
+
+    // MARK: - Efficiency
+
     private var efficiencyCard: some View {
-        VStack(spacing: 6) {
-            // Cache Ratio Bar
+        VStack(spacing: 7) {
             efficiencyRow(
                 title: L("Cache Efficiency", "缓存效率"),
                 percentage: stats.cacheRatio,
                 detail: L("\(TaskRun.formatTokenCount(stats.cachedInputTokens)) cached", "缓存 \(TaskRun.formatTokenCount(stats.cachedInputTokens))"),
-                color: Color(red: 0.28, green: 0.58, blue: 0.95)
+                accent: Color(red: 0.28, green: 0.58, blue: 0.95)
             )
-            
-            // Worker Offload Bar
+
             efficiencyRow(
                 title: L("Worker Offload", "Worker 分流"),
                 percentage: stats.workerOffloadRatio,
                 detail: "\(TaskRun.formatTokenCount(stats.workerTokens)) / \(TaskRun.formatTokenCount(stats.totalTokens))",
-                color: Color(red: 0.22, green: 0.88, blue: 0.58)
+                accent: Color(red: 0.22, green: 0.88, blue: 0.58)
             )
         }
         .padding(8)
-        .background(
-            RoundedRectangle(cornerRadius: 9)
-                .fill(Color.white.opacity(0.04))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 9)
-                        .stroke(Color.white.opacity(0.07), lineWidth: 0.8)
-                )
-        )
+        .background(analyticsCardBackground)
     }
-    
-    private func efficiencyRow(title: String, percentage: Double, detail: String, color: Color) -> some View {
+
+    private func efficiencyRow(title: String, percentage: Double, detail: String, accent: Color) -> some View {
         VStack(alignment: .leading, spacing: 3) {
             HStack {
                 Text(title)
-                    .font(.system(size: 9.0, weight: .medium))
-                    .foregroundColor(.white.opacity(0.75))
-                
+                    .font(.system(size: 8.4, weight: .medium))
+                    .foregroundColor(.white.opacity(0.7))
                 Spacer()
-                
                 Text(String(format: "%.1f%%", percentage))
-                    .font(.system(size: 9.0, weight: .bold, design: .rounded))
-                    .foregroundColor(color)
-                
+                    .font(.system(size: 8.5, weight: .bold, design: .rounded))
+                    .foregroundColor(accent)
                 Text("(\(detail))")
-                    .font(.system(size: 8.0, weight: .regular, design: .rounded))
-                    .foregroundColor(.white.opacity(0.4))
+                    .font(.system(size: 7.2))
+                    .foregroundColor(.white.opacity(0.35))
             }
-            
-            GeometryReader { geo in
-                let w = geo.size.width
-                let fillW = max(0, min(w, w * CGFloat(percentage / 100.0)))
+
+            GeometryReader { proxy in
                 ZStack(alignment: .leading) {
+                    Capsule().fill(Color.white.opacity(0.075))
                     Capsule()
-                        .fill(Color.white.opacity(0.08))
-                    Capsule()
-                        .fill(color)
-                        .frame(width: fillW)
+                        .fill(accent)
+                        .frame(width: proxy.size.width * CGFloat(max(0, min(1, percentage / 100.0))))
                 }
             }
             .frame(height: 4.5)
         }
     }
-    
-    // MARK: - Model Breakdown Card
+
+    // MARK: - Model & project breakdown
+
     private var modelBreakdownCard: some View {
         VStack(alignment: .leading, spacing: 5) {
             Text(L("Model Breakdown", "模型分布"))
-                .font(.system(size: 9.5, weight: .bold, design: .rounded))
-                .foregroundColor(.white.opacity(0.7))
+                .font(.system(size: 8.6, weight: .bold, design: .rounded))
+                .foregroundColor(.white.opacity(0.62))
                 .textCase(.uppercase)
-            
-            VStack(spacing: 4) {
-                ForEach(stats.models) { m in
-                    ModelBreakdownRow(model: m, totalTokens: stats.totalTokens)
-                }
+
+            ForEach(stats.models) { model in
+                AnalyticsModelRow(model: model, totalTokens: stats.totalTokens)
             }
         }
         .padding(8)
-        .background(
-            RoundedRectangle(cornerRadius: 9)
-                .fill(Color.white.opacity(0.04))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 9)
-                        .stroke(Color.white.opacity(0.07), lineWidth: 0.8)
-                )
-        )
+        .background(analyticsCardBackground)
     }
-    
-    // MARK: - Project Breakdown Card
+
     private var projectBreakdownCard: some View {
         VStack(alignment: .leading, spacing: 5) {
             Text(L("Projects Distribution", "项目分布"))
-                .font(.system(size: 9.5, weight: .bold, design: .rounded))
-                .foregroundColor(.white.opacity(0.7))
+                .font(.system(size: 8.6, weight: .bold, design: .rounded))
+                .foregroundColor(.white.opacity(0.62))
                 .textCase(.uppercase)
-            
-            VStack(spacing: 3.5) {
-                ForEach(Array(stats.projects.prefix(5))) { p in
-                    ProjectBreakdownRow(project: p, isPrivacyMode: state.isPrivacyMode)
-                }
+
+            ForEach(Array(stats.projects.prefix(6))) { project in
+                AnalyticsProjectRow(project: project, isPrivacyMode: state.isPrivacyMode)
             }
         }
         .padding(8)
-        .background(
-            RoundedRectangle(cornerRadius: 9)
-                .fill(Color.white.opacity(0.04))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 9)
-                        .stroke(Color.white.opacity(0.07), lineWidth: 0.8)
-                )
-        )
+        .background(analyticsCardBackground)
+    }
+
+    private var analyticsCardBackground: some View {
+        RoundedRectangle(cornerRadius: 9)
+            .fill(Color.white.opacity(0.035))
+            .overlay(RoundedRectangle(cornerRadius: 9).stroke(Color.white.opacity(0.07), lineWidth: 0.7))
+    }
+
+    private func loadTrendRuns() {
+        guard !trendLoading else { return }
+        trendLoading = true
+        let days = state.statsDays
+        let project = state.selectedProject
+        DispatchQueue.global(qos: .userInitiated).async {
+            let runs = TelemetryQueryEngine.shared.fetchHistory(
+                limit: 1200,
+                project: project,
+                todayOnly: false,
+                search: ""
+            )
+            let cutoff = Date().addingTimeInterval(-Double(days) * 86_400).timeIntervalSince1970 * 1000.0
+            let filtered = runs.filter { ($0.startedAtMs ?? 0) >= cutoff }
+            DispatchQueue.main.async {
+                trendRuns = filtered
+                trendLoading = false
+            }
+        }
     }
 }
 
-// MARK: - Model Breakdown Row
-public struct ModelBreakdownRow: View {
-    @ObservedObject private var localization = AppLocalization.shared
-    public var model: ModelStats
-    public var totalTokens: Int
-    
+// MARK: - Trend chart
+
+public struct UsageTrendPoint: Identifiable {
+    public var id: Date { date }
+    public let date: Date
+    public let tokens: Int
+    public let runs: Int
+
+    public static func make(runs: [TaskRun], days: Int) -> [UsageTrendPoint] {
+        let calendar = Calendar.current
+        let end = calendar.startOfDay(for: Date())
+        let start = calendar.date(byAdding: .day, value: -(max(1, days) - 1), to: end) ?? end
+
+        var buckets: [Date: (tokens: Int, runs: Int)] = [:]
+        for run in runs {
+            guard let ms = run.startedAtMs else { continue }
+            let day = calendar.startOfDay(for: Date(timeIntervalSince1970: ms / 1000.0))
+            guard day >= start && day <= end else { continue }
+            let existing = buckets[day] ?? (0, 0)
+            buckets[day] = (existing.tokens + (run.aggregatedUsage.totalTokens ?? 0), existing.runs + 1)
+        }
+
+        return (0..<max(1, days)).compactMap { offset in
+            guard let day = calendar.date(byAdding: .day, value: offset, to: start) else { return nil }
+            let value = buckets[day] ?? (0, 0)
+            return UsageTrendPoint(date: day, tokens: value.tokens, runs: value.runs)
+        }
+    }
+}
+
+public struct UsageTrendChart: View {
+    public let points: [UsageTrendPoint]
+
+    public init(points: [UsageTrendPoint]) {
+        self.points = points
+    }
+
     public var body: some View {
-        let pct = totalTokens > 0 ? (Double(model.tokens) / Double(totalTokens) * 100.0) : 0
+        let maxTokens = max(1, points.map(\.tokens).max() ?? 0)
+        VStack(spacing: 2) {
+            HStack(spacing: 5) {
+                VStack {
+                    Text(TaskRun.formatTokenCount(maxTokens))
+                        .font(.system(size: 6.7, design: .monospaced))
+                        .foregroundColor(.white.opacity(0.3))
+                    Spacer()
+                    Text("0")
+                        .font(.system(size: 6.7, design: .monospaced))
+                        .foregroundColor(.white.opacity(0.3))
+                }
+                .frame(width: 28)
+
+                GeometryReader { proxy in
+                    ZStack {
+                        VStack(spacing: 0) {
+                            chartGridLine
+                            Spacer()
+                            chartGridLine
+                            Spacer()
+                            chartGridLine
+                        }
+
+                        if points.count > 1 {
+                            trendPath(size: proxy.size, maxTokens: maxTokens)
+                                .stroke(
+                                    LinearGradient(colors: [.cyan, .indigo], startPoint: .leading, endPoint: .trailing),
+                                    style: StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round)
+                                )
+                                .shadow(color: .cyan.opacity(0.3), radius: 3)
+
+                            areaPath(size: proxy.size, maxTokens: maxTokens)
+                                .fill(
+                                    LinearGradient(
+                                        colors: [.cyan.opacity(0.16), .cyan.opacity(0.0)],
+                                        startPoint: .top,
+                                        endPoint: .bottom
+                                    )
+                                )
+                        }
+
+                        ForEach(Array(points.enumerated()), id: \.element.id) { index, point in
+                            if point.tokens > 0 && (points.count <= 8 || index % max(1, points.count / 7) == 0 || index == points.count - 1) {
+                                Circle()
+                                    .fill(Color.cyan)
+                                    .frame(width: 4, height: 4)
+                                    .position(position(index: index, tokens: point.tokens, size: proxy.size, maxTokens: maxTokens))
+                                    .help("\(formatTrendDate(point.date)) · \(TaskRun.formatTokenCount(point.tokens)) tokens · \(point.runs) tasks")
+                            }
+                        }
+                    }
+                }
+            }
+
+            HStack {
+                Text(points.first.map { formatTrendDate($0.date) } ?? "—")
+                Spacer()
+                Text(points.last.map { formatTrendDate($0.date) } ?? "—")
+            }
+            .font(.system(size: 6.8, design: .monospaced))
+            .foregroundColor(.white.opacity(0.3))
+            .padding(.leading, 33)
+        }
+    }
+
+    private var chartGridLine: some View {
+        Rectangle()
+            .fill(Color.white.opacity(0.055))
+            .frame(height: 0.5)
+    }
+
+    private func position(index: Int, tokens: Int, size: CGSize, maxTokens: Int) -> CGPoint {
+        let denominator = max(1, points.count - 1)
+        let x = size.width * CGFloat(index) / CGFloat(denominator)
+        let yRatio = CGFloat(Double(tokens) / Double(maxTokens))
+        let y = size.height - (size.height * yRatio)
+        return CGPoint(x: x, y: max(1, min(size.height - 1, y)))
+    }
+
+    private func trendPath(size: CGSize, maxTokens: Int) -> Path {
+        var path = Path()
+        guard points.count > 1 else { return path }
+        let positions = points.enumerated().map { position(index: $0.offset, tokens: $0.element.tokens, size: size, maxTokens: maxTokens) }
+        path.move(to: positions[0])
+        for index in 1..<positions.count {
+            let previous = positions[index - 1]
+            let current = positions[index]
+            let midpoint = (previous.x + current.x) / 2
+            path.addCurve(
+                to: current,
+                control1: CGPoint(x: midpoint, y: previous.y),
+                control2: CGPoint(x: midpoint, y: current.y)
+            )
+        }
+        return path
+    }
+
+    private func areaPath(size: CGSize, maxTokens: Int) -> Path {
+        var path = trendPath(size: size, maxTokens: maxTokens)
+        guard points.count > 1 else { return path }
+        path.addLine(to: CGPoint(x: size.width, y: size.height))
+        path.addLine(to: CGPoint(x: 0, y: size.height))
+        path.closeSubpath()
+        return path
+    }
+}
+
+private func formatTrendDate(_ date: Date) -> String {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "MM-dd"
+    return formatter.string(from: date)
+}
+
+// MARK: - Breakdown rows
+
+public struct AnalyticsModelRow: View {
+    public let model: ModelStats
+    public let totalTokens: Int
+
+    public var body: some View {
+        let percentage = totalTokens > 0 ? Double(model.tokens) / Double(totalTokens) * 100 : 0
         HStack(spacing: 4) {
-            Text(model.name)
-                .font(.system(size: 9.5, weight: .semibold, design: .monospaced))
-                .foregroundColor(.white.opacity(0.9))
-                .frame(minWidth: 80, alignment: .leading)
-                .lineLimit(1)
-            
-            // Roles chips
+            HoverRevealText(
+                model.name,
+                font: .system(size: 8.8, weight: .semibold, design: .monospaced),
+                foregroundColor: .white.opacity(0.86),
+                lineLimit: 1,
+                popoverWidth: 320
+            )
+            .frame(maxWidth: 115, alignment: .leading)
+
             HStack(spacing: 2) {
                 ForEach(model.roles, id: \.self) { role in
                     Text(localizedRole(role))
-                        .font(.system(size: 7.5, weight: .medium))
-                        .foregroundColor(role == "parent" ? .indigo.opacity(0.9) : .teal.opacity(0.9))
+                        .font(.system(size: 6.8, weight: .medium))
+                        .foregroundColor(role == "parent" ? .indigo : .teal)
                         .padding(.horizontal, 3)
-                        .padding(.vertical, 0.5)
-                        .background(
-                            Capsule()
-                                .fill((role == "parent" ? Color.indigo : Color.teal).opacity(0.2))
-                        )
+                        .padding(.vertical, 1)
+                        .background(Capsule().fill((role == "parent" ? Color.indigo : Color.teal).opacity(0.13)))
                 }
             }
-            
+
             Spacer(minLength: 2)
-            
-            Text(L("\(model.calls) calls", "\(model.calls) 次调用"))
-                .font(.system(size: 8.0, weight: .regular))
-                .foregroundColor(.white.opacity(0.4))
-            
-            // Quota delta badge
-            if let qd = model.quotaDelta, abs(qd) >= 0.1 {
-                HStack(spacing: 1.5) {
-                    Image(systemName: qd > 0 ? "gauge.with.needle.fill" : "arrow.down.circle.fill")
-                        .font(.system(size: 6))
-                    Text(String(format: "%+.0f%%", qd))
-                        .font(.system(size: 7.5, weight: .bold, design: .rounded))
-                }
-                .foregroundColor(qd > 0 ? .orange : Color(red: 0.2, green: 0.85, blue: 0.45))
-                .padding(.horizontal, 3.5)
-                .padding(.vertical, 1)
-                .background(Capsule().fill((qd > 0 ? Color.orange : Color.green).opacity(0.15)))
-            }
-            
+
+            Text(L("\(model.calls) calls", "\(model.calls) 次"))
+                .font(.system(size: 7.2))
+                .foregroundColor(.white.opacity(0.35))
+
             Text(TaskRun.formatTokenCount(model.tokens))
-                .font(.system(size: 9.0, weight: .bold, design: .rounded))
+                .font(.system(size: 8.2, weight: .bold, design: .rounded))
                 .foregroundColor(Color(red: 0.95, green: 0.35, blue: 0.8))
                 .frame(minWidth: 38, alignment: .trailing)
-            
-            Text(String(format: "%.0f%%", pct))
-                .font(.system(size: 8.0, weight: .medium, design: .rounded))
-                .foregroundColor(.white.opacity(0.5))
-                .frame(width: 24, alignment: .trailing)
+
+            Text(String(format: "%.0f%%", percentage))
+                .font(.system(size: 7.2, design: .rounded))
+                .foregroundColor(.white.opacity(0.4))
+                .frame(width: 25, alignment: .trailing)
         }
         .padding(.horizontal, 6)
         .padding(.vertical, 3.5)
-        .background(
-            RoundedRectangle(cornerRadius: 6)
-                .fill(Color.white.opacity(0.025))
-        )
+        .background(RoundedRectangle(cornerRadius: 6).fill(Color.white.opacity(0.022)))
     }
 }
 
-// MARK: - Project Breakdown Row
-public struct ProjectBreakdownRow: View {
-    @ObservedObject private var localization = AppLocalization.shared
-    public var project: ProjectStats
-    public var isPrivacyMode: Bool = false
-    
-    public init(project: ProjectStats, isPrivacyMode: Bool = false) {
-        self.project = project
-        self.isPrivacyMode = isPrivacyMode
-    }
-    
+public struct AnalyticsProjectRow: View {
+    public let project: ProjectStats
+    public let isPrivacyMode: Bool
+
     public var body: some View {
         HStack(spacing: 5) {
             Image(systemName: "folder.fill")
-                .font(.system(size: 7.5))
-                .foregroundColor(.white.opacity(0.5))
-            
-            Text(project.name)
-                .font(.system(size: 9.5, weight: .medium, design: .rounded))
-                .foregroundColor(.white.opacity(0.85))
-                .lineLimit(1)
-                .blur(radius: isPrivacyMode ? 4.5 : 0)
-            
-            Spacer(minLength: 2)
-            
-            Text(L("\(project.runs) runs", "\(project.runs) 次任务"))
-                .font(.system(size: 8.0, weight: .regular))
-                .foregroundColor(.white.opacity(0.4))
-            
-            // Quota delta badge
-            if let qd = project.quotaDelta, abs(qd) >= 0.1 {
-                HStack(spacing: 1.5) {
-                    Image(systemName: qd > 0 ? "gauge.with.needle.fill" : "arrow.down.circle.fill")
-                        .font(.system(size: 6))
-                    Text(String(format: "%+.0f%%", qd))
-                        .font(.system(size: 7.5, weight: .bold, design: .rounded))
-                }
-                .foregroundColor(qd > 0 ? .orange : Color(red: 0.2, green: 0.85, blue: 0.45))
-                .padding(.horizontal, 3.5)
-                .padding(.vertical, 1)
-                .background(Capsule().fill((qd > 0 ? Color.orange : Color.green).opacity(0.15)))
-            }
-            
+                .font(.system(size: 7))
+                .foregroundColor(.white.opacity(0.42))
+
+            HoverRevealText(
+                project.name,
+                font: .system(size: 8.7, weight: .medium, design: .rounded),
+                foregroundColor: .white.opacity(0.8),
+                lineLimit: 1,
+                privacyBlur: isPrivacyMode,
+                popoverWidth: 340
+            )
+
+            Spacer(minLength: 3)
+
+            Text(L("\(project.runs) runs", "\(project.runs) 次"))
+                .font(.system(size: 7.2))
+                .foregroundColor(.white.opacity(0.34))
+
             Text(TaskRun.formatTokenCount(project.tokens))
-                .font(.system(size: 9.0, weight: .bold, design: .rounded))
-                .foregroundColor(.cyan)
+                .font(.system(size: 8, weight: .bold, design: .rounded))
+                .foregroundColor(Color(red: 0.95, green: 0.35, blue: 0.8))
         }
-        .padding(.horizontal, 5)
-        .padding(.vertical, 3)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3.5)
+        .background(RoundedRectangle(cornerRadius: 6).fill(Color.white.opacity(0.022)))
     }
 }
-

--- a/apps/macos-overlay/Sources/Views/AnalyticsView.swift
+++ b/apps/macos-overlay/Sources/Views/AnalyticsView.swift
@@ -7,6 +7,7 @@ public struct AnalyticsView: View {
 
     @State private var trendRuns: [TaskRun] = []
     @State private var trendLoading = false
+    @State private var trendRequestGeneration = 0
 
     public init(state: OverlayState, isFullHeight: Bool = false) {
         self.state = state
@@ -53,10 +54,10 @@ public struct AnalyticsView: View {
             state.loadStats()
             loadTrendRuns()
         }
-        .onChange(of: state.statsDays) { _ in
+        .onChange(of: state.statsDays) { _, _ in
             loadTrendRuns()
         }
-        .onChange(of: state.selectedProject) { _ in
+        .onChange(of: state.selectedProject) { _, _ in
             loadTrendRuns()
         }
     }
@@ -303,7 +304,8 @@ public struct AnalyticsView: View {
     }
 
     private func loadTrendRuns() {
-        guard !trendLoading else { return }
+        trendRequestGeneration += 1
+        let generation = trendRequestGeneration
         trendLoading = true
         let days = state.statsDays
         let project = state.selectedProject
@@ -317,6 +319,7 @@ public struct AnalyticsView: View {
             let cutoff = Date().addingTimeInterval(-Double(days) * 86_400).timeIntervalSince1970 * 1000.0
             let filtered = runs.filter { ($0.startedAtMs ?? 0) >= cutoff }
             DispatchQueue.main.async {
+                guard generation == trendRequestGeneration else { return }
                 trendRuns = filtered
                 trendLoading = false
             }

--- a/apps/macos-overlay/Sources/Views/AutostartView.swift
+++ b/apps/macos-overlay/Sources/Views/AutostartView.swift
@@ -1,0 +1,281 @@
+import SwiftUI
+import Foundation
+import Darwin
+
+public struct FlowPilotAutostartStatus: Equatable {
+    public let enabled: Bool
+    public let plistExists: Bool
+    public let launchdLoaded: Bool
+    public let executablePath: String
+}
+
+public enum FlowPilotAutostartService {
+    public static let label = "com.parsifalc.codex-flow.flowpilot"
+
+    private static var environment: [String: String] { ProcessInfo.processInfo.environment }
+    private static var home: URL { FileManager.default.homeDirectoryForCurrentUser }
+    private static var codexHome: URL {
+        environment["CODEX_HOME"].map(URL.init(fileURLWithPath:))
+            ?? home.appendingPathComponent(".codex")
+    }
+    private static var stateDirectory: URL { codexHome.appendingPathComponent("codex-flow") }
+    private static var preferenceURL: URL { stateDirectory.appendingPathComponent("autostart-preference") }
+    private static var launchAgentsDirectory: URL { home.appendingPathComponent("Library/LaunchAgents") }
+    private static var plistURL: URL { launchAgentsDirectory.appendingPathComponent("\(label).plist") }
+
+    /// Reconcile the registration when FlowPilot starts. The first launch opts in
+    /// by default; an explicit user disable is persisted and never overwritten by
+    /// later app launches or updates.
+    public static func reconcileAtLaunch() {
+        do {
+            if configuredPreference() == false {
+                try removeRegistration()
+            } else {
+                try writePreference(enabled: true)
+                try writeRegistration()
+            }
+        } catch {
+            // Startup must remain non-fatal. The Account card and CLI surface the
+            // registration error when the user explicitly interacts with it.
+        }
+    }
+
+    public static func status() -> FlowPilotAutostartStatus {
+        let configured = configuredPreference() ?? true
+        let exists = FileManager.default.fileExists(atPath: plistURL.path)
+        return FlowPilotAutostartStatus(
+            enabled: configured && exists,
+            plistExists: exists,
+            launchdLoaded: launchdIsLoaded(),
+            executablePath: resolvedExecutable().path
+        )
+    }
+
+    @discardableResult
+    public static func enable() throws -> FlowPilotAutostartStatus {
+        try writePreference(enabled: true)
+        try writeRegistration()
+        return status()
+    }
+
+    @discardableResult
+    public static func disable() throws -> FlowPilotAutostartStatus {
+        try writePreference(enabled: false)
+        // Deliberately do not `bootout` the current job here. If FlowPilot was
+        // launched by launchd, booting it out would kill the app as the user
+        // toggles the setting. Removing the plist is sufficient to prevent the
+        // next login from launching it; uninstall performs a full bootout.
+        try removeRegistration()
+        return status()
+    }
+
+    private static func configuredPreference() -> Bool? {
+        guard let raw = try? String(contentsOf: preferenceURL, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() else { return nil }
+        switch raw {
+        case "enabled", "true", "1", "yes": return true
+        case "disabled", "false", "0", "no": return false
+        default: return nil
+        }
+    }
+
+    private static func writePreference(enabled: Bool) throws {
+        try FileManager.default.createDirectory(at: stateDirectory, withIntermediateDirectories: true)
+        try (enabled ? "enabled\n" : "disabled\n").write(to: preferenceURL, atomically: true, encoding: .utf8)
+    }
+
+    private static func writeRegistration() throws {
+        let executable = resolvedExecutable()
+        guard FileManager.default.isExecutableFile(atPath: executable.path) else {
+            throw serviceError(L(
+                "FlowPilot executable is not available for login launch.",
+                "用于登录启动的 FlowPilot 可执行文件不存在。"
+            ))
+        }
+
+        let logs = stateDirectory.appendingPathComponent("logs")
+        try FileManager.default.createDirectory(at: launchAgentsDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: logs, withIntermediateDirectories: true)
+
+        let path = [
+            home.appendingPathComponent(".local/bin").path,
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "/usr/bin",
+            "/bin",
+            "/usr/sbin",
+            "/sbin"
+        ].joined(separator: ":")
+
+        var launchEnvironment: [String: String] = ["PATH": path]
+        if let configuredCodexHome = environment["CODEX_HOME"], !configuredCodexHome.isEmpty {
+            launchEnvironment["CODEX_HOME"] = configuredCodexHome
+        }
+        if let configuredBinDir = environment["CODEX_FLOW_BIN_DIR"], !configuredBinDir.isEmpty {
+            launchEnvironment["CODEX_FLOW_BIN_DIR"] = configuredBinDir
+        }
+
+        let plist: [String: Any] = [
+            "Label": label,
+            "ProgramArguments": [executable.path, "start"],
+            "RunAtLoad": true,
+            "KeepAlive": false,
+            "ProcessType": "Interactive",
+            "LimitLoadToSessionType": "Aqua",
+            "EnvironmentVariables": launchEnvironment,
+            "StandardOutPath": logs.appendingPathComponent("flowpilot-launchd.out.log").path,
+            "StandardErrorPath": logs.appendingPathComponent("flowpilot-launchd.err.log").path
+        ]
+
+        let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+        try data.write(to: plistURL, options: .atomic)
+        _ = chmod(plistURL.path, mode_t(S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH))
+    }
+
+    private static func removeRegistration() throws {
+        guard FileManager.default.fileExists(atPath: plistURL.path) else { return }
+        try FileManager.default.removeItem(at: plistURL)
+    }
+
+    private static func resolvedExecutable() -> URL {
+        // Prefer the stable installer-managed location so a source checkout can
+        // move without breaking login launch. Dev builds fall back to themselves.
+        let installed = stateDirectory.appendingPathComponent("bin/FlowPilot")
+        if FileManager.default.isExecutableFile(atPath: installed.path) {
+            return installed
+        }
+        if let current = CommandLine.arguments.first, !current.isEmpty {
+            return URL(fileURLWithPath: current).standardizedFileURL
+        }
+        return installed
+    }
+
+    private static func launchdIsLoaded() -> Bool {
+        runLaunchctl(["print", "gui/\(getuid())/\(label)"]) == 0
+    }
+
+    private static func runLaunchctl(_ arguments: [String]) -> Int32 {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        process.arguments = arguments
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus
+        } catch {
+            return -1
+        }
+    }
+
+    private static func serviceError(_ message: String) -> NSError {
+        NSError(domain: "FlowPilot.Autostart", code: 1, userInfo: [NSLocalizedDescriptionKey: message])
+    }
+}
+
+public struct AutostartCard: View {
+    @ObservedObject private var localization = AppLocalization.shared
+    @State private var status = FlowPilotAutostartService.status()
+    @State private var isChanging = false
+    @State private var message: String?
+    @State private var isError = false
+
+    public init() {}
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(spacing: 7) {
+                Image(systemName: "power.circle.fill")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(status.enabled ? .green : .white.opacity(0.38))
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(L("Launch at Login", "登录时启动"))
+                        .font(.system(size: 9.5, weight: .bold, design: .rounded))
+                        .foregroundColor(.white.opacity(0.84))
+                    Text(statusText)
+                        .font(.system(size: 7.6))
+                        .foregroundColor(.white.opacity(0.42))
+                }
+
+                Spacer()
+
+                if isChanging {
+                    ProgressView().controlSize(.mini)
+                }
+
+                Toggle("", isOn: Binding(
+                    get: { status.enabled },
+                    set: { setEnabled($0) }
+                ))
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .controlSize(.mini)
+                .disabled(isChanging)
+            }
+
+            if let message {
+                Text(message)
+                    .font(.system(size: 7.6, weight: .medium))
+                    .foregroundColor(isError ? .orange : .green)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            HStack(spacing: 4) {
+                Image(systemName: "info.circle")
+                    .font(.system(size: 7.2))
+                Text(L(
+                    "Registered as a user LaunchAgent; disabling it does not close the currently running widget.",
+                    "使用用户级 LaunchAgent 注册；关闭开机启动不会退出当前正在运行的悬浮窗。"
+                ))
+                    .font(.system(size: 7.2))
+            }
+            .foregroundColor(.white.opacity(0.3))
+        }
+        .padding(9)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color.white.opacity(0.04))
+                .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.white.opacity(0.08), lineWidth: 0.8))
+        )
+        .onAppear { status = FlowPilotAutostartService.status() }
+    }
+
+    private var statusText: String {
+        guard status.enabled else { return L("Disabled", "已关闭") }
+        if status.launchdLoaded {
+            return L("Enabled · managed by launchd in this login session", "已开启 · 当前登录会话由 launchd 托管")
+        }
+        return L("Enabled · starts automatically on next login", "已开启 · 下次登录自动启动")
+    }
+
+    private func setEnabled(_ enabled: Bool) {
+        guard !isChanging else { return }
+        isChanging = true
+        message = nil
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                let next = try enabled
+                    ? FlowPilotAutostartService.enable()
+                    : FlowPilotAutostartService.disable()
+                DispatchQueue.main.async {
+                    status = next
+                    isChanging = false
+                    isError = false
+                    message = enabled
+                        ? L("FlowPilot will launch automatically when you next log in.", "FlowPilot 将在下次登录时自动启动。")
+                        : L("Login launch disabled; FlowPilot remains running now.", "已关闭登录启动；当前 FlowPilot 继续运行。")
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    status = FlowPilotAutostartService.status()
+                    isChanging = false
+                    isError = true
+                    message = error.localizedDescription
+                }
+            }
+        }
+    }
+}

--- a/apps/macos-overlay/Sources/Views/HistoryView.swift
+++ b/apps/macos-overlay/Sources/Views/HistoryView.swift
@@ -8,6 +8,7 @@ public struct HistoryView: View {
     @State private var availableProjects: [String] = []
     @State private var detailRun: TaskRun?
     @State private var detailHoverGeneration = 0
+    @State private var searchGeneration = 0
 
     public init(state: OverlayState, isFullHeight: Bool = false) {
         self.state = state
@@ -85,11 +86,15 @@ public struct HistoryView: View {
                             Image(systemName: "folder")
                                 .font(.system(size: 8))
                                 .foregroundColor(.cyan.opacity(0.85))
-                            Text(state.selectedProject ?? L("All Projects", "全部项目"))
-                                .font(.system(size: 8.5, weight: .medium))
-                                .foregroundColor(.white.opacity(0.72))
-                                .lineLimit(1)
-                                .blur(radius: state.isPrivacyMode && state.selectedProject != nil ? 4.5 : 0)
+                            HoverRevealText(
+                                state.selectedProject ?? L("All Projects", "全部项目"),
+                                font: .system(size: 8.5, weight: .medium),
+                                foregroundColor: .white.opacity(0.72),
+                                lineLimit: 1,
+                                privacyBlur: state.isPrivacyMode && state.selectedProject != nil,
+                                popoverWidth: 320
+                            )
+                            .frame(maxWidth: 118, alignment: .leading)
                             Image(systemName: "chevron.down")
                                 .font(.system(size: 6.5))
                                 .foregroundColor(.white.opacity(0.4))
@@ -124,14 +129,13 @@ public struct HistoryView: View {
                     .textFieldStyle(.plain)
                     .font(.system(size: 9.2))
                     .foregroundColor(.white)
-                    .onChange(of: state.searchQuery) { _ in
-                        state.loadHistory()
+                    .onChange(of: state.searchQuery) { _, _ in
+                        scheduleSearchReload()
                     }
 
                 if !state.searchQuery.isEmpty {
                     Button {
                         state.searchQuery = ""
-                        state.loadHistory()
                     } label: {
                         Image(systemName: "xmark.circle.fill")
                             .font(.system(size: 8.5))
@@ -219,7 +223,6 @@ public struct HistoryView: View {
             if !state.searchQuery.isEmpty {
                 Button(L("Clear Search", "清除搜索")) {
                     state.searchQuery = ""
-                    state.loadHistory()
                 }
                 .buttonStyle(.plain)
                 .font(.system(size: 9, weight: .semibold))
@@ -237,7 +240,7 @@ public struct HistoryView: View {
             detailRun = run
         }
 
-        if run.trajectory == nil || run.skillsUsed == nil || run.logs == nil {
+        if run.trajectory == nil || run.skillsUsed == nil || run.toolsUsed == nil || run.logs == nil {
             var enriched = run
             DispatchQueue.global(qos: .userInitiated).async {
                 TelemetryQueryEngine.shared.enrichRunIfNeeded(&enriched)
@@ -268,6 +271,15 @@ public struct HistoryView: View {
             withAnimation(.easeIn(duration: 0.12)) {
                 detailRun = nil
             }
+        }
+    }
+
+    private func scheduleSearchReload() {
+        searchGeneration += 1
+        let generation = searchGeneration
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) {
+            guard generation == searchGeneration else { return }
+            state.loadHistory()
         }
     }
 }
@@ -550,10 +562,19 @@ public struct HistoryTaskDetailOverlay: View {
 
                     detailNarrative
                     TokenUsageBreakdownView(usage: run.aggregatedUsage)
+
+                    if run.hasSkillsOrTools {
+                        InspectorSkillsToolsView(run: run)
+                    }
+
                     detailWorkers
 
                     if let steps = run.trajectory, !steps.isEmpty {
                         detailSteps(steps)
+                    }
+
+                    if let logs = run.logs, !logs.isEmpty {
+                        detailLogs(logs)
                     }
                 }
             }
@@ -718,7 +739,10 @@ public struct HistoryTaskDetailOverlay: View {
                 .foregroundColor(.white.opacity(0.48))
             ForEach(Array(steps.prefix(5))) { step in
                 HStack(alignment: .top, spacing: 4) {
-                    Circle().fill(.cyan).frame(width: 4, height: 4).padding(.top, 4)
+                    Circle()
+                        .fill(step.status == "error" ? Color.orange : Color.cyan)
+                        .frame(width: 4, height: 4)
+                        .padding(.top, 4)
                     HoverRevealText(
                         [step.title, step.detail].compactMap { $0 }.joined(separator: " — "),
                         font: .system(size: 7.6),
@@ -726,6 +750,33 @@ public struct HistoryTaskDetailOverlay: View {
                         lineLimit: 1,
                         privacyBlur: isPrivacyMode,
                         popoverWidth: 400
+                    )
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+        .padding(7)
+        .background(detailCard)
+    }
+
+    private func detailLogs(_ logs: [TaskLogEntry]) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(L("Recent logs", "最近日志"))
+                .font(.system(size: 7.7, weight: .bold))
+                .foregroundColor(.white.opacity(0.48))
+            ForEach(Array(logs.suffix(4))) { entry in
+                HStack(alignment: .top, spacing: 4) {
+                    Circle()
+                        .fill(entry.level == "error" ? Color.orange : Color.green)
+                        .frame(width: 4, height: 4)
+                        .padding(.top, 4)
+                    HoverRevealText(
+                        entry.message ?? "",
+                        font: .system(size: 7.4, design: .monospaced),
+                        foregroundColor: entry.level == "error" ? .orange.opacity(0.82) : .white.opacity(0.58),
+                        lineLimit: 2,
+                        privacyBlur: isPrivacyMode,
+                        popoverWidth: 410
                     )
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }

--- a/apps/macos-overlay/Sources/Views/HistoryView.swift
+++ b/apps/macos-overlay/Sources/Views/HistoryView.swift
@@ -4,23 +4,46 @@ public struct HistoryView: View {
     @ObservedObject var state: OverlayState
     @ObservedObject private var localization = AppLocalization.shared
     public var isFullHeight: Bool = false
+
     @State private var availableProjects: [String] = []
-    
+    @State private var detailRun: TaskRun?
+    @State private var detailHoverGeneration = 0
+
     public init(state: OverlayState, isFullHeight: Bool = false) {
         self.state = state
         self.isFullHeight = isFullHeight
     }
-    
+
     public var body: some View {
-        VStack(spacing: 8) {
-            // MARK: Filter & Search Bar (Dimension 1: Project & Time Scope)
-            filterBar
-            
-            // MARK: Chat List / Empty State (Dimension 2: Chat & Dimension 3: Session)
-            if state.historyChats.isEmpty && state.historyRuns.isEmpty {
-                emptyState
-            } else {
-                chatList
+        ZStack(alignment: .topTrailing) {
+            VStack(spacing: 8) {
+                filterBar
+
+                if state.historyChats.isEmpty && state.historyRuns.isEmpty {
+                    emptyState
+                } else {
+                    historyList
+                }
+            }
+
+            if let run = detailRun {
+                HistoryTaskDetailOverlay(
+                    run: run,
+                    isPrivacyMode: state.isPrivacyMode,
+                    onClose: closeDetail
+                )
+                .frame(width: 350)
+                .padding(.top, 34)
+                .padding(.trailing, 2)
+                .zIndex(20)
+                .transition(.opacity.combined(with: .scale(scale: 0.97, anchor: .topTrailing)))
+                .onHover { inside in
+                    if inside {
+                        cancelScheduledClose()
+                    } else {
+                        scheduleDetailClose()
+                    }
+                }
             }
         }
         .onAppear {
@@ -30,682 +53,691 @@ public struct HistoryView: View {
             }
         }
     }
-    
-    // MARK: - Filter Bar
+
+    // MARK: - Filters
+
     private var filterBar: some View {
         VStack(spacing: 6) {
             HStack(spacing: 6) {
-                // Scope selector (All / Today)
                 HStack(spacing: 2) {
-                    scopeButton(title: L("All", "全部"), isSelected: !state.isTodayOnly) {
+                    scopeButton(title: L("All", "全部"), selected: !state.isTodayOnly) {
                         state.isTodayOnly = false
                         state.loadHistory()
                     }
-                    scopeButton(title: L("Today", "今天"), isSelected: state.isTodayOnly) {
+                    scopeButton(title: L("Today", "今天"), selected: state.isTodayOnly) {
                         state.isTodayOnly = true
                         state.loadHistory()
                     }
                 }
                 .padding(2)
                 .background(Capsule().fill(Color.white.opacity(0.06)))
-                
-                // Project picker (Dimension 1: Project)
+
                 if availableProjects.count > 2 {
-                    let projectPickerLabel = HStack(spacing: 3) {
-                        Image(systemName: "folder")
-                            .font(.system(size: 9))
-                            .foregroundColor(.cyan.opacity(0.9))
-                        
-                        Text(state.selectedProject ?? L("All", "全部"))
-                            .font(.system(size: 9, weight: .medium))
-                            .foregroundColor(.white.opacity(0.85))
-                            .lineLimit(1)
-                            .blur(radius: (state.isPrivacyMode && state.selectedProject != nil) ? 4.5 : 0)
-                        
-                        Image(systemName: "chevron.down")
-                            .font(.system(size: 7))
-                            .foregroundColor(.white.opacity(0.5))
-                    }
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 3)
-                    .background(
-                        Capsule()
-                            .fill(Color.white.opacity(0.06))
-                    )
-                    
-                    if state.isPrivacyMode || isFullHeight {
-                        projectPickerLabel
-                    } else {
-                        Menu {
-                            ForEach(availableProjects, id: \.self) { proj in
-                                Button(proj == "All" ? L("All", "全部") : proj) {
-                                    state.selectedProject = (proj == "All" ? nil : proj)
-                                    state.loadHistory()
-                                }
+                    Menu {
+                        ForEach(availableProjects, id: \.self) { project in
+                            Button(project == "All" ? L("All Projects", "全部项目") : project) {
+                                state.selectedProject = project == "All" ? nil : project
+                                state.loadHistory()
                             }
-                        } label: {
-                            projectPickerLabel
                         }
-                        .menuStyle(.borderlessButton)
+                    } label: {
+                        HStack(spacing: 3) {
+                            Image(systemName: "folder")
+                                .font(.system(size: 8))
+                                .foregroundColor(.cyan.opacity(0.85))
+                            Text(state.selectedProject ?? L("All Projects", "全部项目"))
+                                .font(.system(size: 8.5, weight: .medium))
+                                .foregroundColor(.white.opacity(0.72))
+                                .lineLimit(1)
+                                .blur(radius: state.isPrivacyMode && state.selectedProject != nil ? 4.5 : 0)
+                            Image(systemName: "chevron.down")
+                                .font(.system(size: 6.5))
+                                .foregroundColor(.white.opacity(0.4))
+                        }
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 3)
+                        .background(Capsule().fill(Color.white.opacity(0.05)))
                     }
+                    .menuStyle(.borderlessButton)
                 }
-                
+
                 Spacer()
-                
-                // Refresh button
+
                 Button {
                     state.loadHistory()
                 } label: {
                     Image(systemName: "arrow.clockwise")
-                        .font(.system(size: 9, weight: .semibold))
-                        .foregroundColor(.white.opacity(0.6))
-                        .padding(4)
-                        .background(Circle().fill(Color.white.opacity(0.06)))
+                        .font(.system(size: 8.5, weight: .semibold))
+                        .foregroundColor(.white.opacity(0.55))
+                        .frame(width: 20, height: 20)
+                        .background(Circle().fill(Color.white.opacity(0.05)))
                 }
                 .buttonStyle(.plain)
             }
-            
-            // Search field
+
             HStack(spacing: 5) {
                 Image(systemName: "magnifyingglass")
-                    .font(.system(size: 9))
+                    .font(.system(size: 8.5))
                     .foregroundColor(.white.opacity(0.4))
-                
-                if state.isPrivacyMode || isFullHeight {
-                    Text(state.searchQuery.isEmpty ? L("Search chat or session...", "搜索对话或会话...") : state.searchQuery)
-                        .font(.system(size: 9.5))
-                        .foregroundColor(state.searchQuery.isEmpty ? .white.opacity(0.35) : .white)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                } else {
-                    TextField(L("Search chat or session...", "搜索对话或会话..."), text: $state.searchQuery)
-                        .textFieldStyle(.plain)
-                        .font(.system(size: 9.5))
-                        .foregroundColor(.white)
-                        .onChange(of: state.searchQuery) { _ in
-                            state.loadHistory()
-                        }
-                }
-                
+
+                TextField(L("Search chat or session…", "搜索对话或任务…"), text: $state.searchQuery)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 9.2))
+                    .foregroundColor(.white)
+                    .onChange(of: state.searchQuery) { _ in
+                        state.loadHistory()
+                    }
+
                 if !state.searchQuery.isEmpty {
                     Button {
                         state.searchQuery = ""
                         state.loadHistory()
                     } label: {
                         Image(systemName: "xmark.circle.fill")
-                            .font(.system(size: 9))
+                            .font(.system(size: 8.5))
                             .foregroundColor(.white.opacity(0.4))
                     }
                     .buttonStyle(.plain)
                 }
             }
             .padding(.horizontal, 7)
-            .padding(.vertical, 4)
+            .padding(.vertical, 5)
             .background(
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(Color.white.opacity(0.04))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 6)
-                            .stroke(Color.white.opacity(0.08), lineWidth: 0.5)
-                    )
+                RoundedRectangle(cornerRadius: 7)
+                    .fill(Color.white.opacity(0.035))
+                    .overlay(RoundedRectangle(cornerRadius: 7).stroke(Color.white.opacity(0.075), lineWidth: 0.6))
             )
         }
+        .padding(.top, 7)
     }
-    
-    private func scopeButton(title: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
+
+    private func scopeButton(title: String, selected: Bool, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Text(title)
-                .font(.system(size: 8.5, weight: isSelected ? .bold : .medium, design: .rounded))
-                .foregroundColor(isSelected ? .white : .white.opacity(0.5))
+                .font(.system(size: 8.2, weight: selected ? .bold : .medium, design: .rounded))
+                .foregroundColor(selected ? .white : .white.opacity(0.46))
                 .padding(.horizontal, 6)
                 .padding(.vertical, 2)
-                .background(
-                    Capsule()
-                        .fill(isSelected ? Color.cyan.opacity(0.35) : Color.clear)
-                )
+                .background(Capsule().fill(selected ? Color.cyan.opacity(0.28) : Color.clear))
         }
         .buttonStyle(.plain)
     }
-    
-    // MARK: - Chat List (Accordion)
-    private var chatList: some View {
-        let listContent = LazyVStack(spacing: 8) {
-            ForEach(Array(state.historyChats.enumerated()), id: \.element.id) { index, chat in
-                ChatAccordionRow(
-                    index: index + 1,
-                    chat: chat,
-                    isExpanded: state.isChatExpanded(chat.sessionId),
-                    inspectedRunId: state.inspectedRun?.id,
-                    isPrivacyMode: state.isPrivacyMode,
-                    onToggleExpand: {
-                        state.toggleChatExpansion(chat.sessionId)
-                    },
-                    onSelectRun: { run in
-                        state.inspect(run: run)
-                    }
-                )
+
+    // MARK: - History List
+
+    private var historyList: some View {
+        let content = LazyVStack(spacing: 7) {
+            if !state.historyChats.isEmpty {
+                ForEach(Array(state.historyChats.enumerated()), id: \.element.id) { index, chat in
+                    HistoryChatRow(
+                        index: index + 1,
+                        chat: chat,
+                        expanded: state.isChatExpanded(chat.sessionId),
+                        selectedRunId: detailRun?.id,
+                        isPrivacyMode: state.isPrivacyMode,
+                        onToggle: { state.toggleChatExpansion(chat.sessionId) },
+                        onSelectRun: showDetail
+                    )
+                }
+            } else {
+                ForEach(Array(state.historyRuns.enumerated()), id: \.element.id) { index, run in
+                    HistoryStandaloneRunRow(
+                        index: index + 1,
+                        run: run,
+                        selected: detailRun?.id == run.id,
+                        isPrivacyMode: state.isPrivacyMode,
+                        onSelect: { showDetail(run) }
+                    )
+                }
             }
         }
         .padding(.vertical, 2)
-        
+
         return Group {
             if isFullHeight {
-                listContent
+                content
             } else {
                 ScrollView(.vertical, showsIndicators: true) {
-                    listContent
+                    content
                 }
-                .frame(maxHeight: 340)
+                .frame(maxHeight: 355)
             }
         }
     }
-    
-    // MARK: - Contextual Empty State
+
     private var emptyState: some View {
         VStack(spacing: 8) {
-            Image(systemName: !state.searchQuery.isEmpty ? "magnifyingglass" : "tray")
-                .font(.system(size: 24))
-                .foregroundColor(.white.opacity(0.3))
-                .padding(.top, 24)
-            
+            Image(systemName: state.searchQuery.isEmpty ? "tray" : "magnifyingglass")
+                .font(.system(size: 23))
+                .foregroundColor(.white.opacity(0.28))
+                .padding(.top, 28)
+
+            Text(state.searchQuery.isEmpty ? L("No telemetry history yet", "尚无遥测历史") : L("No matching tasks", "没有匹配的任务"))
+                .font(.system(size: 11, weight: .semibold, design: .rounded))
+                .foregroundColor(.white.opacity(0.72))
+
             if !state.searchQuery.isEmpty {
-                Text(L("No results for \"\(state.searchQuery)\"", "没有找到‘\(state.searchQuery)’的结果"))
-                    .font(.system(size: 11.5, weight: .medium))
-                    .foregroundColor(.white.opacity(0.75))
-                
-                Button {
+                Button(L("Clear Search", "清除搜索")) {
                     state.searchQuery = ""
                     state.loadHistory()
-                } label: {
-                    Text(L("Clear Search", "清除搜索"))
-                        .font(.system(size: 10, weight: .semibold))
-                        .foregroundColor(.cyan)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 4)
-                        .background(Capsule().fill(Color.cyan.opacity(0.15)))
                 }
                 .buttonStyle(.plain)
-            } else if state.isTodayOnly {
-                Text(L("No chats recorded today", "今天还没有对话记录"))
-                    .font(.system(size: 11.5, weight: .medium))
-                    .foregroundColor(.white.opacity(0.75))
-                
-                Button {
-                    state.isTodayOnly = false
-                    state.loadHistory()
-                } label: {
-                    Text(L("Show All Time", "查看全部时间"))
-                        .font(.system(size: 10, weight: .semibold))
-                        .foregroundColor(.cyan)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 4)
-                        .background(Capsule().fill(Color.cyan.opacity(0.15)))
-                }
-                .buttonStyle(.plain)
-            } else if let p = state.selectedProject {
-                Text(L("No chats for project \"\(p)\"", "项目‘\(p)’暂无对话"))
-                    .font(.system(size: 11.5, weight: .medium))
-                    .foregroundColor(.white.opacity(0.75))
-                
-                Button {
-                    state.selectedProject = nil
-                    state.loadHistory()
-                } label: {
-                    Text(L("Show All Projects", "查看全部项目"))
-                        .font(.system(size: 10, weight: .semibold))
-                        .foregroundColor(.cyan)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 4)
-                        .background(Capsule().fill(Color.cyan.opacity(0.15)))
-                }
-                .buttonStyle(.plain)
-            } else {
-                Text(L("No telemetry runs recorded yet", "尚未记录遥测任务"))
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(.white.opacity(0.75))
-                
-                Text(L("FlowPilot logs token and duration telemetry automatically.", "FlowPilot 会自动记录 Token 和耗时遥测。"))
-                    .font(.system(size: 10))
-                    .foregroundColor(.white.opacity(0.4))
-                    .multilineTextAlignment(.center)
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(.cyan)
             }
         }
-        .frame(maxWidth: .infinity, minHeight: 220)
+        .frame(maxWidth: .infinity, minHeight: 230)
+    }
+
+    // MARK: - Local task detail overlay
+
+    private func showDetail(_ run: TaskRun) {
+        cancelScheduledClose()
+        withAnimation(.easeOut(duration: 0.15)) {
+            detailRun = run
+        }
+
+        if run.trajectory == nil || run.skillsUsed == nil || run.logs == nil {
+            var enriched = run
+            DispatchQueue.global(qos: .userInitiated).async {
+                TelemetryQueryEngine.shared.enrichRunIfNeeded(&enriched)
+                DispatchQueue.main.async {
+                    guard detailRun?.id == enriched.id else { return }
+                    detailRun = enriched
+                }
+            }
+        }
+    }
+
+    private func closeDetail() {
+        cancelScheduledClose()
+        withAnimation(.easeIn(duration: 0.12)) {
+            detailRun = nil
+        }
+    }
+
+    private func cancelScheduledClose() {
+        detailHoverGeneration += 1
+    }
+
+    private func scheduleDetailClose() {
+        detailHoverGeneration += 1
+        let generation = detailHoverGeneration
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.32) {
+            guard generation == detailHoverGeneration else { return }
+            withAnimation(.easeIn(duration: 0.12)) {
+                detailRun = nil
+            }
+        }
     }
 }
 
-// MARK: - Dimension 2: Chat Level Accordion Row
-public struct ChatAccordionRow: View {
-    @ObservedObject private var localization = AppLocalization.shared
-    public var index: Int
-    public var chat: ChatSession
-    public var isExpanded: Bool
-    public var inspectedRunId: String?
-    public var isPrivacyMode: Bool = false
-    public var onToggleExpand: () -> Void
-    public var onSelectRun: (TaskRun) -> Void
-    
-    @State private var isHovered: Bool = false
-    
-    public init(
-        index: Int,
-        chat: ChatSession,
-        isExpanded: Bool,
-        inspectedRunId: String?,
-        isPrivacyMode: Bool = false,
-        onToggleExpand: @escaping () -> Void,
-        onSelectRun: @escaping (TaskRun) -> Void
-    ) {
-        self.index = index
-        self.chat = chat
-        self.isExpanded = isExpanded
-        self.inspectedRunId = inspectedRunId
-        self.isPrivacyMode = isPrivacyMode
-        self.onToggleExpand = onToggleExpand
-        self.onSelectRun = onSelectRun
-    }
-    
+// MARK: - Chat accordion
+
+public struct HistoryChatRow: View {
+    public let index: Int
+    public let chat: ChatSession
+    public let expanded: Bool
+    public let selectedRunId: String?
+    public let isPrivacyMode: Bool
+    public let onToggle: () -> Void
+    public let onSelectRun: (TaskRun) -> Void
+
+    @State private var hovered = false
+
     public var body: some View {
         VStack(spacing: 0) {
-            // Chat Header Card
-            chatHeaderButton
-            
-            // Expanded Session Breakdown (Dimension 3: Sessions inside Chat)
-            if isExpanded {
-                sessionsBreakdownContainer
-                    .transition(.opacity.combined(with: .move(edge: .top)))
-            }
-        }
-        .background(containerBackground)
-        .clipShape(RoundedRectangle(cornerRadius: 10))
-        .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(isExpanded ? Color.cyan.opacity(0.25) : containerStrokeColor, lineWidth: 0.8)
-        )
-    }
-    
-    // MARK: - Chat Header Button
-    private var chatHeaderButton: some View {
-        Button(action: onToggleExpand) {
-            HStack(alignment: .top, spacing: 7) {
-                // Index & Chevron
-                VStack(spacing: 4) {
-                    Text("#\(index)")
-                        .font(.system(size: 9.5, weight: .bold, design: .monospaced))
-                        .foregroundColor(index == 1 ? .cyan : .white.opacity(0.45))
-                    
-                    Image(systemName: "chevron.right")
-                        .font(.system(size: 8, weight: .semibold))
-                        .foregroundColor(.white.opacity(isExpanded ? 0.9 : 0.35))
-                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
-                        .animation(.easeInOut(duration: 0.18), value: isExpanded)
-                }
-                .frame(width: 26, alignment: .leading)
-                .padding(.top, 1)
-                
-                // Chat Info & Aggregation
-                VStack(alignment: .leading, spacing: 3) {
-                    // Top: Project & Branch & Timestamp
-                    HStack(spacing: 4) {
-                        Text(chat.projectName)
-                            .font(.system(size: 10, weight: .bold, design: .rounded))
-                            .foregroundColor(.white.opacity(0.95))
-                            .lineLimit(1)
-                            .blur(radius: isPrivacyMode ? 4.5 : 0)
-                        
-                        if let branch = chat.gitBranch, !branch.isEmpty {
-                            Text("(\(branch))")
-                                .font(.system(size: 8.5, weight: .medium, design: .monospaced))
+            Button(action: onToggle) {
+                HStack(alignment: .top, spacing: 7) {
+                    VStack(spacing: 4) {
+                        Text("#\(index)")
+                            .font(.system(size: 9, weight: .bold, design: .monospaced))
+                            .foregroundColor(index == 1 ? .cyan : .white.opacity(0.45))
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 7.5, weight: .semibold))
+                            .foregroundColor(.white.opacity(0.42))
+                            .rotationEffect(.degrees(expanded ? 90 : 0))
+                    }
+                    .frame(width: 25)
+
+                    VStack(alignment: .leading, spacing: 3) {
+                        HStack(spacing: 4) {
+                            HoverRevealText(
+                                chat.projectName,
+                                font: .system(size: 9.8, weight: .bold, design: .rounded),
+                                foregroundColor: .white.opacity(0.92),
+                                lineLimit: 1,
+                                privacyBlur: isPrivacyMode,
+                                popoverWidth: 300
+                            )
+
+                            if let branch = chat.gitBranch, !branch.isEmpty {
+                                HoverRevealText(
+                                    "(\(branch))",
+                                    font: .system(size: 8, weight: .medium, design: .monospaced),
+                                    foregroundColor: .cyan.opacity(0.78),
+                                    lineLimit: 1,
+                                    privacyBlur: isPrivacyMode,
+                                    popoverWidth: 300
+                                )
+                            }
+
+                            Spacer(minLength: 4)
+                            Text(chat.localizedFormattedDate)
+                                .font(.system(size: 7.8))
+                                .foregroundColor(.white.opacity(0.38))
+                        }
+
+                        HoverRevealText(
+                            chat.title,
+                            font: .system(size: 9.3),
+                            foregroundColor: .white.opacity(0.78),
+                            lineLimit: 1,
+                            privacyBlur: isPrivacyMode,
+                            popoverWidth: 400
+                        )
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                        HStack(spacing: 6) {
+                            Label(chat.localizedRunsSummary, systemImage: "bubble.left.and.bubble.right.fill")
+                                .font(.system(size: 7.8, weight: .semibold))
                                 .foregroundColor(.cyan.opacity(0.8))
-                                .lineLimit(1)
-                        }
-                        
-                        Spacer()
-                        
-                        Text(chat.localizedFormattedDate)
-                            .font(.system(size: 8.5, weight: .regular))
-                            .foregroundColor(.white.opacity(0.4))
-                    }
-                    
-                    // Chat Title / Prompt Preview
-                    Text(chat.title)
-                        .font(.system(size: 10, weight: .regular))
-                        .foregroundColor(.white.opacity(0.85))
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                        .blur(radius: isPrivacyMode ? 4.5 : 0)
-                    
-                    // Chat Aggregated Metrics Row (Chat Totals)
-                    HStack(spacing: 6) {
-                        // Sessions count badge
-                        HStack(spacing: 2.5) {
-                            Image(systemName: "bubble.left.and.bubble.right.fill")
-                                .font(.system(size: 7))
-                            Text(chat.localizedRunsSummary)
-                                .font(.system(size: 8.5, weight: .semibold, design: .rounded))
-                        }
-                        .foregroundColor(Color.cyan.opacity(0.9))
-                        .padding(.horizontal, 4.5)
-                        .padding(.vertical, 1.5)
-                        .background(Capsule().fill(Color.cyan.opacity(0.12)))
-                        
-                        // Execution mode (Worker or Direct)
-                        executionModeBadge
-                        
-                        Text("·")
-                            .foregroundColor(.white.opacity(0.2))
-                        
-                        // Total Chat Duration
-                        Text(chat.formattedDuration)
-                            .font(.system(size: 8.5, weight: .medium, design: .monospaced))
-                            .foregroundColor(.white.opacity(0.55))
-                        
-                        Spacer()
-                        
-                        // Quota Delta Badge (Chat Session Level)
-                        if let totalDelta = chat.totalQuotaDelta, abs(totalDelta) >= 0.1 {
-                            HStack(spacing: 2) {
-                                Image(systemName: totalDelta > 0 ? "gauge.with.needle.fill" : "arrow.down.circle.fill")
-                                    .font(.system(size: 6.5))
-                                Text(String(format: "%+.0f%%", totalDelta))
-                                    .font(.system(size: 8, weight: .bold, design: .rounded))
+
+                            Text(chat.formattedDuration)
+                                .font(.system(size: 7.8, design: .monospaced))
+                                .foregroundColor(.white.opacity(0.45))
+
+                            if chat.maxWorkerCount > 0 {
+                                Label("\(chat.maxWorkerCount)w", systemImage: "person.2.fill")
+                                    .font(.system(size: 7.6, weight: .medium))
+                                    .foregroundColor(.teal.opacity(0.8))
                             }
-                            .foregroundColor(totalDelta > 0 ? .orange : Color(red: 0.2, green: 0.85, blue: 0.45))
-                            .padding(.horizontal, 4)
-                            .padding(.vertical, 1.5)
-                            .background(Capsule().fill((totalDelta > 0 ? Color.orange : Color.green).opacity(0.15)))
-                        }
-                        
-                        // Total Chat Tokens (Aggregated Sum)
-                        Text(chat.formattedTotalTokens)
-                            .font(.system(size: 9.5, weight: .bold, design: .rounded))
-                            .foregroundColor(Color(red: 0.95, green: 0.35, blue: 0.8))
-                        
-                        // Overall Status Dot
-                        Circle()
-                            .fill(statusColor)
-                            .frame(width: 5, height: 5)
-                    }
-                    .padding(.top, 1)
-                }
-            }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 7)
-            .background(headerBackground)
-        }
-        .buttonStyle(.plain)
-        .onHover { isHovered = $0 }
-    }
-    
-    // MARK: - Sessions Breakdown Container (Dimension 3: Sessions)
-    private var sessionsBreakdownContainer: some View {
-        VStack(spacing: 0) {
-            Divider()
-                .background(Color.white.opacity(0.08))
-            
-            VStack(alignment: .leading, spacing: 3) {
-                // Section Header / Quick action
-                HStack {
-                    HStack(spacing: 3) {
-                        Image(systemName: "list.bullet.indent")
-                            .font(.system(size: 8))
-                            .foregroundColor(.cyan.opacity(0.7))
-                        Text(L("Session Turns (\(chat.runs.count))", "执行轮次（共 \(chat.runs.count) 轮）"))
-                            .font(.system(size: 8.5, weight: .semibold))
-                            .foregroundColor(.white.opacity(0.5))
-                    }
-                    
-                    Spacer()
-                    
-                    if let latest = chat.latestRun {
-                        Button {
-                            onSelectRun(latest)
-                        } label: {
-                            HStack(spacing: 2) {
-                                Image(systemName: "bolt.fill")
-                                    .font(.system(size: 7))
-                                Text(L("Inspect Latest", "查看最新"))
-                                    .font(.system(size: 8, weight: .medium))
+
+                            Spacer()
+
+                            if let delta = chat.totalQuotaDelta, abs(delta) >= 0.1 {
+                                Text(String(format: "%+.0f%%", delta))
+                                    .font(.system(size: 7.5, weight: .bold))
+                                    .foregroundColor(delta > 0 ? .orange : .green)
                             }
-                            .foregroundColor(.cyan.opacity(0.85))
-                            .padding(.horizontal, 4)
-                            .padding(.vertical, 1.5)
-                            .background(Capsule().fill(Color.cyan.opacity(0.12)))
+
+                            Text(chat.formattedTotalTokens)
+                                .font(.system(size: 8.5, weight: .bold, design: .rounded))
+                                .foregroundColor(Color(red: 0.95, green: 0.35, blue: 0.8))
+
+                            Circle()
+                                .fill(chat.isRunning ? .cyan : (chat.isError ? .orange : .green))
+                                .frame(width: 4.5, height: 4.5)
                         }
-                        .buttonStyle(.plain)
                     }
                 }
-                .padding(.horizontal, 8)
-                .padding(.top, 4)
-                .padding(.bottom, 2)
-                
-                // Individual Session Rows
-                ForEach(Array(chat.runs.enumerated()), id: \.element.id) { turnIndex, run in
-                    // In reversed chronological order: latest turn is highest #
-                    let turnNumber = chat.runs.count - turnIndex
-                    SessionItemRow(
-                        chatIndex: index,
-                        turnNumber: turnNumber,
-                        run: run,
-                        isSelected: inspectedRunId == run.id,
-                        isPrivacyMode: isPrivacyMode,
-                        onSelect: {
-                            onSelectRun(run)
+                .padding(.horizontal, 7)
+                .padding(.vertical, 7)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .onHover { hovered = $0 }
+
+            if expanded {
+                Divider().background(Color.white.opacity(0.07))
+                VStack(spacing: 3) {
+                    HStack {
+                        Text(L("Session Turns", "执行轮次"))
+                            .font(.system(size: 7.8, weight: .bold, design: .rounded))
+                            .foregroundColor(.white.opacity(0.42))
+                        Spacer()
+                        if let latest = chat.latestRun {
+                            Button {
+                                onSelectRun(latest)
+                            } label: {
+                                Label(L("Details", "详情"), systemImage: "rectangle.inset.filled.and.person.filled")
+                                    .font(.system(size: 7.5, weight: .semibold))
+                                    .foregroundColor(.cyan)
+                            }
+                            .buttonStyle(.plain)
                         }
-                    )
+                    }
+                    .padding(.horizontal, 7)
+                    .padding(.top, 5)
+
+                    ForEach(Array(chat.runs.enumerated()), id: \.element.id) { offset, run in
+                        HistoryRunRow(
+                            turnNumber: chat.runs.count - offset,
+                            run: run,
+                            selected: selectedRunId == run.id,
+                            isPrivacyMode: isPrivacyMode,
+                            onSelect: { onSelectRun(run) }
+                        )
+                    }
                 }
+                .padding(.horizontal, 5)
+                .padding(.bottom, 5)
+                .background(Color.black.opacity(0.16))
             }
-            .padding(.horizontal, 6)
-            .padding(.vertical, 4)
-            .background(Color.black.opacity(0.2))
         }
-    }
-    
-    @ViewBuilder
-    private var executionModeBadge: some View {
-        let maxWorkers = chat.maxWorkerCount
-        if maxWorkers > 0 {
-            HStack(spacing: 2) {
-                Image(systemName: "person.2.fill")
-                    .font(.system(size: 7.5))
-                Text(L("\(maxWorkers) workers", "\(maxWorkers) 个 Worker"))
-                    .font(.system(size: 8.5, weight: .medium))
-            }
-            .foregroundColor(.teal.opacity(0.85))
-        } else {
-            Text(L("Direct", "直接执行"))
-                .font(.system(size: 8.5, weight: .regular))
-                .foregroundColor(.white.opacity(0.4))
-        }
-    }
-    
-    private var headerBackground: Color {
-        if isHovered { return Color.white.opacity(0.06) }
-        return Color.white.opacity(0.02)
-    }
-    
-    private var containerBackground: Color {
-        if isExpanded { return Color.white.opacity(0.04) }
-        return Color.white.opacity(0.025)
-    }
-    
-    private var containerStrokeColor: Color {
-        if isHovered { return Color.white.opacity(0.12) }
-        return Color.white.opacity(0.06)
-    }
-    
-    private var statusColor: Color {
-        if chat.isRunning {
-            return .cyan
-        } else if chat.isError {
-            return .orange
-        }
-        return Color(red: 0.2, green: 0.85, blue: 0.45)
+        .background(RoundedRectangle(cornerRadius: 9).fill(hovered ? Color.white.opacity(0.055) : Color.white.opacity(0.03)))
+        .overlay(
+            RoundedRectangle(cornerRadius: 9)
+                .stroke(expanded ? Color.cyan.opacity(0.22) : Color.white.opacity(hovered ? 0.12 : 0.065), lineWidth: 0.7)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 9))
     }
 }
 
-// MARK: - Dimension 3: Individual Session Item Row
-public struct SessionItemRow: View {
-    @ObservedObject private var localization = AppLocalization.shared
-    public var chatIndex: Int
-    public var turnNumber: Int
-    public var run: TaskRun
-    public var isSelected: Bool
-    public var isPrivacyMode: Bool = false
-    public var onSelect: () -> Void
-    
-    public init(
-        chatIndex: Int,
-        turnNumber: Int,
-        run: TaskRun,
-        isSelected: Bool,
-        isPrivacyMode: Bool = false,
-        onSelect: @escaping () -> Void
-    ) {
-        self.chatIndex = chatIndex
-        self.turnNumber = turnNumber
-        self.run = run
-        self.isSelected = isSelected
-        self.isPrivacyMode = isPrivacyMode
-        self.onSelect = onSelect
-    }
-    
-    @State private var isHovered: Bool = false
-    
+public struct HistoryRunRow: View {
+    public let turnNumber: Int
+    public let run: TaskRun
+    public let selected: Bool
+    public let isPrivacyMode: Bool
+    public let onSelect: () -> Void
+
+    @State private var hovered = false
+
     public var body: some View {
         Button(action: onSelect) {
-            HStack(spacing: 6) {
-                // Left connector guide
+            HStack(spacing: 5) {
                 Capsule()
-                    .fill(isSelected ? Color.cyan : (isHovered ? Color.white.opacity(0.4) : Color.white.opacity(0.12)))
-                    .frame(width: 2.5, height: 22)
-                
-                // Turn Badge
-                Text("#\(chatIndex).\(turnNumber)")
-                    .font(.system(size: 8.5, weight: .bold, design: .monospaced))
-                    .foregroundColor(isSelected ? .cyan : .white.opacity(0.55))
-                    .frame(width: 28, alignment: .leading)
-                
-                // Turn Content & Meta
-                VStack(alignment: .leading, spacing: 1.5) {
+                    .fill(selected ? Color.cyan : Color.white.opacity(hovered ? 0.35 : 0.12))
+                    .frame(width: 2.5, height: 24)
+
+                Text("#\(turnNumber)")
+                    .font(.system(size: 7.8, weight: .bold, design: .monospaced))
+                    .foregroundColor(selected ? .cyan : .white.opacity(0.45))
+                    .frame(width: 22, alignment: .leading)
+
+                VStack(alignment: .leading, spacing: 2) {
                     HStack(spacing: 4) {
-                        // Time & Duration
                         Text(run.localizedFormattedDate)
-                            .font(.system(size: 8.0, weight: .regular))
-                            .foregroundColor(.white.opacity(0.45))
-                        
+                            .font(.system(size: 7.4))
+                            .foregroundColor(.white.opacity(0.38))
                         Text("·")
                             .foregroundColor(.white.opacity(0.2))
-                        
                         Text(run.formattedDuration)
-                            .font(.system(size: 8.0, weight: .medium, design: .monospaced))
-                            .foregroundColor(.white.opacity(0.6))
-                        
+                            .font(.system(size: 7.4, design: .monospaced))
+                            .foregroundColor(.white.opacity(0.5))
+
                         Spacer()
-                        
-                        // Worker info
-                        sessionWorkerBadge
-                        
-                        // Skill & MCP Badges
-                        if let skills = run.skillsUsed, !skills.isEmpty {
-                            HStack(spacing: 2) {
-                                Image(systemName: "sparkles")
-                                    .font(.system(size: 6))
-                                Text("\(skills.count)")
-                                    .font(.system(size: 7.5, weight: .bold))
-                            }
-                            .foregroundColor(.purple)
-                            .padding(.horizontal, 3.5)
-                            .padding(.vertical, 1)
-                            .background(Capsule().fill(Color.purple.opacity(0.15)))
+
+                        if !run.allWorkers.isEmpty {
+                            Text("\(run.allWorkers.count)w")
+                                .font(.system(size: 7.2, weight: .semibold))
+                                .foregroundColor(.teal.opacity(0.8))
                         }
-                        if let tools = run.toolsUsed, tools.contains(where: { $0.isMcp == true }) {
-                            HStack(spacing: 2) {
-                                Image(systemName: "network")
-                                    .font(.system(size: 6))
-                                Text("MCP")
-                                    .font(.system(size: 7.5, weight: .bold))
-                            }
-                            .foregroundColor(.orange)
-                            .padding(.horizontal, 3.5)
-                            .padding(.vertical, 1)
-                            .background(Capsule().fill(Color.orange.opacity(0.15)))
-                        }
-                        
-                        // Quota Delta Badge (Turn Level)
-                        if let delta = run.primaryQuotaDelta, abs(delta) >= 0.1 {
-                            HStack(spacing: 1.5) {
-                                Image(systemName: delta > 0 ? "arrow.up.right" : "arrow.down.right")
-                                    .font(.system(size: 6))
-                                Text(String(format: "%+.0f%%", delta))
-                                    .font(.system(size: 7.5, weight: .bold, design: .rounded))
-                            }
-                            .foregroundColor(delta > 0 ? .orange : Color(red: 0.2, green: 0.85, blue: 0.45))
-                            .padding(.horizontal, 3.5)
-                            .padding(.vertical, 1)
-                            .background(Capsule().fill((delta > 0 ? Color.orange : Color.green).opacity(0.15)))
-                        }
-                        
-                        // Turn Tokens
+
                         Text(run.formattedTotalTokens)
-                            .font(.system(size: 8.5, weight: .bold, design: .rounded))
-                            .foregroundColor(Color(red: 0.95, green: 0.35, blue: 0.8).opacity(0.9))
-                        
-                        // Status dot
-                        Circle()
-                            .fill(runStatusColor)
-                            .frame(width: 4, height: 4)
+                            .font(.system(size: 7.8, weight: .bold, design: .rounded))
+                            .foregroundColor(Color(red: 0.95, green: 0.35, blue: 0.8))
                     }
-                    
-                    // Turn prompt snippet / summary if available
+
                     if let preview = run.thread?.preview ?? run.summary, !preview.isEmpty {
-                        Text(preview)
-                            .font(.system(size: 8.5, weight: .regular))
-                            .foregroundColor(.white.opacity(0.65))
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-                            .blur(radius: isPrivacyMode ? 4.5 : 0)
+                        HoverRevealText(
+                            preview,
+                            font: .system(size: 8.2),
+                            foregroundColor: .white.opacity(0.6),
+                            lineLimit: 1,
+                            privacyBlur: isPrivacyMode,
+                            popoverWidth: 400
+                        )
+                        .frame(maxWidth: .infinity, alignment: .leading)
                     }
                 }
             }
-            .padding(.horizontal, 6)
-            .padding(.vertical, 4.5)
-            .background(rowBackground)
-            .clipShape(RoundedRectangle(cornerRadius: 6))
-            .overlay(
-                RoundedRectangle(cornerRadius: 6)
-                    .stroke(isSelected ? Color.cyan.opacity(0.5) : (isHovered ? Color.white.opacity(0.12) : Color.clear), lineWidth: 0.8)
-            )
+            .padding(.horizontal, 5)
+            .padding(.vertical, 4)
+            .background(RoundedRectangle(cornerRadius: 6).fill(selected ? Color.cyan.opacity(0.14) : (hovered ? Color.white.opacity(0.06) : Color.white.opacity(0.018))))
+            .overlay(RoundedRectangle(cornerRadius: 6).stroke(selected ? Color.cyan.opacity(0.42) : Color.clear, lineWidth: 0.7))
         }
         .buttonStyle(.plain)
-        .onHover { isHovered = $0 }
+        .onHover { hovered = $0 }
     }
-    
-    @ViewBuilder
-    private var sessionWorkerBadge: some View {
-        let workers = run.allWorkers.count
-        if workers > 0 {
-            HStack(spacing: 1.5) {
-                Image(systemName: "person.2.fill")
-                    .font(.system(size: 6.5))
-                Text("\(workers)w")
-                    .font(.system(size: 7.5, weight: .medium))
+}
+
+public struct HistoryStandaloneRunRow: View {
+    public let index: Int
+    public let run: TaskRun
+    public let selected: Bool
+    public let isPrivacyMode: Bool
+    public let onSelect: () -> Void
+
+    public var body: some View {
+        HistoryRunRow(
+            turnNumber: index,
+            run: run,
+            selected: selected,
+            isPrivacyMode: isPrivacyMode,
+            onSelect: onSelect
+        )
+    }
+}
+
+// MARK: - History-local detail surface
+
+public struct HistoryTaskDetailOverlay: View {
+    public let run: TaskRun
+    public let isPrivacyMode: Bool
+    public let onClose: () -> Void
+
+    public var body: some View {
+        VStack(spacing: 7) {
+            HStack(spacing: 5) {
+                Image(systemName: "rectangle.inset.filled.and.person.filled")
+                    .font(.system(size: 9))
+                    .foregroundColor(.cyan)
+                Text(L("Task Detail", "任务详情"))
+                    .font(.system(size: 10.5, weight: .bold, design: .rounded))
+                    .foregroundColor(.white)
+                Spacer()
+                Text(run.localizedFormattedDate)
+                    .font(.system(size: 7.4))
+                    .foregroundColor(.white.opacity(0.38))
+                Button(action: onClose) {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 12))
+                        .foregroundColor(.white.opacity(0.48))
+                }
+                .buttonStyle(.plain)
+                .help(L("Close", "关闭"))
             }
-            .foregroundColor(.teal.opacity(0.8))
+
+            ScrollView(.vertical, showsIndicators: true) {
+                VStack(spacing: 7) {
+                    detailHeader
+                    detailMetrics
+
+                    if !run.effectiveQuotaWindows.isEmpty {
+                        QuotaWindowsView(windows: run.effectiveQuotaWindows)
+                    }
+
+                    detailNarrative
+                    TokenUsageBreakdownView(usage: run.aggregatedUsage)
+                    detailWorkers
+
+                    if let steps = run.trajectory, !steps.isEmpty {
+                        detailSteps(steps)
+                    }
+                }
+            }
+            .frame(maxHeight: 360)
+        }
+        .padding(9)
+        .background(
+            RoundedRectangle(cornerRadius: 13)
+                .fill(Color(red: 0.045, green: 0.052, blue: 0.073).opacity(0.985))
+                .shadow(color: .black.opacity(0.55), radius: 16, y: 7)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 13)
+                .stroke(Color.cyan.opacity(0.28), lineWidth: 0.8)
+        )
+    }
+
+    private var detailHeader: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 4) {
+                HoverRevealText(
+                    run.projectName,
+                    font: .system(size: 9.6, weight: .bold, design: .rounded),
+                    foregroundColor: .white.opacity(0.9),
+                    lineLimit: 1,
+                    privacyBlur: isPrivacyMode,
+                    popoverWidth: 300
+                )
+                if let branch = run.gitBranch, !branch.isEmpty {
+                    HoverRevealText(
+                        "(\(branch))",
+                        font: .system(size: 7.8, design: .monospaced),
+                        foregroundColor: .cyan.opacity(0.75),
+                        lineLimit: 1,
+                        privacyBlur: isPrivacyMode,
+                        popoverWidth: 300
+                    )
+                }
+                Spacer()
+            }
+
+            HoverRevealText(
+                run.thread?.preview ?? run.sessionTitle,
+                font: .system(size: 8.7),
+                foregroundColor: .white.opacity(0.62),
+                lineLimit: 2,
+                privacyBlur: isPrivacyMode,
+                popoverWidth: 390
+            )
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(7)
+        .background(detailCard)
+    }
+
+    private var detailMetrics: some View {
+        HStack(spacing: 5) {
+            miniMetric(L("Time", "耗时"), run.formattedDuration, .cyan)
+            miniMetric(L("Tokens", "Token"), run.formattedTotalTokens, Color(red: 0.95, green: 0.35, blue: 0.8))
+            miniMetric(L("Output", "输出"), TaskRun.formatTokenCount(run.aggregatedUsage.effectiveOutputTokens), .green)
         }
     }
-    
-    private var rowBackground: Color {
-        if isSelected { return Color.cyan.opacity(0.18) }
-        if isHovered { return Color.white.opacity(0.08) }
-        return Color.white.opacity(0.02)
-    }
-    
-    private var runStatusColor: Color {
-        if run.isRunning {
-            return .cyan
-        } else if run.isError {
-            return .orange
+
+    private func miniMetric(_ title: String, _ value: String, _ tint: Color) -> some View {
+        VStack(spacing: 2) {
+            Text(title)
+                .font(.system(size: 7.2, weight: .semibold))
+                .foregroundColor(.white.opacity(0.42))
+            Text(value)
+                .font(.system(size: 9.2, weight: .bold, design: .rounded))
+                .foregroundColor(tint)
+                .lineLimit(1)
         }
-        return Color(red: 0.2, green: 0.85, blue: 0.45)
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 5)
+        .background(detailCard)
+    }
+
+    private var detailNarrative: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            if let goal = run.effectiveGoal, !goal.isEmpty {
+                detailTextBlock(L("Objective", "目标"), goal, .cyan, 3)
+            }
+            if let conclusion = run.effectiveConclusion, !conclusion.isEmpty {
+                detailTextBlock(L("Outcome", "结论"), conclusion, .green, 4)
+            }
+        }
+    }
+
+    private func detailTextBlock(_ title: String, _ text: String, _ tint: Color, _ lines: Int) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.system(size: 7.6, weight: .bold))
+                .foregroundColor(tint.opacity(0.85))
+            HoverRevealText(
+                text,
+                font: .system(size: 8.5),
+                foregroundColor: .white.opacity(0.75),
+                lineLimit: lines,
+                privacyBlur: isPrivacyMode,
+                popoverWidth: 390
+            )
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(7)
+        .background(detailCard)
+    }
+
+    private var detailWorkers: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(L("Participants", "参与 Agent"))
+                    .font(.system(size: 7.7, weight: .bold))
+                    .foregroundColor(.white.opacity(0.48))
+                Spacer()
+                Text(L("\(run.allWorkers.count) workers", "\(run.allWorkers.count) 个 Worker"))
+                    .font(.system(size: 7.3))
+                    .foregroundColor(.teal.opacity(0.7))
+            }
+
+            HStack(spacing: 3) {
+                Text(L("Parent", "父 Agent"))
+                    .font(.system(size: 7.4, weight: .semibold))
+                    .foregroundColor(.indigo)
+                HoverRevealText(
+                    run.parent?.displayModel ?? "unknown",
+                    font: .system(size: 7.6, weight: .medium, design: .monospaced),
+                    foregroundColor: .white.opacity(0.7),
+                    lineLimit: 1,
+                    popoverWidth: 300
+                )
+                Spacer()
+            }
+
+            ForEach(run.allWorkers.prefix(4)) { worker in
+                HStack(spacing: 3) {
+                    Text(L("Worker", "Worker"))
+                        .font(.system(size: 7.4, weight: .semibold))
+                        .foregroundColor(.teal)
+                    HoverRevealText(
+                        worker.name ?? worker.displayModel,
+                        font: .system(size: 7.6),
+                        foregroundColor: .white.opacity(0.68),
+                        lineLimit: 1,
+                        popoverWidth: 320
+                    )
+                    Spacer()
+                    Text(TaskRun.formatTokenCount(worker.effectiveUsage?.totalTokens ?? 0))
+                        .font(.system(size: 7.3, design: .monospaced))
+                        .foregroundColor(.white.opacity(0.4))
+                }
+            }
+        }
+        .padding(7)
+        .background(detailCard)
+    }
+
+    private func detailSteps(_ steps: [TrajectoryStep]) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(L("Execution", "执行轨迹"))
+                .font(.system(size: 7.7, weight: .bold))
+                .foregroundColor(.white.opacity(0.48))
+            ForEach(Array(steps.prefix(5))) { step in
+                HStack(alignment: .top, spacing: 4) {
+                    Circle().fill(.cyan).frame(width: 4, height: 4).padding(.top, 4)
+                    HoverRevealText(
+                        [step.title, step.detail].compactMap { $0 }.joined(separator: " — "),
+                        font: .system(size: 7.6),
+                        foregroundColor: .white.opacity(0.6),
+                        lineLimit: 1,
+                        privacyBlur: isPrivacyMode,
+                        popoverWidth: 400
+                    )
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+        .padding(7)
+        .background(detailCard)
+    }
+
+    private var detailCard: some View {
+        RoundedRectangle(cornerRadius: 7)
+            .fill(Color.white.opacity(0.035))
+            .overlay(RoundedRectangle(cornerRadius: 7).stroke(Color.white.opacity(0.065), lineWidth: 0.6))
     }
 }

--- a/apps/macos-overlay/Sources/Views/HoverRevealText.swift
+++ b/apps/macos-overlay/Sources/Views/HoverRevealText.swift
@@ -47,7 +47,7 @@ public struct HoverRevealText: View {
             .multilineTextAlignment(alignment)
             .blur(radius: privacyBlur ? 4.5 : 0)
             .contentShape(Rectangle())
-            .onHover(perform: handleHover)
+            .onHover(perform: handleSourceHover)
             .popover(isPresented: $isPresented, arrowEdge: .bottom) {
                 ScrollView(.vertical, showsIndicators: true) {
                     Text(text)
@@ -61,10 +61,11 @@ public struct HoverRevealText: View {
                 }
                 .frame(width: popoverWidth)
                 .frame(maxHeight: 240)
+                .onHover(perform: handlePopoverHover)
             }
     }
 
-    private func handleHover(_ inside: Bool) {
+    private func handleSourceHover(_ inside: Bool) {
         hoverGeneration += 1
         let generation = hoverGeneration
 
@@ -73,11 +74,28 @@ public struct HoverRevealText: View {
             return
         }
 
-        let delay = inside ? 0.22 : 0.16
+        let delay = inside ? 0.22 : 0.25
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
             guard generation == hoverGeneration else { return }
             withAnimation(.easeInOut(duration: 0.12)) {
                 isPresented = inside
+            }
+        }
+    }
+
+    private func handlePopoverHover(_ inside: Bool) {
+        hoverGeneration += 1
+        let generation = hoverGeneration
+
+        if inside {
+            isPresented = true
+            return
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.16) {
+            guard generation == hoverGeneration else { return }
+            withAnimation(.easeInOut(duration: 0.12)) {
+                isPresented = false
             }
         }
     }

--- a/apps/macos-overlay/Sources/Views/HoverRevealText.swift
+++ b/apps/macos-overlay/Sources/Views/HoverRevealText.swift
@@ -59,7 +59,8 @@ public struct HoverRevealText: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(10)
                 }
-                .frame(width: popoverWidth, maxHeight: 240)
+                .frame(width: popoverWidth)
+                .frame(maxHeight: 240)
             }
     }
 

--- a/apps/macos-overlay/Sources/Views/HoverRevealText.swift
+++ b/apps/macos-overlay/Sources/Views/HoverRevealText.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+/// A compact text label that keeps the normal layout truncated, but reveals the
+/// complete value in a small native popover after a short hover dwell.
+///
+/// Use this anywhere a user-facing string is intentionally line-limited. The
+/// component does not reveal content while privacy mode is active.
+public struct HoverRevealText: View {
+    public let text: String
+    public let font: Font
+    public let foregroundColor: Color
+    public let lineLimit: Int?
+    public let truncationMode: Text.TruncationMode
+    public let privacyBlur: Bool
+    public let alignment: TextAlignment
+    public let popoverWidth: CGFloat
+
+    @State private var isPresented = false
+    @State private var hoverGeneration = 0
+
+    public init(
+        _ text: String,
+        font: Font = .system(size: 10),
+        foregroundColor: Color = .white,
+        lineLimit: Int? = 1,
+        truncationMode: Text.TruncationMode = .tail,
+        privacyBlur: Bool = false,
+        alignment: TextAlignment = .leading,
+        popoverWidth: CGFloat = 340
+    ) {
+        self.text = text
+        self.font = font
+        self.foregroundColor = foregroundColor
+        self.lineLimit = lineLimit
+        self.truncationMode = truncationMode
+        self.privacyBlur = privacyBlur
+        self.alignment = alignment
+        self.popoverWidth = popoverWidth
+    }
+
+    public var body: some View {
+        Text(text)
+            .font(font)
+            .foregroundColor(foregroundColor)
+            .lineLimit(lineLimit)
+            .truncationMode(truncationMode)
+            .multilineTextAlignment(alignment)
+            .blur(radius: privacyBlur ? 4.5 : 0)
+            .contentShape(Rectangle())
+            .onHover(perform: handleHover)
+            .popover(isPresented: $isPresented, arrowEdge: .bottom) {
+                ScrollView(.vertical, showsIndicators: true) {
+                    Text(text)
+                        .font(font)
+                        .foregroundColor(.primary)
+                        .multilineTextAlignment(.leading)
+                        .textSelection(.enabled)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(10)
+                }
+                .frame(width: popoverWidth, maxHeight: 240)
+            }
+    }
+
+    private func handleHover(_ inside: Bool) {
+        hoverGeneration += 1
+        let generation = hoverGeneration
+
+        guard !privacyBlur, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            isPresented = false
+            return
+        }
+
+        let delay = inside ? 0.22 : 0.16
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            guard generation == hoverGeneration else { return }
+            withAnimation(.easeInOut(duration: 0.12)) {
+                isPresented = inside
+            }
+        }
+    }
+}

--- a/apps/macos-overlay/Sources/Views/InspectorSkillsToolsView.swift
+++ b/apps/macos-overlay/Sources/Views/InspectorSkillsToolsView.swift
@@ -1,0 +1,121 @@
+import SwiftUI
+
+/// Keeps the existing Skills / MCP visibility in the refreshed Inspector while
+/// using the same hover-to-reveal behavior as the rest of the app.
+public struct InspectorSkillsToolsView: View {
+    public let run: TaskRun
+    @State private var expanded = false
+
+    public init(run: TaskRun) {
+        self.run = run
+    }
+
+    private var skills: [SkillUsage] { run.skillsUsed ?? [] }
+    private var tools: [ToolCallInfo] { run.toolsUsed ?? [] }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    expanded.toggle()
+                }
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "square.grid.2x2.fill")
+                        .font(.system(size: 8))
+                        .foregroundColor(.purple)
+                    Text(L("Skills & Tools", "技能与工具"))
+                        .font(.system(size: 8.8, weight: .bold, design: .rounded))
+                        .foregroundColor(.white.opacity(0.7))
+                    Spacer()
+                    Text(L("\(skills.count) skills · \(tools.count) tools", "\(skills.count) 个技能 · \(tools.count) 个工具"))
+                        .font(.system(size: 7.3, weight: .medium))
+                        .foregroundColor(.white.opacity(0.38))
+                    Image(systemName: expanded ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 7, weight: .bold))
+                        .foregroundColor(.white.opacity(0.35))
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if expanded {
+                if !skills.isEmpty {
+                    compactSection(title: L("Skills", "技能"), icon: "sparkles", tint: .purple) {
+                        ForEach(skills) { skill in
+                            compactItem(
+                                text: skill.name,
+                                trailing: skill.count.map { "×\($0)" },
+                                tint: .purple
+                            )
+                        }
+                    }
+                }
+
+                if !tools.isEmpty {
+                    compactSection(title: L("Tools", "工具"), icon: "wrench.and.screwdriver.fill", tint: .teal) {
+                        ForEach(tools) { tool in
+                            compactItem(
+                                text: tool.displayName,
+                                trailing: tool.count.map { "×\($0)" },
+                                tint: tool.isMcp == true ? .cyan : .teal
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        .padding(8)
+        .background(
+            RoundedRectangle(cornerRadius: 9)
+                .fill(Color.white.opacity(0.035))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 9)
+                        .stroke(Color.white.opacity(0.07), lineWidth: 0.7)
+                )
+        )
+    }
+
+    private func compactSection<Content: View>(
+        title: String,
+        icon: String,
+        tint: Color,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Label(title, systemImage: icon)
+                .font(.system(size: 7.6, weight: .semibold))
+                .foregroundColor(tint.opacity(0.85))
+
+            VStack(spacing: 3) {
+                content()
+            }
+        }
+    }
+
+    private func compactItem(text: String, trailing: String?, tint: Color) -> some View {
+        HStack(spacing: 5) {
+            Circle()
+                .fill(tint.opacity(0.85))
+                .frame(width: 4, height: 4)
+
+            HoverRevealText(
+                text,
+                font: .system(size: 8, weight: .medium, design: .monospaced),
+                foregroundColor: .white.opacity(0.68),
+                lineLimit: 1,
+                popoverWidth: 380
+            )
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            if let trailing {
+                Text(trailing)
+                    .font(.system(size: 7.2, weight: .bold, design: .monospaced))
+                    .foregroundColor(tint.opacity(0.75))
+            }
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(RoundedRectangle(cornerRadius: 6).fill(Color.white.opacity(0.022)))
+    }
+}

--- a/apps/macos-overlay/Sources/Views/StrategyModeView.swift
+++ b/apps/macos-overlay/Sources/Views/StrategyModeView.swift
@@ -55,6 +55,25 @@ public struct StrategyModeSnapshot {
     public let profiles: [StrategyProfileInfo]
 }
 
+private final class StrategyCommandCapture {
+    private let lock = NSLock()
+    private var data = Data()
+
+    func append(_ chunk: Data) {
+        guard !chunk.isEmpty else { return }
+        lock.lock()
+        data.append(chunk)
+        lock.unlock()
+    }
+
+    func string() -> String {
+        lock.lock()
+        let snapshot = data
+        lock.unlock()
+        return String(data: snapshot, encoding: .utf8) ?? ""
+    }
+}
+
 public enum StrategyModeService {
     public static func load() throws -> StrategyModeSnapshot {
         // `strategy show` deliberately returns 2 when the stored value is invalid.
@@ -134,13 +153,47 @@ public enum StrategyModeService {
             process.arguments = ["codex-flow"] + arguments
         }
 
+        let stdoutCapture = StrategyCommandCapture()
+        let stderrCapture = StrategyCommandCapture()
+        let stdoutEOF = DispatchSemaphore(value: 0)
+        let stderrEOF = DispatchSemaphore(value: 0)
+
         process.standardOutput = output
         process.standardError = error
+        output.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            if data.isEmpty {
+                handle.readabilityHandler = nil
+                stdoutEOF.signal()
+            } else {
+                stdoutCapture.append(data)
+            }
+        }
+        error.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            if data.isEmpty {
+                handle.readabilityHandler = nil
+                stderrEOF.signal()
+            } else {
+                stderrCapture.append(data)
+            }
+        }
+        defer {
+            output.fileHandleForReading.readabilityHandler = nil
+            error.fileHandleForReading.readabilityHandler = nil
+        }
+
         try process.run()
         process.waitUntilExit()
 
-        let stdout = String(data: output.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        let stderr = String(data: error.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        // stdout/stderr are drained concurrently while the process runs, so a
+        // verbose child cannot fill a pipe and deadlock waitUntilExit(). Give
+        // the EOF callbacks a bounded moment to flush their final chunks.
+        _ = stdoutEOF.wait(timeout: .now() + 1.0)
+        _ = stderrEOF.wait(timeout: .now() + 1.0)
+
+        let stdout = stdoutCapture.string()
+        let stderr = stderrCapture.string()
         guard acceptedExitCodes.contains(process.terminationStatus) else {
             let detail = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
             throw serviceError(detail.isEmpty
@@ -338,7 +391,8 @@ public struct StrategyModeCard: View {
                     snapshot = verified
                     applyingProfile = nil
                     isError = false
-                    message = L("Global strategy switched to \(profile).", "全局策略已切换为 \(profile)。")
+                    let displayName = verified.profiles.first(where: { $0.name == profile })?.localizedName ?? profile
+                    message = L("Global strategy switched to \(displayName).", "全局策略已切换为 \(displayName)。")
                 }
             } catch {
                 DispatchQueue.main.async {

--- a/apps/macos-overlay/Sources/Views/StrategyModeView.swift
+++ b/apps/macos-overlay/Sources/Views/StrategyModeView.swift
@@ -1,0 +1,322 @@
+import SwiftUI
+import Foundation
+
+public struct StrategyProfileInfo: Identifiable, Equatable {
+    public let name: String
+    public let description: String
+
+    public var id: String { name }
+
+    public var localizedName: String {
+        switch name {
+        case "efficient": return L("Efficient", "高效")
+        case "balanced": return L("Balanced", "均衡")
+        case "quality": return L("Quality", "质量")
+        case "speed": return L("Speed", "速度")
+        default: return name.capitalized
+        }
+    }
+
+    public var localizedDescription: String {
+        switch name {
+        case "efficient": return L("Minimize quota waste and expensive parent usage.", "优先降低额度浪费和高成本父 Agent 使用。")
+        case "balanced": return L("Balance quality, quota, and latency.", "在质量、额度与延迟之间取得平衡。")
+        case "quality": return L("Maximize correctness and independent verification.", "优先正确性、深度推理与独立验证。")
+        case "speed": return L("Minimize wall-clock time with safe parallelism.", "在安全并行边界内优先降低整体耗时。")
+        default: return description
+        }
+    }
+
+    public var iconName: String {
+        switch name {
+        case "efficient": return "leaf.fill"
+        case "balanced": return "scale.3d"
+        case "quality": return "checkmark.seal.fill"
+        case "speed": return "bolt.fill"
+        default: return "slider.horizontal.3"
+        }
+    }
+
+    public var accent: Color {
+        switch name {
+        case "efficient": return .green
+        case "balanced": return .cyan
+        case "quality": return .purple
+        case "speed": return .orange
+        default: return .cyan
+        }
+    }
+}
+
+public struct StrategyModeSnapshot {
+    public let configured: String
+    public let routing: String?
+    public let valid: Bool
+    public let profiles: [StrategyProfileInfo]
+}
+
+public enum StrategyModeService {
+    public static func load() throws -> StrategyModeSnapshot {
+        let show = try run(["strategy", "show", "--json"])
+        guard let data = show.stdout.data(using: .utf8),
+              let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let configured = json["strategy"] as? String else {
+            throw serviceError(L("Unable to parse the current strategy.", "无法解析当前策略。"))
+        }
+
+        let routing = json["routing"] as? String
+        let valid = (json["valid"] as? NSNumber)?.boolValue ?? false
+        let profilesOutput = try run(["strategy", "profiles"])
+        let profiles = parseProfiles(profilesOutput.stdout)
+        guard !profiles.isEmpty else {
+            throw serviceError(L("No strategy profiles were reported by codex-flow.", "codex-flow 未返回可用策略模式。"))
+        }
+
+        return StrategyModeSnapshot(
+            configured: configured,
+            routing: routing,
+            valid: valid,
+            profiles: profiles
+        )
+    }
+
+    public static func set(_ profile: String) throws -> StrategyModeSnapshot {
+        let before = try load()
+        guard before.profiles.contains(where: { $0.name == profile }) else {
+            throw serviceError(L("Unsupported strategy: \(profile)", "不支持的策略：\(profile)"))
+        }
+
+        _ = try run(["strategy", "set", profile])
+        let verified = try load()
+        guard verified.configured == profile, verified.valid else {
+            throw serviceError(L("Strategy change could not be verified.", "策略切换后无法验证配置结果。"))
+        }
+        return verified
+    }
+
+    private struct CommandResult {
+        let stdout: String
+        let stderr: String
+    }
+
+    private static func run(_ arguments: [String]) throws -> CommandResult {
+        let process = Process()
+        let output = Pipe()
+        let error = Pipe()
+        let codeHome = ProcessInfo.processInfo.environment["CODEX_HOME"]
+            .map(URL.init(fileURLWithPath:))
+            ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".codex")
+        let installedCLI = codeHome.appendingPathComponent("codex-flow/bin/codex-flow")
+
+        if FileManager.default.isExecutableFile(atPath: installedCLI.path) {
+            process.executableURL = installedCLI
+            process.arguments = arguments
+        } else {
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            process.arguments = ["codex-flow"] + arguments
+        }
+
+        process.standardOutput = output
+        process.standardError = error
+        try process.run()
+        process.waitUntilExit()
+
+        let stdout = String(data: output.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderr = String(data: error.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        guard process.terminationStatus == 0 else {
+            let detail = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            throw serviceError(detail.isEmpty
+                ? L("codex-flow strategy command failed.", "codex-flow 策略命令执行失败。")
+                : detail)
+        }
+        return CommandResult(stdout: stdout, stderr: stderr)
+    }
+
+    private static func parseProfiles(_ raw: String) -> [StrategyProfileInfo] {
+        raw.split(whereSeparator: \.isNewline).compactMap { line in
+            let text = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else { return nil }
+            let pieces = text.split(maxSplits: 1, whereSeparator: \.isWhitespace)
+            guard let first = pieces.first else { return nil }
+            let name = String(first)
+            let description = pieces.count > 1 ? String(pieces[1]).trimmingCharacters(in: .whitespaces) : ""
+            return StrategyProfileInfo(name: name, description: description)
+        }
+    }
+
+    private static func serviceError(_ message: String) -> NSError {
+        NSError(domain: "FlowPilot.Strategy", code: 1, userInfo: [NSLocalizedDescriptionKey: message])
+    }
+}
+
+public struct StrategyModeCard: View {
+    @ObservedObject private var localization = AppLocalization.shared
+    @State private var snapshot: StrategyModeSnapshot?
+    @State private var isLoading = false
+    @State private var applyingProfile: String?
+    @State private var message: String?
+    @State private var isError = false
+
+    public init() {}
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(spacing: 5) {
+                Label(L("Strategy mode", "策略模式"), systemImage: "slider.horizontal.3")
+                    .font(.system(size: 9.5, weight: .bold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.82))
+                Spacer()
+                if let current = snapshot?.configured {
+                    Text(current.uppercased())
+                        .font(.system(size: 7.5, weight: .heavy, design: .rounded))
+                        .foregroundColor(.cyan)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Capsule().fill(Color.cyan.opacity(0.12)))
+                }
+                Button(action: refresh) {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 8, weight: .semibold))
+                        .foregroundColor(.white.opacity(0.48))
+                }
+                .buttonStyle(.plain)
+                .disabled(isLoading || applyingProfile != nil)
+            }
+
+            if isLoading && snapshot == nil {
+                HStack(spacing: 6) {
+                    ProgressView().controlSize(.mini)
+                    Text(L("Reading strategy…", "正在读取策略…"))
+                        .font(.system(size: 8.5))
+                        .foregroundColor(.white.opacity(0.45))
+                }
+                .frame(maxWidth: .infinity, minHeight: 48)
+            } else if let snapshot {
+                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 6) {
+                    ForEach(snapshot.profiles) { profile in
+                        strategyButton(profile, current: snapshot.configured)
+                    }
+                }
+
+                HStack(spacing: 4) {
+                    Image(systemName: "info.circle")
+                        .font(.system(size: 7.5))
+                    Text(L("Changes are persisted through `codex-flow strategy set`. Repository policy can still override the global mode.", "切换通过 `codex-flow strategy set` 持久化；仓库级策略仍可覆盖全局模式。"))
+                        .font(.system(size: 7.5))
+                }
+                .foregroundColor(.white.opacity(0.35))
+
+                if let message {
+                    Text(message)
+                        .font(.system(size: 8, weight: .medium))
+                        .foregroundColor(isError ? .orange : .green)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            } else {
+                Text(message ?? L("Strategy data unavailable", "策略数据暂不可用"))
+                    .font(.system(size: 8.5, weight: .medium))
+                    .foregroundColor(.orange.opacity(0.85))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .padding(9)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color.white.opacity(0.04))
+                .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.white.opacity(0.08), lineWidth: 0.8))
+        )
+        .onAppear(perform: refresh)
+    }
+
+    private func strategyButton(_ profile: StrategyProfileInfo, current: String) -> some View {
+        let selected = profile.name == current
+        let pending = applyingProfile == profile.name
+        return Button {
+            apply(profile.name)
+        } label: {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 4) {
+                    Image(systemName: profile.iconName)
+                        .font(.system(size: 8.5, weight: .semibold))
+                        .foregroundColor(profile.accent)
+                    Text(profile.localizedName)
+                        .font(.system(size: 8.8, weight: .bold, design: .rounded))
+                        .foregroundColor(.white.opacity(selected ? 0.95 : 0.72))
+                    Spacer()
+                    if pending {
+                        ProgressView().controlSize(.mini)
+                    } else if selected {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 8.5))
+                            .foregroundColor(profile.accent)
+                    }
+                }
+                HoverRevealText(
+                    profile.localizedDescription,
+                    font: .system(size: 7.3),
+                    foregroundColor: .white.opacity(0.38),
+                    lineLimit: 2,
+                    popoverWidth: 320
+                )
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(7)
+            .frame(maxWidth: .infinity, minHeight: 52, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 7)
+                    .fill(selected ? profile.accent.opacity(0.12) : Color.white.opacity(0.025))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 7)
+                            .stroke(selected ? profile.accent.opacity(0.45) : Color.white.opacity(0.055), lineWidth: 0.7)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(applyingProfile != nil || selected)
+    }
+
+    private func refresh() {
+        guard !isLoading, applyingProfile == nil else { return }
+        isLoading = true
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                let value = try StrategyModeService.load()
+                DispatchQueue.main.async {
+                    snapshot = value
+                    message = nil
+                    isError = false
+                    isLoading = false
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    message = error.localizedDescription
+                    isError = true
+                    isLoading = false
+                }
+            }
+        }
+    }
+
+    private func apply(_ profile: String) {
+        guard applyingProfile == nil else { return }
+        applyingProfile = profile
+        message = nil
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                let verified = try StrategyModeService.set(profile)
+                DispatchQueue.main.async {
+                    snapshot = verified
+                    applyingProfile = nil
+                    isError = false
+                    message = L("Strategy switched to \(profile).", "策略已切换为 \(profile)。")
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    applyingProfile = nil
+                    isError = true
+                    message = error.localizedDescription
+                }
+            }
+        }
+    }
+}

--- a/apps/macos-overlay/Sources/Views/StrategyModeView.swift
+++ b/apps/macos-overlay/Sources/Views/StrategyModeView.swift
@@ -239,11 +239,11 @@ public struct StrategyModeCard: View {
                 Spacer()
                 if let snapshot {
                     if let routing = snapshot.routing, !routing.isEmpty {
-                        Text(routing.uppercased())
+                        Text(localizedRoutingName(routing))
                             .font(.system(size: 6.8, weight: .bold, design: .rounded))
                             .foregroundColor(.white.opacity(0.42))
                     }
-                    Text(snapshot.configured.uppercased())
+                    Text(localizedConfiguredName(snapshot))
                         .font(.system(size: 7.5, weight: .heavy, design: .rounded))
                         .foregroundColor(snapshot.valid ? .cyan : .orange)
                         .padding(.horizontal, 6)
@@ -309,6 +309,20 @@ public struct StrategyModeCard: View {
                 .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.white.opacity(0.08), lineWidth: 0.8))
         )
         .onAppear(perform: refresh)
+    }
+
+    private func localizedConfiguredName(_ snapshot: StrategyModeSnapshot) -> String {
+        snapshot.profiles.first(where: { $0.name == snapshot.configured })?.localizedName
+            ?? snapshot.configured.capitalized
+    }
+
+    private func localizedRoutingName(_ routing: String) -> String {
+        switch routing.lowercased() {
+        case "adaptive": return L("Adaptive", "自适应")
+        case "direct": return L("Direct", "直接")
+        case "delegate": return L("Delegate", "委派")
+        default: return routing.capitalized
+        }
     }
 
     private func strategyButton(_ profile: StrategyProfileInfo, current: String) -> some View {

--- a/apps/macos-overlay/Sources/Views/StrategyModeView.swift
+++ b/apps/macos-overlay/Sources/Views/StrategyModeView.swift
@@ -108,12 +108,25 @@ public enum StrategyModeService {
         let process = Process()
         let output = Pipe()
         let error = Pipe()
-        let codexHome = ProcessInfo.processInfo.environment["CODEX_HOME"]
+        let environment = ProcessInfo.processInfo.environment
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let codexHome = environment["CODEX_HOME"]
             .map(URL.init(fileURLWithPath:))
-            ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".codex")
-        let installedCLI = codexHome.appendingPathComponent("codex-flow/bin/codex-flow")
+            ?? home.appendingPathComponent(".codex")
 
-        if FileManager.default.isExecutableFile(atPath: installedCLI.path) {
+        // FlowPilot is commonly launched by Finder or a login item, where the
+        // process PATH does not include ~/.local/bin. Resolve the CLI locations
+        // used by install.sh directly before falling back to PATH lookup.
+        var candidates: [URL] = []
+        if let configuredBinDir = environment["CODEX_FLOW_BIN_DIR"], !configuredBinDir.isEmpty {
+            candidates.append(URL(fileURLWithPath: configuredBinDir).appendingPathComponent("codex-flow"))
+        }
+        candidates.append(home.appendingPathComponent(".local/bin/codex-flow"))
+        candidates.append(codexHome.appendingPathComponent("codex-flow/bin/codex-flow"))
+        candidates.append(URL(fileURLWithPath: "/opt/homebrew/bin/codex-flow"))
+        candidates.append(URL(fileURLWithPath: "/usr/local/bin/codex-flow"))
+
+        if let installedCLI = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0.path) }) {
             process.executableURL = installedCLI
             process.arguments = arguments
         } else {

--- a/apps/macos-overlay/Sources/Views/StrategyModeView.swift
+++ b/apps/macos-overlay/Sources/Views/StrategyModeView.swift
@@ -57,7 +57,9 @@ public struct StrategyModeSnapshot {
 
 public enum StrategyModeService {
     public static func load() throws -> StrategyModeSnapshot {
-        let show = try run(["strategy", "show", "--json"])
+        // `strategy show` deliberately returns 2 when the stored value is invalid.
+        // Accept that status so the app can still offer a supported profile to repair it.
+        let show = try run(["strategy", "show", "--json"], acceptedExitCodes: [0, 2])
         guard let data = show.stdout.data(using: .utf8),
               let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
               let configured = json["strategy"] as? String else {
@@ -99,14 +101,17 @@ public enum StrategyModeService {
         let stderr: String
     }
 
-    private static func run(_ arguments: [String]) throws -> CommandResult {
+    private static func run(
+        _ arguments: [String],
+        acceptedExitCodes: Set<Int32> = [0]
+    ) throws -> CommandResult {
         let process = Process()
         let output = Pipe()
         let error = Pipe()
-        let codeHome = ProcessInfo.processInfo.environment["CODEX_HOME"]
+        let codexHome = ProcessInfo.processInfo.environment["CODEX_HOME"]
             .map(URL.init(fileURLWithPath:))
             ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".codex")
-        let installedCLI = codeHome.appendingPathComponent("codex-flow/bin/codex-flow")
+        let installedCLI = codexHome.appendingPathComponent("codex-flow/bin/codex-flow")
 
         if FileManager.default.isExecutableFile(atPath: installedCLI.path) {
             process.executableURL = installedCLI
@@ -123,7 +128,7 @@ public enum StrategyModeService {
 
         let stdout = String(data: output.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
         let stderr = String(data: error.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        guard process.terminationStatus == 0 else {
+        guard acceptedExitCodes.contains(process.terminationStatus) else {
             let detail = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
             throw serviceError(detail.isEmpty
                 ? L("codex-flow strategy command failed.", "codex-flow 策略命令执行失败。")
@@ -162,17 +167,22 @@ public struct StrategyModeCard: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 7) {
             HStack(spacing: 5) {
-                Label(L("Strategy mode", "策略模式"), systemImage: "slider.horizontal.3")
+                Label(L("Global strategy mode", "全局策略模式"), systemImage: "slider.horizontal.3")
                     .font(.system(size: 9.5, weight: .bold, design: .rounded))
                     .foregroundColor(.white.opacity(0.82))
                 Spacer()
-                if let current = snapshot?.configured {
-                    Text(current.uppercased())
+                if let snapshot {
+                    if let routing = snapshot.routing, !routing.isEmpty {
+                        Text(routing.uppercased())
+                            .font(.system(size: 6.8, weight: .bold, design: .rounded))
+                            .foregroundColor(.white.opacity(0.42))
+                    }
+                    Text(snapshot.configured.uppercased())
                         .font(.system(size: 7.5, weight: .heavy, design: .rounded))
-                        .foregroundColor(.cyan)
+                        .foregroundColor(snapshot.valid ? .cyan : .orange)
                         .padding(.horizontal, 6)
                         .padding(.vertical, 2)
-                        .background(Capsule().fill(Color.cyan.opacity(0.12)))
+                        .background(Capsule().fill((snapshot.valid ? Color.cyan : Color.orange).opacity(0.12)))
                 }
                 Button(action: refresh) {
                     Image(systemName: "arrow.clockwise")
@@ -192,16 +202,23 @@ public struct StrategyModeCard: View {
                 }
                 .frame(maxWidth: .infinity, minHeight: 48)
             } else if let snapshot {
+                if !snapshot.valid {
+                    Text(L("The stored strategy is invalid. Choose a supported mode below to repair it.", "当前保存的策略无效，请在下方选择一个受支持模式进行修复。"))
+                        .font(.system(size: 7.8, weight: .medium))
+                        .foregroundColor(.orange.opacity(0.88))
+                }
+
                 LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 6) {
                     ForEach(snapshot.profiles) { profile in
                         strategyButton(profile, current: snapshot.configured)
                     }
                 }
 
-                HStack(spacing: 4) {
+                HStack(alignment: .top, spacing: 4) {
                     Image(systemName: "info.circle")
                         .font(.system(size: 7.5))
-                    Text(L("Changes are persisted through `codex-flow strategy set`. Repository policy can still override the global mode.", "切换通过 `codex-flow strategy set` 持久化；仓库级策略仍可覆盖全局模式。"))
+                        .padding(.top, 1)
+                    Text(L("This changes the global policy through `codex-flow strategy set`. A repository `.codex-flow.toml` remains higher priority for tasks in that repository.", "这里通过 `codex-flow strategy set` 修改全局策略；具体仓库中的 `.codex-flow.toml` 对该仓库任务仍具有更高优先级。"))
                         .font(.system(size: 7.5))
                 }
                 .foregroundColor(.white.opacity(0.35))
@@ -308,7 +325,7 @@ public struct StrategyModeCard: View {
                     snapshot = verified
                     applyingProfile = nil
                     isError = false
-                    message = L("Strategy switched to \(profile).", "策略已切换为 \(profile)。")
+                    message = L("Global strategy switched to \(profile).", "全局策略已切换为 \(profile)。")
                 }
             } catch {
                 DispatchQueue.main.async {

--- a/apps/macos-overlay/Sources/Views/SummaryView.swift
+++ b/apps/macos-overlay/Sources/Views/SummaryView.swift
@@ -1,1316 +1,747 @@
 import SwiftUI
 import AppKit
 
-// MARK: - Metric Progress Ring Component
-public struct MetricRingView: View {
-    public var title: String
-    public var value: String
-    public var progress: Double // 0.0 to 1.0
-    public var ringColor: Color
-    public var secondaryColor: Color
-    public var iconName: String?
-    
-    public init(
-        title: String,
-        value: String,
-        progress: Double = 0.75,
-        ringColor: Color = .cyan,
-        secondaryColor: Color = .blue,
-        iconName: String? = nil
-    ) {
-        self.title = title
-        self.value = value
-        let cleanProgress = progress.isFinite ? progress : 0.04
-        self.progress = min(max(cleanProgress, 0.04), 1.0)
-        self.ringColor = ringColor
-        self.secondaryColor = secondaryColor
-        self.iconName = iconName
-    }
-    
-    public var body: some View {
-        VStack(spacing: 5) {
-            ZStack {
-                // Background track
-                Circle()
-                    .stroke(Color.white.opacity(0.08), lineWidth: 3.5)
-                    .frame(width: 40, height: 40)
-                
-                // Progress stroke
-                Circle()
-                    .trim(from: 0.0, to: CGFloat(progress))
-                    .stroke(
-                        AngularGradient(
-                            colors: [ringColor, secondaryColor, ringColor],
-                            center: .center
-                        ),
-                        style: StrokeStyle(lineWidth: 3.5, lineCap: .round)
-                    )
-                    .rotationEffect(.degrees(-90))
-                    .frame(width: 40, height: 40)
-                    .shadow(color: ringColor.opacity(0.35), radius: 2.5)
-                
-                // Value or icon inside ring
-                if let icon = iconName {
-                    Image(systemName: icon)
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundColor(.white.opacity(0.9))
-                } else {
-                    Circle()
-                        .fill(Color.white.opacity(0.05))
-                        .frame(width: 26, height: 26)
-                }
-            }
-            
-            VStack(spacing: 1) {
-                Text(title)
-                    .font(.system(size: 8.5, weight: .medium, design: .rounded))
-                    .foregroundColor(.white.opacity(0.55))
-                    .textCase(.uppercase)
-                    .lineLimit(1)
-                
-                Text(value)
-                    .font(.system(size: 12, weight: .bold, design: .rounded))
-                    .foregroundColor(.white)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.75)
-            }
-        }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 6)
-        .padding(.horizontal, 2)
-        .background(
-            RoundedRectangle(cornerRadius: 10)
-                .fill(Color.white.opacity(0.04))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.white.opacity(0.08), lineWidth: 0.8)
-                )
-        )
-    }
-}
-
-// MARK: - Quota & Rate Limit Windows Meter
-public struct QuotaWindowsView: View {
-    @ObservedObject private var localization = AppLocalization.shared
-    public var windows: [QuotaWindow]
-    
-    public init(windows: [QuotaWindow]) {
-        self.windows = windows
-    }
-    
-    public var body: some View {
-        if !windows.isEmpty {
-            VStack(alignment: .leading, spacing: 5) {
-                HStack {
-                    HStack(spacing: 4) {
-                        Image(systemName: "gauge.with.needle.fill")
-                            .font(.system(size: 9))
-                            .foregroundColor(.cyan)
-                        Text(L("Rate Limits & Account Quota", "速率限制与账户配额"))
-                            .font(.system(size: 9.5, weight: .semibold, design: .rounded))
-                            .foregroundColor(.white.opacity(0.85))
-                            .lineLimit(1)
-                    }
-                    
-                    Spacer(minLength: 4)
-                    
-                    if let firstReset = windows.compactMap({ $0.localizedFormattedResetsAt }).first {
-                        Text(firstReset)
-                            .font(.system(size: 8.0, weight: .regular))
-                            .foregroundColor(.white.opacity(0.45))
-                            .lineLimit(1)
-                    }
-                }
-                
-                HStack(spacing: 5) {
-                    ForEach(windows) { window in
-                        quotaWindowPill(window: window)
-                    }
-                }
-            }
-            .padding(8)
-            .background(
-                RoundedRectangle(cornerRadius: 10)
-                    .fill(Color.white.opacity(0.04))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 10)
-                            .stroke(Color.white.opacity(0.08), lineWidth: 0.8)
-                    )
-            )
-        }
-    }
-    
-    private func quotaWindowPill(window: QuotaWindow) -> some View {
-        let used = window.usedPercent ?? 0.0
-        let rem = window.remainingPercent
-        let color = used > 80 ? Color.orange : (used > 50 ? Color.yellow : Color.cyan)
-        let delta = window.deltaPercentagePoints
-        
-        return VStack(alignment: .leading, spacing: 3) {
-            HStack {
-                Text(window.label)
-                    .font(.system(size: 8.5, weight: .bold, design: .monospaced))
-                    .foregroundColor(.white.opacity(0.85))
-                    .lineLimit(1)
-                
-                Spacer(minLength: 4)
-                
-                if let d = delta, abs(d) >= 0.01 {
-                    Text(String(format: L("本次 %+.1f%%", "本次 %+.1f%%"), d))
-                        .font(.system(size: 8.0, weight: .bold, design: .rounded))
-                        .foregroundColor(d > 0 ? .orange : Color(red: 0.2, green: 0.85, blue: 0.45))
-                } else if delta != nil {
-                    Text(L("本次 0%", "本次 0%"))
-                        .font(.system(size: 7.5, weight: .regular))
-                        .foregroundColor(.white.opacity(0.4))
-                }
-                
-                Text(String(format: L("· 剩余 %.0f%%", "· 剩余 %.0f%%"), rem))
-                    .font(.system(size: 8.0, weight: .semibold, design: .rounded))
-                    .foregroundColor(color)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.8)
-            }
-            
-            // Progress Bar
-            GeometryReader { geo in
-                let w = geo.size.width
-                let fillW = max(0, min(w, w * CGFloat(used / 100.0)))
-                ZStack(alignment: .leading) {
-                    Capsule()
-                        .fill(Color.white.opacity(0.1))
-                    Capsule()
-                        .fill(color)
-                        .frame(width: fillW)
-                }
-            }
-            .frame(height: 3)
-        }
-        .frame(maxWidth: .infinity)
-        .padding(.horizontal, 6)
-        .padding(.vertical, 4)
-        .background(
-            RoundedRectangle(cornerRadius: 6)
-                .fill(Color.white.opacity(0.03))
-        )
-    }
-}
-
-// MARK: - Token Segmented Distribution Bar
-public struct TokenDistributionBar: View {
-    @ObservedObject private var localization = AppLocalization.shared
-    public var usage: TokenUsage
-    
-    public init(usage: TokenUsage) {
-        self.usage = usage
-    }
-    
-    private var prompt: Int { usage.effectivePromptTokens }
-    private var completion: Int { usage.effectiveOutputTokens }
-    private var cached: Int { usage.effectiveCachedTokens }
-    private var reasoning: Int { usage.effectiveReasoningTokens }
-    private var rawTotal: Int { usage.totalTokens ?? (prompt + completion) }
-    private var total: Int { max(rawTotal, 1) }
-    
-    private var promptOnly: Int { max(0, prompt - cached) }
-    
-    private var promptOnlyRatio: CGFloat { rawTotal > 0 ? CGFloat(promptOnly) / CGFloat(total) : 0 }
-    private var cachedRatio: CGFloat { rawTotal > 0 ? CGFloat(cached) / CGFloat(total) : 0 }
-    private var completionRatio: CGFloat { rawTotal > 0 ? CGFloat(max(0, completion - reasoning)) / CGFloat(total) : 0 }
-    private var reasoningRatio: CGFloat { rawTotal > 0 ? CGFloat(reasoning) / CGFloat(total) : 0 }
-    
-    public var body: some View {
-        VStack(alignment: .leading, spacing: 5) {
-            headerRow
-            progressBar
-            legendRow
-        }
-        .padding(8)
-        .background(
-            RoundedRectangle(cornerRadius: 10)
-                .fill(Color.white.opacity(0.04))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.white.opacity(0.08), lineWidth: 0.8)
-                )
-        )
-    }
-    
-    private var headerRow: some View {
-        HStack {
-            Text(L("Token Distribution", "Token 分布"))
-                .font(.system(size: 9.5, weight: .semibold, design: .rounded))
-                .foregroundColor(.white.opacity(0.85))
-                .lineLimit(1)
-            
-            Spacer(minLength: 4)
-            
-            Text(L("Total: \(TaskRun.formatTokenCount(usage.totalTokens ?? (prompt + completion)))", "总计：\(TaskRun.formatTokenCount(usage.totalTokens ?? (prompt + completion)))"))
-                .font(.system(size: 9.5, weight: .semibold, design: .rounded))
-                .foregroundColor(.white.opacity(0.6))
-                .lineLimit(1)
-        }
-    }
-    
-    private var progressBar: some View {
-        GeometryReader { geo in
-            let w = geo.size.width
-            HStack(spacing: 0) {
-                if rawTotal == 0 {
-                    Capsule()
-                        .fill(Color.white.opacity(0.08))
-                } else {
-                    if promptOnly > 0 {
-                        Rectangle()
-                            .fill(Color(red: 0.88, green: 0.35, blue: 0.82))
-                            .frame(width: max(2, w * promptOnlyRatio))
-                    }
-                    
-                    if cached > 0 {
-                        Rectangle()
-                            .fill(Color(red: 0.28, green: 0.58, blue: 0.95))
-                            .frame(width: max(2, w * cachedRatio))
-                    }
-                    
-                    if completion > 0 {
-                        Rectangle()
-                            .fill(Color(red: 0.22, green: 0.88, blue: 0.58))
-                            .frame(width: max(2, w * completionRatio))
-                        
-                        if reasoning > 0 {
-                            Rectangle()
-                                .fill(Color(red: 0.65, green: 0.45, blue: 0.95))
-                                .frame(width: max(2, w * reasoningRatio))
-                        }
-                    }
-                }
-            }
-        }
-        .frame(height: 5)
-        .clipShape(Capsule())
-        .background(Capsule().fill(Color.white.opacity(0.08)))
-    }
-    
-    private var legendRow: some View {
-        VStack(spacing: 3.5) {
-            // Row 1: Prompt & Output
-            HStack {
-                let promptPct = rawTotal > 0 ? Int(Double(prompt) / Double(total) * 100) : 0
-                legendItem(
-                    color: Color(red: 0.88, green: 0.35, blue: 0.82),
-                    label: L("Prompt", "输入"),
-                    count: TaskRun.formatTokenCount(prompt),
-                    pct: promptPct
-                )
-                
-                Spacer(minLength: 8)
-                
-                let compPct = rawTotal > 0 ? Int(Double(completion) / Double(total) * 100) : 0
-                legendItem(
-                    color: Color(red: 0.22, green: 0.88, blue: 0.58),
-                    label: L("Output", "输出"),
-                    count: TaskRun.formatTokenCount(completion),
-                    pct: compPct
-                )
-            }
-            
-            // Row 2: Cached & Reasoning (if present)
-            if cached > 0 || reasoning > 0 {
-                HStack {
-                    if cached > 0 {
-                        let cachedPct = Int(Double(cached) / Double(total) * 100)
-                        legendItem(
-                            color: Color(red: 0.28, green: 0.58, blue: 0.95),
-                            label: L("Cached", "缓存"),
-                            count: TaskRun.formatTokenCount(cached),
-                            pct: cachedPct
-                        )
-                    } else {
-                        Spacer()
-                    }
-                    
-                    Spacer(minLength: 8)
-                    
-                    if reasoning > 0 {
-                        let rPct = Int(Double(reasoning) / Double(total) * 100)
-                        legendItem(
-                            color: Color(red: 0.65, green: 0.45, blue: 0.95),
-                            label: L("Reason", "推理"),
-                            count: TaskRun.formatTokenCount(reasoning),
-                            pct: rPct
-                        )
-                    } else {
-                        Spacer()
-                    }
-                }
-            }
-        }
-        .padding(.top, 1)
-    }
-    
-    private func legendItem(color: Color, label: String, count: String, pct: Int) -> some View {
-        HStack(spacing: 3) {
-            Circle()
-                .fill(color)
-                .frame(width: 4.5, height: 4.5)
-            
-            Text(label)
-                .font(.system(size: 8.5, weight: .medium))
-                .foregroundColor(.white.opacity(0.6))
-            
-            Text("\(pct)%")
-                .font(.system(size: 8.5, weight: .bold, design: .rounded))
-                .foregroundColor(.white.opacity(0.95))
-            
-            Text("(\(count))")
-                .font(.system(size: 8.0, weight: .regular, design: .rounded))
-                .foregroundColor(.white.opacity(0.45))
-        }
-        .lineLimit(1)
-        .minimumScaleFactor(0.8)
-    }
-}
-
-// MARK: - Native Summary View Card
+/// Main expanded FlowPilot surface.
+///
+/// The Account surface is intentionally a UI-level fourth tab instead of a
+/// persisted `OverlayTab` enum case so older IPC clients that only know
+/// inspector/history/analytics remain wire-compatible.
 public struct SummaryView: View {
     @ObservedObject var state: OverlayState
     @ObservedObject private var localization = AppLocalization.shared
     public var isFullHeight: Bool = false
-    @State private var copiedSummary: Bool = false
-    @State private var isSummaryExpanded: Bool = true
-    @State private var isSkillsExpanded: Bool = false
-    @State private var isTrajectoryExpanded: Bool = false
-    @State private var isLogsExpanded: Bool = false
-    
+
+    @State private var showingAccount = false
+    @State private var copiedSummary = false
+
     public init(state: OverlayState, isFullHeight: Bool = false) {
         self.state = state
         self.isFullHeight = isFullHeight
     }
-    
+
     private var currentRun: TaskRun? {
-        return state.inspectedRun ?? state.latestRun
+        state.inspectedRun ?? state.latestRun
     }
-    
-    private var isViewingHistoricalTask: Bool {
-        if let inspected = state.inspectedRun, let latest = state.latestRun {
-            return inspected.id != latest.id
-        }
-        return state.inspectedRun != nil
-    }
-    
+
     public var body: some View {
-        VStack(alignment: .leading, spacing: 9) {
-            // MARK: 1. Top Bar (App Title & Window Controls)
+        VStack(spacing: 0) {
             topBar
-            
-            // MARK: 2. Glass Segmented Tab Bar
-            tabSegmentedBar
-            
-            // MARK: 3. Dynamic Content
-            switch state.activeTab {
-            case .inspector:
-                if let run = currentRun {
-                    activeInspectorScrollContent(run: run)
+            Divider().background(Color.white.opacity(0.07))
+            tabBar
+            Divider().background(Color.white.opacity(0.06))
+
+            Group {
+                if showingAccount {
+                    AccountView(state: state, isFullHeight: isFullHeight)
                 } else {
-                    idleInspectorContent
+                    switch state.activeTab {
+                    case .inspector:
+                        inspectorSurface
+                    case .history:
+                        HistoryView(state: state, isFullHeight: isFullHeight)
+                    case .analytics:
+                        AnalyticsView(state: state, isFullHeight: isFullHeight)
+                    }
                 }
-            case .history:
-                HistoryView(state: state, isFullHeight: isFullHeight)
-            case .analytics:
-                AnalyticsView(state: state, isFullHeight: isFullHeight)
             }
+            .padding(.horizontal, 10)
+            .padding(.bottom, 9)
         }
-        .padding(12)
-        .frame(width: 384)
-        .background(
-            RoundedRectangle(cornerRadius: 20)
-                .fill(.ultraThinMaterial)
-                .background(
-                    RoundedRectangle(cornerRadius: 20)
-                        .fill(
-                            LinearGradient(
-                                colors: [
-                                    Color(nsColor: .windowBackgroundColor).opacity(0.85),
-                                    Color.black.opacity(0.92)
-                                ],
-                                startPoint: .topLeading,
-                                endPoint: .bottomTrailing
-                            )
-                        )
-                )
-        )
+        .background(background)
+        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
         .overlay(
-            RoundedRectangle(cornerRadius: 20)
-                .stroke(
-                    LinearGradient(
-                        colors: [
-                            Color.white.opacity(0.2),
-                            Color.white.opacity(0.05),
-                            Color.cyan.opacity(0.2)
-                        ],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
-                    ),
-                    lineWidth: 1.0
-                )
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(Color.white.opacity(0.11), lineWidth: 0.8)
         )
-        .shadow(color: Color.black.opacity(0.4), radius: 16, x: 0, y: 8)
+        .onChange(of: state.activeTab) { _ in
+            // An IPC tab command should take precedence over the local Account tab.
+            if showingAccount {
+                showingAccount = false
+            }
+        }
     }
-    
-    // MARK: - Top Bar
+
+    // MARK: - Chrome
+
     private var topBar: some View {
-        HStack(spacing: 8) {
-            HStack(spacing: 6) {
-                Image(systemName: "sparkles")
-                    .font(.system(size: 12.5, weight: .bold))
-                    .foregroundStyle(
-                        LinearGradient(
-                            colors: [.cyan, .indigo],
-                            startPoint: .topLeading,
-                            endPoint: .bottomTrailing
-                        )
-                    )
-                
+        HStack(spacing: 7) {
+            FlowPilotLogoView(size: 29, showGlow: true, withBolt: false, text: "FP")
+                .frame(width: 29, height: 29)
+
+            VStack(alignment: .leading, spacing: 0) {
                 Text("FlowPilot")
-                    .font(.system(size: 13, weight: .bold, design: .rounded))
+                    .font(.system(size: 11.5, weight: .heavy, design: .rounded))
                     .foregroundColor(.white)
+                Text(statusText)
+                    .font(.system(size: 7.8, weight: .medium, design: .rounded))
+                    .foregroundColor(statusColor.opacity(0.85))
             }
-            
-            if state.activeTab == .inspector {
-                statusBadge
-            }
-            
+
             Spacer()
-            
-            // Pin Toggle Button
-            Button {
+
+            chromeButton(
+                icon: state.isPrivacyMode ? "eye.slash.fill" : "eye.fill",
+                tint: state.isPrivacyMode ? .orange : .white.opacity(0.55),
+                help: L("Privacy mode", "隐私模式")
+            ) {
+                state.isPrivacyMode.toggle()
+            }
+
+            chromeButton(
+                icon: state.isPinned ? "pin.fill" : "pin",
+                tint: state.isPinned ? .cyan : .white.opacity(0.55),
+                help: L("Pin window", "置顶窗口")
+            ) {
                 state.isPinned.toggle()
-            } label: {
-                Image(systemName: state.isPinned ? "pin.fill" : "pin")
-                    .font(.system(size: 10.5, weight: .semibold))
-                    .foregroundColor(state.isPinned ? .cyan : .white.opacity(0.5))
-                    .frame(width: 22, height: 22)
-                    .background(
-                        Circle()
-                            .fill(state.isPinned ? Color.cyan.opacity(0.2) : Color.white.opacity(0.06))
-                    )
             }
-            .buttonStyle(.plain)
-            
-            // Collapse Button
-            Button {
+
+            chromeButton(
+                icon: "chevron.down",
+                tint: .white.opacity(0.55),
+                help: L("Collapse", "收起")
+            ) {
                 state.collapse()
-            } label: {
-                Image(systemName: "chevron.up.circle.fill")
-                    .font(.system(size: 13.5))
-                    .foregroundColor(.white.opacity(0.4))
-                    .frame(width: 22, height: 22)
             }
-            .buttonStyle(.plain)
         }
+        .padding(.horizontal, 11)
+        .padding(.vertical, 8)
     }
-    
-    // MARK: - Glass Segmented Tab Bar
-    private var tabSegmentedBar: some View {
-        HStack(spacing: 4) {
+
+    private func chromeButton(icon: String, tint: Color, help: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(tint)
+                .frame(width: 23, height: 23)
+                .background(Circle().fill(Color.white.opacity(0.045)))
+        }
+        .buttonStyle(.plain)
+        .help(help)
+    }
+
+    private var tabBar: some View {
+        HStack(spacing: 3) {
             ForEach(OverlayTab.allCases) { tab in
-                let isSelected = state.activeTab == tab
-                Button {
-                    withAnimation(.easeInOut(duration: 0.15)) {
-                        state.selectTab(tab)
-                    }
-                } label: {
-                    HStack(spacing: 5) {
-                        Image(systemName: tab.iconName)
-                            .font(.system(size: 10, weight: isSelected ? .bold : .medium))
-                        Text(tab.localizedTitle)
-                            .font(.system(size: 11, weight: isSelected ? .bold : .medium, design: .rounded))
-                    }
-                    .foregroundColor(isSelected ? .white : .white.opacity(0.6))
-                    .frame(maxWidth: .infinity, minHeight: 27)
-                    .contentShape(RoundedRectangle(cornerRadius: 8))
-                    .background(
-                        RoundedRectangle(cornerRadius: 8)
-                            .fill(isSelected ? Color.cyan.opacity(0.28) : Color.white.opacity(0.001))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .stroke(isSelected ? Color.cyan.opacity(0.45) : Color.clear, lineWidth: 0.8)
-                            )
-                    )
+                tabButton(
+                    title: tab.localizedTitle,
+                    icon: tab.iconName,
+                    selected: !showingAccount && state.activeTab == tab
+                ) {
+                    showingAccount = false
+                    state.selectTab(tab)
                 }
-                .buttonStyle(.plain)
+            }
+
+            tabButton(
+                title: L("Account", "账户"),
+                icon: "person.crop.circle.fill",
+                selected: showingAccount
+            ) {
+                showingAccount = true
             }
         }
-        .padding(3)
-        .background(
-            RoundedRectangle(cornerRadius: 10)
-                .fill(Color.white.opacity(0.06))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.white.opacity(0.08), lineWidth: 0.6)
-                )
-        )
+        .padding(4)
+        .background(Color.black.opacity(0.12))
     }
-    
-    // MARK: - Active Inspector Content (Scrollable Container)
-    private func activeInspectorScrollContent(run: TaskRun) -> some View {
-        let content = VStack(alignment: .leading, spacing: 8) {
-            // Historical Task Notice Bar
-            if isViewingHistoricalTask {
-                historicalTaskBanner
+
+    private func tabButton(title: String, icon: String, selected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 3) {
+                Image(systemName: icon)
+                    .font(.system(size: 7.8, weight: .semibold))
+                Text(title)
+                    .font(.system(size: 8.4, weight: selected ? .bold : .medium, design: .rounded))
+                    .lineLimit(1)
             }
-            
-            // Project & Branch + Session Preview
-            projectHeaderRow(run: run)
-            
-            // 1. Task Objective & Delivery Conclusion Card
-            if run.effectiveGoal != nil || run.effectiveConclusion != nil {
-                TaskSummaryCardView(run: run, isExpanded: $isSummaryExpanded, isPrivacyMode: state.isPrivacyMode)
-            }
-            
-            // 3 KPI Rings
-            HStack(spacing: 6) {
-                MetricRingView(
-                    title: L("Time", "耗时"),
-                    value: run.formattedDuration,
-                    progress: min(1.0, run.durationSeconds / 30.0),
-                    ringColor: Color.cyan,
-                    secondaryColor: Color.indigo
-                )
-                
-                MetricRingView(
-                    title: L("Tokens", "Token"),
-                    value: run.formattedTotalTokens,
-                    progress: min(1.0, Double(run.aggregatedUsage.totalTokens ?? 0) / 100_000.0),
-                    ringColor: Color(red: 0.95, green: 0.35, blue: 0.8),
-                    secondaryColor: Color(red: 0.6, green: 0.2, blue: 0.9)
-                )
-                
-                MetricRingView(
-                    title: L("Cost", "成本"),
-                    value: run.formattedCost,
-                    progress: min(1.0, (run.aggregatedUsage.estimatedCreditsMicros ?? 0) / 100_000.0),
-                    ringColor: Color(red: 0.2, green: 0.85, blue: 0.45),
-                    secondaryColor: Color.teal
-                )
-            }
-            
-            // Quota & Rate Limit Windows Meter
-            if !run.effectiveQuotaWindows.isEmpty {
-                QuotaWindowsView(windows: run.effectiveQuotaWindows)
-            }
-            
-            // Participants (Parent & Worker Topology)
-            participantsSection(run: run)
-            
-            if run.allWorkers.contains(where: {
-                !(($0.conclusion ?? "").trimmingCharacters(in: .whitespacesAndNewlines)).isEmpty
-            }) {
-                workerOutcomesSection(run: run)
-            }
-            
-            // Token Distribution Bar
-            TokenDistributionBar(usage: run.aggregatedUsage)
-            
-            // Skills & MCP Tools Badges Section
-            if run.hasSkillsOrTools {
-                SkillsAndToolsSectionView(run: run, isExpanded: $isSkillsExpanded)
-            }
-            
-            // Execution Trajectory Timeline Section
-            if run.hasTrajectory {
-                TrajectoryTimelineSectionView(run: run, isExpanded: $isTrajectoryExpanded)
-            }
-            
-            // Execution Logs Drawer Section
-            if run.hasLogs {
-                LogsSectionView(run: run, isExpanded: $isLogsExpanded)
-            }
-            
-            // Action Footer
-            actionFooter(run: run)
+            .foregroundColor(selected ? .white : .white.opacity(0.48))
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 4)
+            .background(
+                RoundedRectangle(cornerRadius: 7)
+                    .fill(selected ? Color.cyan.opacity(0.22) : Color.clear)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 7)
+                            .stroke(selected ? Color.cyan.opacity(0.32) : Color.clear, lineWidth: 0.6)
+                    )
+            )
         }
-        .padding(.vertical, 2)
-        
-        return Group {
+        .buttonStyle(.plain)
+    }
+
+    private var background: some View {
+        RoundedRectangle(cornerRadius: 18, style: .continuous)
+            .fill(
+                LinearGradient(
+                    colors: [
+                        Color(red: 0.055, green: 0.062, blue: 0.085).opacity(0.98),
+                        Color(red: 0.035, green: 0.041, blue: 0.058).opacity(0.98)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .shadow(color: .black.opacity(0.48), radius: 18, y: 8)
+    }
+
+    // MARK: - Inspector
+
+    @ViewBuilder
+    private var inspectorSurface: some View {
+        if let run = currentRun {
+            let content = VStack(spacing: 8) {
+                if state.inspectedRun != nil {
+                    historicalBanner
+                }
+                projectHeader(run)
+                metricsGrid(run)
+
+                if !run.effectiveQuotaWindows.isEmpty {
+                    QuotaWindowsView(windows: run.effectiveQuotaWindows)
+                }
+
+                taskNarrativeCard(run)
+                participantsCard(run)
+                TokenUsageBreakdownView(usage: run.aggregatedUsage)
+
+                if run.allWorkers.contains(where: { !($0.conclusion ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) {
+                    workerOutcomesCard(run)
+                }
+
+                if run.hasTrajectory {
+                    trajectoryCard(run)
+                }
+
+                if run.hasLogs {
+                    logsCard(run)
+                }
+
+                actionFooter(run)
+            }
+            .padding(.top, 8)
+
             if isFullHeight {
                 content
             } else {
-                ScrollView(.vertical, showsIndicators: false) {
+                ScrollView(.vertical, showsIndicators: true) {
                     content
                 }
                 .frame(maxHeight: 440)
             }
+        } else {
+            idleInspector
         }
     }
-    
-    // MARK: - Idle / Ready Inspector Content (Clean Zero/Cleared State)
-    private var idleInspectorContent: some View {
-        VStack(spacing: 12) {
-            ZStack {
-                Circle()
-                    .fill(Color.cyan.opacity(0.12))
-                    .frame(width: 54, height: 54)
-                
-                Image(systemName: "sparkles")
-                    .font(.system(size: 24, weight: .medium))
-                    .foregroundStyle(
-                        LinearGradient(
-                            colors: [.cyan, .indigo],
-                            startPoint: .topLeading,
-                            endPoint: .bottomTrailing
-                        )
-                    )
-            }
-            .padding(.top, 14)
-            
-            VStack(spacing: 4) {
-                Text(L("FlowPilot is Ready", "FlowPilot 已就绪"))
-                    .font(.system(size: 14, weight: .bold, design: .rounded))
-                    .foregroundColor(.white)
-                
-                Text(L("Listening for live agent runs & telemetry", "正在监听 Agent 任务与遥测数据"))
-                    .font(.system(size: 11, weight: .regular))
-                    .foregroundColor(.white.opacity(0.6))
-            }
-            
-            VStack(alignment: .leading, spacing: 6) {
-                HStack(spacing: 6) {
-                    Circle()
-                        .fill(Color(red: 0.2, green: 0.85, blue: 0.45))
-                        .frame(width: 6, height: 6)
-                    Text(L("Telemetry Hook:", "遥测 Hook："))
-                        .font(.system(size: 10, weight: .semibold))
-                        .foregroundColor(.white.opacity(0.7))
-                    Spacer()
-                    Text(L("Active & Streaming", "运行中 · 实时传输"))
-                        .font(.system(size: 10, weight: .medium))
-                        .foregroundColor(Color(red: 0.2, green: 0.85, blue: 0.45))
-                }
-                
-                HStack(spacing: 6) {
-                    Circle()
-                        .fill(Color.cyan)
-                        .frame(width: 6, height: 6)
-                    Text(L("IPC Daemon:", "IPC 守护进程："))
-                        .font(.system(size: 10, weight: .semibold))
-                        .foregroundColor(.white.opacity(0.7))
-                    Spacer()
-                    Text(L("Connected", "已连接"))
-                        .font(.system(size: 10, weight: .medium))
-                        .foregroundColor(.cyan)
-                }
-            }
-            .padding(10)
-            .background(
-                RoundedRectangle(cornerRadius: 9)
-                    .fill(Color.white.opacity(0.04))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 9)
-                            .stroke(Color.white.opacity(0.08), lineWidth: 0.8)
-                    )
-            )
-            
-            // Quick Actions
-            HStack(spacing: 8) {
-                Button {
-                    openConsole()
-                } label: {
-                    HStack(spacing: 4) {
-                        Image(systemName: "terminal.fill")
-                            .font(.system(size: 9.5))
-                        Text(L("Open Console", "打开控制台"))
-                            .font(.system(size: 10.5, weight: .semibold))
-                    }
-                    .foregroundColor(.white)
-                    .frame(maxWidth: .infinity, minHeight: 28)
-                    .background(
-                        RoundedRectangle(cornerRadius: 8)
-                            .fill(Color.cyan.opacity(0.3))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .stroke(Color.cyan.opacity(0.5), lineWidth: 0.8)
-                            )
-                    )
-                }
-                .buttonStyle(.plain)
-                
-                Button {
-                    state.selectTab(.history)
-                } label: {
-                    HStack(spacing: 4) {
-                        Image(systemName: "clock.arrow.circlepath")
-                            .font(.system(size: 9.5))
-                        Text(L("History", "历史"))
-                            .font(.system(size: 10.5, weight: .semibold))
-                    }
-                    .foregroundColor(.white.opacity(0.85))
-                    .frame(maxWidth: .infinity, minHeight: 28)
-                    .background(
-                        RoundedRectangle(cornerRadius: 8)
-                            .fill(Color.white.opacity(0.06))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .stroke(Color.white.opacity(0.1), lineWidth: 0.8)
-                            )
-                    )
-                }
-                .buttonStyle(.plain)
-            }
-            .padding(.bottom, 6)
-        }
-        .frame(maxWidth: .infinity)
-        .padding(.horizontal, 4)
-    }
-    
-    // MARK: - Historical Task Banner
-    private var historicalTaskBanner: some View {
+
+    private var historicalBanner: some View {
         HStack(spacing: 5) {
             Image(systemName: "clock.arrow.circlepath")
-                .font(.system(size: 9))
+                .font(.system(size: 8.5))
                 .foregroundColor(.cyan)
-            
-            Text(L("Viewing Historical Task", "正在查看历史任务"))
-                .font(.system(size: 9.5, weight: .semibold))
+            Text(L("Viewing historical task", "正在查看历史任务"))
+                .font(.system(size: 8.8, weight: .semibold))
                 .foregroundColor(.cyan)
-            
-            Spacer(minLength: 4)
-            
-            // Switch Task Menu
-            taskPickerMenu(
-                label: HStack(spacing: 3) {
-                    Image(systemName: "clock")
-                        .font(.system(size: 8))
-                    Text(L("Select Run", "选择任务"))
-                        .font(.system(size: 8.5, weight: .medium))
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 6.5))
-                }
-                .foregroundColor(.white.opacity(0.85))
-                .padding(.horizontal, 6)
-                .padding(.vertical, 2.5)
-                .background(
-                    Capsule()
-                        .fill(Color.white.opacity(0.1))
-                        .overlay(
-                            Capsule()
-                                .stroke(Color.white.opacity(0.15), lineWidth: 0.5)
-                        )
-                )
-            )
-            
+            Spacer()
             Button {
                 state.jumpToLive()
             } label: {
-                HStack(spacing: 3) {
-                    Image(systemName: "bolt.fill")
-                        .font(.system(size: 8))
-                    Text(L("Jump to Live", "返回当前任务"))
-                        .font(.system(size: 9, weight: .bold))
-                }
-                .foregroundColor(.white)
-                .padding(.horizontal, 7)
-                .padding(.vertical, 2.5)
-                .background(
-                    Capsule()
-                        .fill(Color.cyan.opacity(0.35))
-                )
+                Text(L("Live", "当前任务"))
+                    .font(.system(size: 8, weight: .bold))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Capsule().fill(Color.cyan.opacity(0.3)))
             }
             .buttonStyle(.plain)
         }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
-        .background(
-            RoundedRectangle(cornerRadius: 8)
-                .fill(Color.cyan.opacity(0.1))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(Color.cyan.opacity(0.25), lineWidth: 0.6)
-                )
-        )
-    }
-    
-    // MARK: - Project Header Row
-    private func projectHeaderRow(run: TaskRun) -> some View {
-        HStack(spacing: 6) {
-            // Project & Branch Chip with interactive switcher menu
-            taskPickerMenu(
-                label: HStack(spacing: 4) {
-                    Image(systemName: "folder.fill")
-                        .font(.system(size: 8.5))
-                        .foregroundColor(.white.opacity(0.65))
-                    
-                    Text(run.projectName)
-                        .font(.system(size: 10, weight: .semibold, design: .rounded))
-                        .foregroundColor(.white.opacity(0.95))
-                        .lineLimit(1)
-                        .blur(radius: state.isPrivacyMode ? 4.5 : 0)
-                    
-                    if let branch = run.gitBranch {
-                        Text("·")
-                            .foregroundColor(.white.opacity(0.35))
-                        
-                        Image(systemName: "point.topleft.down.curvedto.point.bottomright.up")
-                            .font(.system(size: 7.5))
-                            .foregroundColor(.cyan.opacity(0.85))
-                        
-                        Text(branch)
-                            .font(.system(size: 9.5, weight: .medium, design: .monospaced))
-                            .foregroundColor(.cyan.opacity(0.95))
-                            .lineLimit(1)
-                    }
-                    
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 7.0, weight: .bold))
-                        .foregroundColor(.white.opacity(0.5))
-                        .padding(.leading, 1)
-                }
-                .padding(.horizontal, 6)
-                .padding(.vertical, 3)
-                .background(
-                    Capsule()
-                        .fill(Color.white.opacity(0.08))
-                        .overlay(
-                            Capsule()
-                                .stroke(Color.white.opacity(0.12), lineWidth: 0.6)
-                        )
-                )
-            )
-            .layoutPriority(1)
-            
-            // Task Subtitle / Preview
-            if let preview = run.thread?.preview ?? run.summary, !preview.isEmpty {
-                Text(preview)
-                    .font(.system(size: 10, weight: .regular))
-                    .foregroundColor(.white.opacity(0.65))
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .blur(radius: state.isPrivacyMode ? 4.5 : 0)
-            }
-        }
-    }
-    
-    // MARK: - Task Picker Dropdown Menu
-    @ViewBuilder
-    private func taskPickerMenu<LabelContent: View>(label: LabelContent) -> some View {
-        if state.isPrivacyMode || isFullHeight {
-            label
-        } else {
-            Menu {
-                // 1. Live Task Option
-                if let latest = state.latestRun {
-                Section(L("Live Session", "当前会话")) {
-                    Button {
-                        state.jumpToLive()
-                    } label: {
-                        let isLiveActive = (state.inspectedRun == nil || state.inspectedRun?.id == latest.id)
-                        let check = isLiveActive ? "✓ " : ""
-                        let branch = latest.gitBranch.map { " (\($0))" } ?? ""
-                        Text(L("\(check)⚡ Live: \(latest.projectName)\(branch) · \(latest.localizedFormattedDate)", "\(check)⚡ 当前：\(latest.projectName)\(branch) · \(latest.localizedFormattedDate)"))
-                    }
-                }
-            }
-            
-            // 2. Recent Chats & Tasks
-            let historyChats = state.recentChats
-            if !historyChats.isEmpty {
-                Section(L("Recent Chats & Tasks", "最近对话任务")) {
-                    ForEach(Array(historyChats.enumerated()), id: \.element.id) { index, hChat in
-                        Button {
-                            if let latest = hChat.latestRun {
-                                if latest.id == state.latestRun?.id {
-                                    state.jumpToLive()
-                                } else {
-                                    state.inspect(run: latest)
-                                }
-                            }
-                        } label: {
-                            let isCurrent = (currentRun?.sessionId == hChat.sessionId)
-                            let check = isCurrent ? "✓ " : ""
-                            let branch = hChat.gitBranch.map { " (\($0))" } ?? ""
-                            let preview = (hChat.title)
-                                .replacingOccurrences(of: "\n", with: " ")
-                                .trimmingCharacters(in: .whitespaces)
-                            let shortPreview = preview.count > 24 ? String(preview.prefix(24)) + "..." : preview
-                            let countLabel = hChat.runs.count > 1 ? " (\(hChat.runs.count)s)" : ""
-                            let title = "#\(index + 1) \(hChat.projectName)\(branch)\(countLabel) · \(hChat.localizedFormattedDate) - \(shortPreview)"
-                            Text("\(check)\(title)")
-                        }
-                    }
-                }
-            }
-            
-            // 3. Project Quick Filter
-            let projects = state.allProjectsList
-            if projects.count > 1 {
-                Section(L("Filter History by Project", "按项目筛选历史")) {
-                    ForEach(projects, id: \.self) { proj in
-                        Button {
-                            state.selectedProject = proj
-                            state.selectTab(.history)
-                        } label: {
-                            Text("📁 \(proj)...")
-                        }
-                    }
-                }
-            }
-            
-            Divider()
-            
-            // 4. Open History Tab
-            Button {
-                state.selectTab(.history)
-            } label: {
-                Label(L("Browse All in History...", "浏览全部历史…"), systemImage: "clock.arrow.circlepath")
-            }
-        } label: {
-            label
-        }
-        .menuStyle(.borderlessButton)
-        .fixedSize()
-        }
-    }
-    
-    // MARK: - Status Badge
-    private var statusBadge: some View {
-        HStack(spacing: 4) {
-            Circle()
-                .fill(statusBadgeColor)
-                .frame(width: 5, height: 5)
-                .shadow(color: statusBadgeColor.opacity(0.8), radius: 2)
-            
-            Text(statusBadgeText)
-                .font(.system(size: 8.5, weight: .bold, design: .rounded))
-                .foregroundColor(statusBadgeColor)
-        }
-        .padding(.horizontal, 5.5)
-        .padding(.vertical, 2)
-        .background(
-            Capsule()
-                .fill(statusBadgeColor.opacity(0.12))
-                .overlay(
-                    Capsule()
-                        .stroke(statusBadgeColor.opacity(0.3), lineWidth: 0.5)
-                )
-        )
-    }
-    
-    private var statusBadgeColor: Color {
-        guard let run = currentRun else {
-            return Color(red: 0.2, green: 0.85, blue: 0.45)
-        }
-        if run.isRunning {
-            return .cyan
-        } else if run.isError {
-            return .orange
-        }
-        return Color(red: 0.2, green: 0.85, blue: 0.45)
-    }
-    
-    private var statusBadgeText: String {
-        guard let run = currentRun else {
-            return L("READY", "就绪")
-        }
-        if run.isRunning {
-            return L("RUNNING", "运行中")
-        } else if run.isError {
-            return L("FAILED", "失败")
-        }
-        return L("COMPLETED", "已完成")
-    }
-    
-    // MARK: - Participants Section
-    private func participantsSection(run: TaskRun) -> some View {
-        HStack(spacing: 6) {
-            // Parent Agent
-            VStack(alignment: .leading, spacing: 3) {
-                HStack(spacing: 3) {
-                    Image(systemName: "brain.head.profile")
-                        .font(.system(size: 9))
-                        .foregroundColor(.indigo.opacity(0.9))
-                    Text(L("Parent Model", "父 Agent 模型"))
-                        .font(.system(size: 9.0, weight: .semibold))
-                        .foregroundColor(.white.opacity(0.7))
-                }
-                
-                HStack(spacing: 3) {
-                    Text(run.parent?.displayModel ?? "Direct CLI")
-                        .font(.system(size: 10.5, weight: .bold, design: .rounded))
-                        .foregroundColor(.white)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                    
-                    if let effort = run.parent?.displayEffort {
-                        Text(effort)
-                            .font(.system(size: 7.5, weight: .medium))
-                            .foregroundColor(.indigo.opacity(0.9))
-                            .padding(.horizontal, 3)
-                            .padding(.vertical, 0.5)
-                            .background(
-                                Capsule()
-                                    .fill(Color.indigo.opacity(0.2))
-                            )
-                            .lineLimit(1)
-                    }
-                }
-                
-                let u = run.parent?.effectiveUsage?.totalTokens ?? 0
-                Text(L("\(TaskRun.formatTokenCount(u)) tokens", "\(TaskRun.formatTokenCount(u)) Token"))
-                    .font(.system(size: 8.5, weight: .regular))
-                    .foregroundColor(.white.opacity(0.5))
-                    .lineLimit(1)
-            }
-            .padding(6)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(Color.white.opacity(0.04))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 8)
-                            .stroke(Color.white.opacity(0.08), lineWidth: 0.8)
-                    )
-            )
-            
-            // Workers Section
-            VStack(alignment: .leading, spacing: 3) {
-                HStack(spacing: 3) {
-                    Image(systemName: "person.2.fill")
-                        .font(.system(size: 9))
-                        .foregroundColor(.teal.opacity(0.9))
-                    Text(L("Workers (\(run.allWorkers.count))", "Worker（\(run.allWorkers.count)）"))
-                        .font(.system(size: 9.0, weight: .semibold))
-                        .foregroundColor(.white.opacity(0.7))
-                }
-                
-                if run.allWorkers.isEmpty {
-                    VStack(alignment: .leading, spacing: 1) {
-                        Text(L("Direct Execution", "直接执行"))
-                            .font(.system(size: 10, weight: .medium))
-                            .foregroundColor(.white.opacity(0.75))
-                        Text(L("No subagents", "未使用子 Agent"))
-                            .font(.system(size: 8.5, weight: .regular))
-                            .foregroundColor(.white.opacity(0.4))
-                    }
-                } else {
-                    VStack(alignment: .leading, spacing: 2) {
-                        ForEach(run.allWorkers.prefix(2)) { worker in
-                            HStack(spacing: 3) {
-                                Text(worker.name ?? worker.displayModel)
-                                    .font(.system(size: 9, weight: .medium))
-                                    .foregroundColor(.white.opacity(0.85))
-                                    .lineLimit(1)
-                                    .truncationMode(.tail)
-                                
-                                Spacer(minLength: 2)
-                                
-                                if let tok = worker.effectiveUsage?.totalTokens {
-                                    Text(TaskRun.formatTokenCount(tok))
-                                        .font(.system(size: 8.0, weight: .semibold, design: .rounded))
-                                        .foregroundColor(.teal.opacity(0.9))
-                                        .lineLimit(1)
-                                }
-                            }
-                        }
-                        
-                        if run.allWorkers.count > 2 {
-                            Text(L("+\(run.allWorkers.count - 2) more subagents", "还有 \(run.allWorkers.count - 2) 个子 Agent"))
-                                .font(.system(size: 8.0, weight: .regular))
-                                .foregroundColor(.teal.opacity(0.7))
-                                .lineLimit(1)
-                        }
-                    }
-                }
-            }
-            .padding(6)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(Color.white.opacity(0.04))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 8)
-                            .stroke(Color.white.opacity(0.08), lineWidth: 0.8)
-                    )
-            )
-        }
-    }
-    
-    // MARK: - Worker Outcomes
-    @ViewBuilder
-    private func workerOutcomeCard(worker: ParticipantInfo) -> some View {
-        let title = worker.agentType ?? worker.name ?? L("Worker", "Worker")
-        let model = worker.displayModel
-        let conclusionText = (worker.conclusion ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        
-        VStack(alignment: .leading, spacing: 3) {
-            HStack(spacing: 4) {
-                Text(title)
-                    .font(.system(size: 9, weight: .semibold, design: .rounded))
-                    .foregroundColor(.white.opacity(0.9))
-                    .lineLimit(1)
-                Spacer(minLength: 4)
-                Text(model)
-                    .font(.system(size: 8, weight: .medium, design: .monospaced))
-                    .foregroundColor(.teal.opacity(0.8))
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-            }
-            
-            if !conclusionText.isEmpty {
-                Text(conclusionText)
-                    .font(.system(size: 9, weight: .regular))
-                    .foregroundColor(.white.opacity(0.68))
-                    .lineLimit(3)
-                    .textSelection(.enabled)
-            }
-        }
-        .padding(6)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 7)
-                .fill(Color.white.opacity(0.035))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 7)
-                        .stroke(Color.teal.opacity(0.14), lineWidth: 0.7)
-                )
-        )
+        .padding(7)
+        .background(cardBackground(tint: .cyan))
     }
 
-    private func workerOutcomesSection(run: TaskRun) -> some View {
-        let workers = run.allWorkers.filter { worker in
-            guard let conclusion = worker.conclusion else { return false }
-            return !conclusion.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        }
-        
-        return VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 4) {
-                Image(systemName: "checkmark.bubble.fill")
-                    .font(.system(size: 9))
-                    .foregroundColor(.teal.opacity(0.9))
-                Text(L("Worker Outcomes", "Worker 执行结果"))
-                    .font(.system(size: 9.5, weight: .semibold, design: .rounded))
-                    .foregroundColor(.white.opacity(0.85))
-                Spacer()
-                Text("\(workers.count)")
-                    .font(.system(size: 8.5, weight: .bold, design: .rounded))
-                    .foregroundColor(.teal.opacity(0.9))
+    private func projectHeader(_ run: TaskRun) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 5) {
+                Image(systemName: "folder.fill")
+                    .font(.system(size: 8))
+                    .foregroundColor(.white.opacity(0.48))
+
+                HoverRevealText(
+                    run.projectName,
+                    font: .system(size: 10, weight: .bold, design: .rounded),
+                    foregroundColor: .white.opacity(0.94),
+                    lineLimit: 1,
+                    privacyBlur: state.isPrivacyMode,
+                    popoverWidth: 300
+                )
+
+                if let branch = run.gitBranch, !branch.isEmpty {
+                    Text("·")
+                        .foregroundColor(.white.opacity(0.25))
+                    Image(systemName: "point.topleft.down.curvedto.point.bottomright.up")
+                        .font(.system(size: 7))
+                        .foregroundColor(.cyan.opacity(0.85))
+                    HoverRevealText(
+                        branch,
+                        font: .system(size: 8.8, weight: .medium, design: .monospaced),
+                        foregroundColor: .cyan.opacity(0.88),
+                        lineLimit: 1,
+                        privacyBlur: state.isPrivacyMode,
+                        popoverWidth: 320
+                    )
+                }
+
+                Spacer(minLength: 2)
+                statusBadge(run)
             }
-            
-            ForEach(workers) { worker in
-                workerOutcomeCard(worker: worker)
+
+            let preview = run.thread?.preview ?? run.summary ?? run.sessionTitle
+            HoverRevealText(
+                preview,
+                font: .system(size: 9.4),
+                foregroundColor: .white.opacity(0.63),
+                lineLimit: 1,
+                privacyBlur: state.isPrivacyMode,
+                popoverWidth: 380
+            )
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(8)
+        .background(cardBackground())
+    }
+
+    private func metricsGrid(_ run: TaskRun) -> some View {
+        let usage = run.aggregatedUsage
+        return HStack(spacing: 6) {
+            InspectorMetricView(
+                title: L("Time", "耗时"),
+                value: run.formattedDuration,
+                detail: L("wall time", "任务时长"),
+                icon: "timer",
+                accent: .cyan,
+                progress: min(1, run.durationSeconds / 600.0)
+            )
+
+            InspectorMetricView(
+                title: L("Tokens", "Token"),
+                value: run.formattedCompactTokens,
+                detail: L("total", "总用量"),
+                icon: "circle.grid.cross.fill",
+                accent: Color(red: 0.95, green: 0.35, blue: 0.8),
+                progress: min(1, Double(usage.totalTokens ?? 0) / 100_000.0)
+            )
+
+            // This intentionally replaces the old "Cost" ring. Credits are not
+            // monetary USD and are often unavailable, so presenting them as cost
+            // was both ambiguous and commonly blank.
+            InspectorMetricView(
+                title: L("Output", "输出"),
+                value: TaskRun.formatTokenCount(usage.effectiveOutputTokens),
+                detail: L("tokens", "Token"),
+                icon: "arrow.up.circle.fill",
+                accent: Color(red: 0.25, green: 0.88, blue: 0.58),
+                progress: outputShare(usage)
+            )
+        }
+    }
+
+    private func outputShare(_ usage: TokenUsage) -> Double {
+        let total = max(1, usage.totalTokens ?? 0)
+        return min(1, Double(usage.effectiveOutputTokens) / Double(total))
+    }
+
+    private func taskNarrativeCard(_ run: TaskRun) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            sectionHeader(icon: "sparkles.rectangle.stack.fill", title: L("Task Objective & Summary", "任务目标与概要说明"), tint: .cyan)
+
+            if let goal = run.effectiveGoal, !goal.isEmpty {
+                narrativeBlock(
+                    label: L("Objective", "目标"),
+                    icon: "target",
+                    text: goal,
+                    tint: .cyan,
+                    lineLimit: 3
+                )
+            }
+
+            if let conclusion = run.effectiveConclusion, !conclusion.isEmpty {
+                narrativeBlock(
+                    label: L("Outcome / Conclusion", "交付结论"),
+                    icon: "checkmark.seal.fill",
+                    text: conclusion,
+                    tint: Color(red: 0.25, green: 0.88, blue: 0.58),
+                    lineLimit: 4
+                )
             }
         }
         .padding(8)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 10)
-                .fill(Color.white.opacity(0.04))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.white.opacity(0.08), lineWidth: 0.8)
-                )
-        )
+        .background(cardBackground())
     }
-    
-    // MARK: - Action Footer
-    private func actionFooter(run: TaskRun) -> some View {
+
+    private func narrativeBlock(label: String, icon: String, text: String, tint: Color, lineLimit: Int) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 3) {
+                Image(systemName: icon)
+                    .font(.system(size: 7.5))
+                Text(label)
+                    .font(.system(size: 8.2, weight: .bold))
+            }
+            .foregroundColor(tint.opacity(0.9))
+
+            HoverRevealText(
+                text,
+                font: .system(size: 9.3),
+                foregroundColor: .white.opacity(0.88),
+                lineLimit: lineLimit,
+                privacyBlur: state.isPrivacyMode,
+                popoverWidth: 390
+            )
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(6)
+        .background(RoundedRectangle(cornerRadius: 7).fill(tint.opacity(0.07)))
+    }
+
+    private func participantsCard(_ run: TaskRun) -> some View {
         HStack(spacing: 6) {
-            // Copy Summary Button
-            Button {
-                copySummaryToClipboard(run: run)
-            } label: {
-                HStack(spacing: 3) {
-                    Image(systemName: copiedSummary ? "checkmark" : "doc.on.doc")
-                        .font(.system(size: 9, weight: .semibold))
-                    Text(copiedSummary ? L("Copied!", "已复制") : L("Copy", "复制"))
-                        .font(.system(size: 9.5, weight: .medium))
-                }
-                .foregroundColor(copiedSummary ? Color(red: 0.2, green: 0.85, blue: 0.45) : .white.opacity(0.85))
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
-                .background(
-                    RoundedRectangle(cornerRadius: 6)
-                        .fill(copiedSummary ? Color.green.opacity(0.15) : Color.white.opacity(0.06))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 6)
-                                .stroke(Color.white.opacity(0.1), lineWidth: 0.6)
+            participantBlock(
+                icon: "brain.head.profile",
+                title: L("Parent", "父 Agent"),
+                name: run.parent?.displayModel ?? L("Direct CLI", "直接 CLI"),
+                subtitle: participantSubtitle(run.parent),
+                tint: .indigo
+            )
+
+            let workerSummary: String
+            if run.allWorkers.isEmpty {
+                workerSummary = L("Direct execution", "直接执行")
+            } else if run.allWorkers.count == 1 {
+                workerSummary = run.allWorkers[0].name ?? run.allWorkers[0].displayModel
+            } else {
+                workerSummary = L("\(run.allWorkers.count) workers", "\(run.allWorkers.count) 个 Worker")
+            }
+
+            participantBlock(
+                icon: "person.2.fill",
+                title: L("Workers", "Worker"),
+                name: workerSummary,
+                subtitle: L("\(run.allWorkers.count) subagents", "\(run.allWorkers.count) 个子 Agent"),
+                tint: .teal
+            )
+        }
+    }
+
+    private func participantBlock(icon: String, title: String, name: String, subtitle: String, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 3) {
+                Image(systemName: icon)
+                    .font(.system(size: 8))
+                    .foregroundColor(tint.opacity(0.9))
+                Text(title)
+                    .font(.system(size: 8.5, weight: .semibold))
+                    .foregroundColor(.white.opacity(0.58))
+            }
+
+            HoverRevealText(
+                name,
+                font: .system(size: 9.8, weight: .bold, design: .rounded),
+                foregroundColor: .white.opacity(0.9),
+                lineLimit: 1,
+                privacyBlur: false,
+                popoverWidth: 280
+            )
+
+            Text(subtitle)
+                .font(.system(size: 7.8))
+                .foregroundColor(.white.opacity(0.4))
+                .lineLimit(1)
+        }
+        .padding(7)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(cardBackground())
+    }
+
+    private func participantSubtitle(_ participant: ParticipantInfo?) -> String {
+        guard let participant else { return L("No usage data", "暂无用量数据") }
+        let tokens = participant.effectiveUsage?.totalTokens ?? 0
+        if let effort = participant.displayEffort {
+            return "\(effort) · \(TaskRun.formatTokenCount(tokens)) tokens"
+        }
+        return "\(TaskRun.formatTokenCount(tokens)) tokens"
+    }
+
+    private func workerOutcomesCard(_ run: TaskRun) -> some View {
+        let workers = run.allWorkers.filter {
+            !($0.conclusion ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+
+        return VStack(alignment: .leading, spacing: 5) {
+            sectionHeader(icon: "checkmark.bubble.fill", title: L("Worker Outcomes", "Worker 执行结果"), tint: .teal)
+
+            ForEach(workers) { worker in
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 4) {
+                        HoverRevealText(
+                            worker.agentType ?? worker.name ?? L("Worker", "Worker"),
+                            font: .system(size: 8.7, weight: .semibold, design: .rounded),
+                            foregroundColor: .white.opacity(0.88),
+                            lineLimit: 1,
+                            popoverWidth: 300
                         )
-                )
+                        Spacer(minLength: 4)
+                        HoverRevealText(
+                            worker.displayModel,
+                            font: .system(size: 7.7, weight: .medium, design: .monospaced),
+                            foregroundColor: .teal.opacity(0.78),
+                            lineLimit: 1,
+                            popoverWidth: 280
+                        )
+                    }
+
+                    HoverRevealText(
+                        worker.conclusion ?? "",
+                        font: .system(size: 8.8),
+                        foregroundColor: .white.opacity(0.64),
+                        lineLimit: 3,
+                        privacyBlur: state.isPrivacyMode,
+                        popoverWidth: 390
+                    )
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .padding(6)
+                .background(RoundedRectangle(cornerRadius: 7).fill(Color.white.opacity(0.025)))
+            }
+        }
+        .padding(8)
+        .background(cardBackground())
+    }
+
+    private func trajectoryCard(_ run: TaskRun) -> some View {
+        let steps = run.trajectory ?? []
+        return VStack(alignment: .leading, spacing: 5) {
+            sectionHeader(icon: "point.filled.topleft.down.curvedto.point.bottomright.up", title: L("Execution Trajectory", "执行步骤轨迹"), tint: .indigo)
+
+            ForEach(Array(steps.prefix(8))) { step in
+                HStack(alignment: .top, spacing: 5) {
+                    Circle()
+                        .fill(step.status == "error" ? Color.orange : Color.cyan)
+                        .frame(width: 4.5, height: 4.5)
+                        .padding(.top, 4)
+
+                    VStack(alignment: .leading, spacing: 1) {
+                        HoverRevealText(
+                            step.title ?? step.name ?? "Step",
+                            font: .system(size: 8.7, weight: .semibold),
+                            foregroundColor: .white.opacity(0.82),
+                            lineLimit: 1,
+                            popoverWidth: 360
+                        )
+                        if let detail = step.detail, !detail.isEmpty {
+                            HoverRevealText(
+                                detail,
+                                font: .system(size: 7.8, design: .monospaced),
+                                foregroundColor: .white.opacity(0.5),
+                                lineLimit: 1,
+                                privacyBlur: state.isPrivacyMode,
+                                popoverWidth: 410
+                            )
+                        }
+                    }
+                }
+            }
+
+            if steps.count > 8 {
+                Text(L("+\(steps.count - 8) more steps", "还有 \(steps.count - 8) 个步骤"))
+                    .font(.system(size: 7.8))
+                    .foregroundColor(.white.opacity(0.38))
+            }
+        }
+        .padding(8)
+        .background(cardBackground())
+    }
+
+    private func logsCard(_ run: TaskRun) -> some View {
+        let logs = Array((run.logs ?? []).suffix(6))
+        return VStack(alignment: .leading, spacing: 4) {
+            sectionHeader(icon: "doc.text.magnifyingglass", title: L("Execution Logs", "执行日志流"), tint: .teal)
+
+            ForEach(logs) { entry in
+                HStack(alignment: .top, spacing: 4) {
+                    Circle()
+                        .fill(entry.level == "error" ? Color.orange : Color.green)
+                        .frame(width: 4, height: 4)
+                        .padding(.top, 4)
+                    HoverRevealText(
+                        entry.message ?? "",
+                        font: .system(size: 7.8, design: .monospaced),
+                        foregroundColor: entry.level == "error" ? .orange.opacity(0.85) : .white.opacity(0.65),
+                        lineLimit: 2,
+                        privacyBlur: state.isPrivacyMode,
+                        popoverWidth: 420
+                    )
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+        .padding(8)
+        .background(RoundedRectangle(cornerRadius: 9).fill(Color.black.opacity(0.28)).overlay(
+            RoundedRectangle(cornerRadius: 9).stroke(Color.white.opacity(0.06), lineWidth: 0.6)
+        ))
+    }
+
+    private func actionFooter(_ run: TaskRun) -> some View {
+        HStack(spacing: 6) {
+            Button {
+                copySummary(run)
+            } label: {
+                Label(copiedSummary ? L("Copied", "已复制") : L("Copy summary", "复制摘要"), systemImage: copiedSummary ? "checkmark" : "doc.on.doc")
+                    .font(.system(size: 8.6, weight: .semibold))
+                    .foregroundColor(copiedSummary ? .green : .white.opacity(0.75))
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 4)
+                    .background(RoundedRectangle(cornerRadius: 6).fill(Color.white.opacity(0.05)))
             }
             .buttonStyle(.plain)
-            
-            // Open Console Button
+
             Button {
                 openConsole()
             } label: {
-                HStack(spacing: 3) {
-                    Image(systemName: "terminal.fill")
-                        .font(.system(size: 9, weight: .semibold))
-                    Text(L("Console", "控制台"))
-                        .font(.system(size: 9.5, weight: .medium))
-                }
-                .foregroundColor(.white.opacity(0.85))
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
-                .background(
-                    RoundedRectangle(cornerRadius: 6)
-                        .fill(Color.white.opacity(0.06))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 6)
-                                .stroke(Color.white.opacity(0.1), lineWidth: 0.6)
-                        )
-                )
+                Label(L("Console", "控制台"), systemImage: "terminal.fill")
+                    .font(.system(size: 8.6, weight: .semibold))
+                    .foregroundColor(.white.opacity(0.75))
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 4)
+                    .background(RoundedRectangle(cornerRadius: 6).fill(Color.white.opacity(0.05)))
             }
             .buttonStyle(.plain)
-            
+
             Spacer()
-            
-            // Relative date / update time
+
             Text(run.localizedFormattedDate)
-                .font(.system(size: 8.5, weight: .regular))
-                .foregroundColor(.white.opacity(0.4))
+                .font(.system(size: 7.8))
+                .foregroundColor(.white.opacity(0.35))
         }
-        .padding(.top, 1)
     }
-    
-    private func copySummaryToClipboard(run: TaskRun) {
+
+    private var idleInspector: some View {
+        VStack(spacing: 10) {
+            FlowPilotLogoView(size: 58, showGlow: true, withBolt: true, text: "FlowPilot")
+                .frame(width: 58, height: 58)
+                .padding(.top, 20)
+            Text(L("FlowPilot is Ready", "FlowPilot 已就绪"))
+                .font(.system(size: 13, weight: .bold, design: .rounded))
+                .foregroundColor(.white)
+            Text(L("Listening for live task and usage telemetry", "正在监听任务与用量遥测"))
+                .font(.system(size: 9.5))
+                .foregroundColor(.white.opacity(0.48))
+            Button {
+                showingAccount = true
+            } label: {
+                Label(L("View Account Limits", "查看账户额度"), systemImage: "person.crop.circle")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundColor(.cyan)
+                    .padding(.horizontal, 9)
+                    .padding(.vertical, 5)
+                    .background(Capsule().fill(Color.cyan.opacity(0.12)))
+            }
+            .buttonStyle(.plain)
+            Spacer(minLength: 12)
+        }
+        .frame(maxWidth: .infinity, minHeight: 300)
+    }
+
+    // MARK: - Helpers
+
+    private func statusBadge(_ run: TaskRun) -> some View {
+        HStack(spacing: 3) {
+            Circle().fill(runStatusColor(run)).frame(width: 4.5, height: 4.5)
+            Text(runStatusText(run))
+                .font(.system(size: 7.4, weight: .bold, design: .rounded))
+        }
+        .foregroundColor(runStatusColor(run))
+        .padding(.horizontal, 5)
+        .padding(.vertical, 2)
+        .background(Capsule().fill(runStatusColor(run).opacity(0.12)))
+    }
+
+    private func runStatusColor(_ run: TaskRun) -> Color {
+        if run.isRunning { return .cyan }
+        if run.isError { return .orange }
+        return Color(red: 0.25, green: 0.88, blue: 0.58)
+    }
+
+    private func runStatusText(_ run: TaskRun) -> String {
+        if run.isRunning { return L("RUNNING", "运行中") }
+        if run.isError { return L("FAILED", "失败") }
+        return L("COMPLETED", "已完成")
+    }
+
+    private var statusText: String {
+        guard let run = currentRun else { return L("READY", "就绪") }
+        return runStatusText(run)
+    }
+
+    private var statusColor: Color {
+        guard let run = currentRun else { return Color(red: 0.25, green: 0.88, blue: 0.58) }
+        return runStatusColor(run)
+    }
+
+    private func sectionHeader(icon: String, title: String, tint: Color) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.system(size: 8))
+                .foregroundColor(tint)
+            Text(title)
+                .font(.system(size: 8.8, weight: .bold, design: .rounded))
+                .foregroundColor(.white.opacity(0.7))
+            Spacer()
+        }
+    }
+
+    private func cardBackground(tint: Color? = nil) -> some View {
+        RoundedRectangle(cornerRadius: 9)
+            .fill((tint ?? .white).opacity(tint == nil ? 0.04 : 0.07))
+            .overlay(
+                RoundedRectangle(cornerRadius: 9)
+                    .stroke((tint ?? .white).opacity(tint == nil ? 0.075 : 0.18), lineWidth: 0.7)
+            )
+    }
+
+    private func copySummary(_ run: TaskRun) {
+        let usage = run.aggregatedUsage
         let text = L(
             """
-            📊 FlowPilot Task Summary
-            • Project: \(run.projectName) (\(run.gitBranch ?? "main"))
-            • Duration: \(run.formattedDuration)
-            • Total Tokens: \(run.formattedTotalTokens)
-            • Estimated Cost: \(run.formattedCost)
-            • Parent Model: \(run.parent?.displayModel ?? "unknown")
-            • Workers: \(run.allWorkers.count)
-            • Overview: \(run.summary ?? run.sessionTitle)
+            FlowPilot Task Summary
+            Project: \(run.projectName) (\(run.gitBranch ?? "main"))
+            Duration: \(run.formattedDuration)
+            Total tokens: \(run.formattedTotalTokens)
+            Input tokens: \(TaskRun.formatTokenCount(usage.effectivePromptTokens))
+            Output tokens: \(TaskRun.formatTokenCount(usage.effectiveOutputTokens))
+            Cached input: \(TaskRun.formatTokenCount(usage.effectiveCachedTokens))
+            Parent: \(run.parent?.displayModel ?? "unknown")
+            Workers: \(run.allWorkers.count)
+            Summary: \(run.summary ?? run.sessionTitle)
             """,
             """
-            📊 FlowPilot 任务摘要
-            • 项目：\(run.projectName)（\(run.gitBranch ?? "main")）
-            • 耗时：\(run.formattedDuration)
-            • 总 Token：\(run.formattedTotalTokens)
-            • 预估成本：\(run.formattedCost)
-            • 父 Agent 模型：\(run.parent?.displayModel ?? "unknown")
-            • Worker：\(run.allWorkers.count)
-            • 摘要：\(run.summary ?? run.sessionTitle)
+            FlowPilot 任务摘要
+            项目：\(run.projectName)（\(run.gitBranch ?? "main")）
+            耗时：\(run.formattedDuration)
+            总 Token：\(run.formattedTotalTokens)
+            输入 Token：\(TaskRun.formatTokenCount(usage.effectivePromptTokens))
+            输出 Token：\(TaskRun.formatTokenCount(usage.effectiveOutputTokens))
+            缓存输入：\(TaskRun.formatTokenCount(usage.effectiveCachedTokens))
+            父 Agent：\(run.parent?.displayModel ?? "unknown")
+            Worker：\(run.allWorkers.count)
+            摘要：\(run.summary ?? run.sessionTitle)
             """
         )
-        
+
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(text, forType: .string)
-        
-        withAnimation {
-            copiedSummary = true
-        }
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-            withAnimation {
-                copiedSummary = false
-            }
+        copiedSummary = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            copiedSummary = false
         }
     }
-    
+
     private func openConsole() {
         let script = """
         tell application "Terminal"
@@ -1325,463 +756,194 @@ public struct SummaryView: View {
     }
 }
 
-// MARK: - Task Objective & Delivery Conclusion Card View
-public struct TaskSummaryCardView: View {
-    @ObservedObject private var localization = AppLocalization.shared
-    public var run: TaskRun
-    @Binding public var isExpanded: Bool
-    public var isPrivacyMode: Bool = false
-    
-    public init(run: TaskRun, isExpanded: Binding<Bool>, isPrivacyMode: Bool = false) {
-        self.run = run
-        self._isExpanded = isExpanded
-        self.isPrivacyMode = isPrivacyMode
-    }
-    
+// MARK: - Inspector Metric
+
+public struct InspectorMetricView: View {
+    public let title: String
+    public let value: String
+    public let detail: String
+    public let icon: String
+    public let accent: Color
+    public let progress: Double
+
     public var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            headerButton
-            if isExpanded {
-                expandedContent
+        VStack(spacing: 3) {
+            ZStack {
+                Circle()
+                    .stroke(Color.white.opacity(0.07), lineWidth: 3)
+                Circle()
+                    .trim(from: 0, to: CGFloat(max(0.015, min(1, progress))))
+                    .stroke(accent, style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                    .rotationEffect(.degrees(-90))
+                Image(systemName: icon)
+                    .font(.system(size: 8.5, weight: .semibold))
+                    .foregroundColor(accent)
             }
+            .frame(width: 29, height: 29)
+
+            Text(title)
+                .font(.system(size: 7.6, weight: .semibold, design: .rounded))
+                .foregroundColor(.white.opacity(0.48))
+                .textCase(.uppercase)
+
+            Text(value)
+                .font(.system(size: 10.5, weight: .bold, design: .rounded))
+                .foregroundColor(.white)
+                .lineLimit(1)
+
+            Text(detail)
+                .font(.system(size: 6.9))
+                .foregroundColor(.white.opacity(0.32))
+                .lineLimit(1)
         }
-        .padding(8)
-        .background(cardBackground)
-    }
-    
-    private var headerButton: some View {
-        Button(action: toggleExpanded) {
-            HStack(spacing: 4) {
-                Image(systemName: "sparkles.rectangle.stack.fill")
-                    .font(.system(size: 9))
-                    .foregroundColor(.cyan)
-                Text(L("Task Objective & Summary", "任务目标与概要说明"))
-                    .font(.system(size: 9.5, weight: .semibold, design: .rounded))
-                    .foregroundColor(.white.opacity(0.85))
-                Spacer(minLength: 0)
-                Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                    .font(.system(size: 7.5, weight: .bold))
-                    .foregroundColor(.white.opacity(0.4))
-            }
-            .padding(.vertical, 2)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-    }
-    
-    private func toggleExpanded() {
-        withAnimation(.easeInOut(duration: 0.2)) {
-            isExpanded.toggle()
-        }
-    }
-    
-    @ViewBuilder
-    private var expandedContent: some View {
-        VStack(alignment: .leading, spacing: 5) {
-            if let g = run.effectiveGoal, !g.isEmpty {
-                objectiveBox(goal: g)
-            }
-            if let c = run.effectiveConclusion, !c.isEmpty {
-                conclusionBox(conclusion: c)
-            }
-        }
-    }
-    
-    private func objectiveBox(goal: String) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
-            HStack(spacing: 3) {
-                Image(systemName: "target")
-                    .font(.system(size: 8))
-                    .foregroundColor(.cyan.opacity(0.9))
-                Text(L("Objective", "目标"))
-                    .font(.system(size: 8.5, weight: .bold))
-                    .foregroundColor(.cyan.opacity(0.9))
-            }
-            Text(goal)
-                .font(.system(size: 9.5, weight: .regular))
-                .foregroundColor(.white.opacity(0.9))
-                .lineLimit(3)
-                .blur(radius: isPrivacyMode ? 4.5 : 0)
-        }
-        .padding(6)
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 7)
         .background(
-            RoundedRectangle(cornerRadius: 6)
-                .fill(Color.cyan.opacity(0.08))
-                .overlay(RoundedRectangle(cornerRadius: 6).stroke(Color.cyan.opacity(0.2), lineWidth: 0.5))
+            RoundedRectangle(cornerRadius: 9)
+                .fill(Color.white.opacity(0.035))
+                .overlay(RoundedRectangle(cornerRadius: 9).stroke(Color.white.opacity(0.07), lineWidth: 0.7))
         )
-    }
-    
-    private func conclusionBox(conclusion: String) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
-            HStack(spacing: 3) {
-                Image(systemName: "checkmark.seal.fill")
-                    .font(.system(size: 8))
-                    .foregroundColor(Color(red: 0.2, green: 0.85, blue: 0.45))
-                Text(L("Outcome / Conclusion", "交付结论"))
-                    .font(.system(size: 8.5, weight: .bold))
-                    .foregroundColor(Color(red: 0.2, green: 0.85, blue: 0.45))
-            }
-            Text(conclusion)
-                .font(.system(size: 9.5, weight: .regular))
-                .foregroundColor(.white.opacity(0.9))
-                .lineLimit(4)
-                .blur(radius: isPrivacyMode ? 4.5 : 0)
-        }
-        .padding(6)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 6)
-                .fill(Color.green.opacity(0.08))
-                .overlay(RoundedRectangle(cornerRadius: 6).stroke(Color.green.opacity(0.2), lineWidth: 0.5))
-        )
-    }
-    
-    private var cardBackground: some View {
-        RoundedRectangle(cornerRadius: 10)
-            .fill(Color.white.opacity(0.04))
-            .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.white.opacity(0.08), lineWidth: 0.8))
     }
 }
 
-// MARK: - Skills & Tools Section View
-public struct SkillsAndToolsSectionView: View {
-    @ObservedObject private var localization = AppLocalization.shared
-    public var run: TaskRun
-    @Binding public var isExpanded: Bool
-    
-    public init(run: TaskRun, isExpanded: Binding<Bool>) {
-        self.run = run
-        self._isExpanded = isExpanded
+// MARK: - Quota Windows
+
+public struct QuotaWindowsView: View {
+    public let windows: [QuotaWindow]
+
+    public init(windows: [QuotaWindow]) {
+        self.windows = windows
     }
-    
-    private var skills: [SkillUsage] { run.skillsUsed ?? [] }
-    private var tools: [ToolCallInfo] { run.toolsUsed ?? [] }
-    
+
+    private var orderedWindows: [QuotaWindow] {
+        windows.sorted { ($0.windowDurationMins ?? Int.max) < ($1.windowDurationMins ?? Int.max) }
+    }
+
     public var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            headerButton
-            if isExpanded {
-                if !skills.isEmpty {
-                    skillsScrollView
-                }
-                if !tools.isEmpty {
-                    toolsScrollView
-                }
-            }
-        }
-        .padding(8)
-        .background(cardBackground)
-    }
-    
-    private var headerButton: some View {
-        Button(action: toggleExpanded) {
             HStack {
-                HStack(spacing: 4) {
-                    Image(systemName: "square.grid.2x2.fill")
-                        .font(.system(size: 9))
-                        .foregroundColor(.purple)
-                    Text(L("Skills & Tool Invocations", "技能与工具调用"))
-                        .font(.system(size: 9.5, weight: .semibold, design: .rounded))
-                        .foregroundColor(.white.opacity(0.85))
-                }
-                Spacer(minLength: 0)
-                HStack(spacing: 4) {
-                    Text("\(skills.count) skills · \(tools.count) tools")
-                        .font(.system(size: 8.0, weight: .regular))
-                        .foregroundColor(.white.opacity(0.45))
-                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                        .font(.system(size: 7.5, weight: .bold))
+                Label(L("Quota remaining", "额度剩余"), systemImage: "gauge.with.needle.fill")
+                    .font(.system(size: 8.8, weight: .bold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.7))
+                Spacer()
+                if let reset = orderedWindows.first?.localizedFormattedResetsAt {
+                    Text(reset)
+                        .font(.system(size: 7.4, weight: .medium, design: .monospaced))
                         .foregroundColor(.white.opacity(0.4))
                 }
             }
-            .padding(.vertical, 2)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-    }
-    
-    private func toggleExpanded() {
-        withAnimation(.easeInOut(duration: 0.2)) {
-            isExpanded.toggle()
-        }
-    }
-    
-    private var skillsScrollView: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 4) {
-                ForEach(skills) { skill in
-                    skillPill(skill: skill)
-                }
-            }
-        }
-    }
-    
-    private func skillPill(skill: SkillUsage) -> some View {
-        HStack(spacing: 3) {
-            Image(systemName: "sparkles")
-                .font(.system(size: 7.5))
-                .foregroundColor(.purple)
-            Text(skill.name)
-                .font(.system(size: 8.5, weight: .semibold, design: .monospaced))
-                .foregroundColor(.white.opacity(0.9))
-            if let c = skill.count, c > 1 {
-                Text("×\(c)")
-                    .font(.system(size: 7.5, weight: .bold))
-                    .foregroundColor(.purple.opacity(0.9))
-            }
-        }
-        .padding(.horizontal, 6)
-        .padding(.vertical, 3)
-        .background(
-            Capsule()
-                .fill(Color.purple.opacity(0.15))
-                .overlay(Capsule().stroke(Color.purple.opacity(0.35), lineWidth: 0.6))
-        )
-    }
-    
-    private var toolsScrollView: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 4) {
-                ForEach(tools) { tool in
-                    toolPill(tool: tool)
-                }
-            }
-        }
-    }
-    
-    private func toolPill(tool: ToolCallInfo) -> some View {
-        let isMcp = tool.isMcp == true
-        let tintColor: Color = isMcp ? .orange : .cyan
-        return HStack(spacing: 3) {
-            Image(systemName: isMcp ? "network" : "wrench.and.screwdriver.fill")
-                .font(.system(size: 7.5))
-                .foregroundColor(tintColor)
-            Text(tool.displayName)
-                .font(.system(size: 8.5, weight: .semibold, design: .monospaced))
-                .foregroundColor(.white.opacity(0.9))
-            if let c = tool.count {
-                Text("×\(c)")
-                    .font(.system(size: 7.5, weight: .bold))
-                    .foregroundColor(tintColor.opacity(0.9))
-            }
-        }
-        .padding(.horizontal, 6)
-        .padding(.vertical, 3)
-        .background(
-            Capsule()
-                .fill(tintColor.opacity(0.12))
-                .overlay(Capsule().stroke(tintColor.opacity(0.3), lineWidth: 0.6))
-        )
-    }
-    
-    private var cardBackground: some View {
-        RoundedRectangle(cornerRadius: 10)
-            .fill(Color.white.opacity(0.04))
-            .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.white.opacity(0.08), lineWidth: 0.8))
-    }
-}
 
-// MARK: - Trajectory Timeline Section View
-public struct TrajectoryTimelineSectionView: View {
-    @ObservedObject private var localization = AppLocalization.shared
-    public var run: TaskRun
-    @Binding public var isExpanded: Bool
-    
-    public init(run: TaskRun, isExpanded: Binding<Bool>) {
-        self.run = run
-        self._isExpanded = isExpanded
-    }
-    
-    private var steps: [TrajectoryStep] { run.trajectory ?? [] }
-    
-    public var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            headerButton
-            if isExpanded {
-                stepsListView
+            ForEach(orderedWindows) { window in
+                quotaRow(window)
             }
         }
         .padding(8)
-        .background(cardBackground)
+        .background(
+            RoundedRectangle(cornerRadius: 9)
+                .fill(Color.white.opacity(0.035))
+                .overlay(RoundedRectangle(cornerRadius: 9).stroke(Color.white.opacity(0.07), lineWidth: 0.7))
+        )
     }
-    
-    private var headerButton: some View {
-        Button(action: toggleExpanded) {
+
+    private func quotaRow(_ window: QuotaWindow) -> some View {
+        let used = max(0, min(100, window.usedPercent ?? 0))
+        let remaining = window.remainingPercent
+        let tint: Color = used >= 85 ? .orange : (used >= 60 ? .yellow : .cyan)
+        return VStack(spacing: 3) {
             HStack {
-                HStack(spacing: 4) {
-                    Image(systemName: "point.filled.topleft.down.curvedto.point.bottomright.up")
-                        .font(.system(size: 9))
-                        .foregroundColor(.indigo)
-                    Text(L("Execution Trajectory (\(steps.count) steps)", "执行步骤轨迹（\(steps.count) 步）"))
-                        .font(.system(size: 9.5, weight: .semibold, design: .rounded))
-                        .foregroundColor(.white.opacity(0.85))
-                }
-                Spacer(minLength: 0)
-                Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                    .font(.system(size: 7.5, weight: .bold))
-                    .foregroundColor(.white.opacity(0.4))
-            }
-            .padding(.vertical, 2)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-    }
-    
-    private func toggleExpanded() {
-        withAnimation(.easeInOut(duration: 0.2)) {
-            isExpanded.toggle()
-        }
-    }
-    
-    private var stepsListView: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            ForEach(Array(steps.prefix(8).enumerated()), id: \.element.id) { idx, step in
-                stepRow(step: step, isLast: idx >= min(steps.count - 1, 7))
-            }
-            if steps.count > 8 {
-                Text(L("+\(steps.count - 8) earlier steps", "还有 \(steps.count - 8) 个早期执行步骤"))
-                    .font(.system(size: 8, weight: .regular))
-                    .foregroundColor(.white.opacity(0.4))
-                    .padding(.leading, 14)
-            }
-        }
-        .padding(.top, 2)
-    }
-    
-    private func stepRow(step: TrajectoryStep, isLast: Bool) -> some View {
-        let dotColor: Color = step.status == "error" ? .orange : (step.isMcp == true ? .orange : .cyan)
-        return HStack(alignment: .top, spacing: 6) {
-            VStack(spacing: 0) {
-                Circle()
-                    .fill(dotColor)
-                    .frame(width: 5, height: 5)
-                    .padding(.top, 4)
-                if !isLast {
-                    Rectangle()
-                        .fill(Color.white.opacity(0.1))
-                        .frame(width: 1, height: 16)
+                Text(window.label)
+                    .font(.system(size: 8, weight: .heavy, design: .monospaced))
+                    .foregroundColor(tint)
+                    .frame(width: 34, alignment: .leading)
+                Text(String(format: L("%.0f%% left", "剩余 %.0f%%"), remaining))
+                    .font(.system(size: 8, weight: .bold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.72))
+                Spacer()
+                if let reset = window.localizedFormattedResetsAt {
+                    Text(reset)
+                        .font(.system(size: 7.3, weight: .medium, design: .monospaced))
+                        .foregroundColor(.white.opacity(0.42))
                 }
             }
-            .frame(width: 8)
-            
-            VStack(alignment: .leading, spacing: 1.5) {
-                HStack(spacing: 4) {
-                    Text(step.title ?? step.name ?? "Step")
-                        .font(.system(size: 9, weight: .semibold, design: .rounded))
-                        .foregroundColor(.white.opacity(0.9))
-                    Spacer(minLength: 4)
-                    if let dur = step.durationMs, dur > 0 {
-                        Text("\(dur)ms")
-                            .font(.system(size: 7.5, weight: .regular, design: .monospaced))
-                            .foregroundColor(.white.opacity(0.4))
-                    }
-                }
-                if let detail = step.detail, !detail.isEmpty {
-                    Text(detail)
-                        .font(.system(size: 8.5, weight: .regular, design: .monospaced))
-                        .foregroundColor(.white.opacity(0.6))
-                        .lineLimit(1)
-                        .truncationMode(.tail)
+
+            GeometryReader { proxy in
+                ZStack(alignment: .leading) {
+                    Capsule().fill(Color.white.opacity(0.075))
+                    Capsule()
+                        .fill(tint)
+                        .frame(width: proxy.size.width * CGFloat(max(0, min(1, remaining / 100.0))))
                 }
             }
+            .frame(height: 4)
         }
-    }
-    
-    private var cardBackground: some View {
-        RoundedRectangle(cornerRadius: 10)
-            .fill(Color.white.opacity(0.04))
-            .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.white.opacity(0.08), lineWidth: 0.8))
     }
 }
 
-// MARK: - Logs Section View
-public struct LogsSectionView: View {
-    @ObservedObject private var localization = AppLocalization.shared
-    public var run: TaskRun
-    @Binding public var isExpanded: Bool
-    
-    public init(run: TaskRun, isExpanded: Binding<Bool>) {
-        self.run = run
-        self._isExpanded = isExpanded
+// MARK: - Token Usage Breakdown
+
+public struct TokenUsageBreakdownView: View {
+    public let usage: TokenUsage
+
+    public init(usage: TokenUsage) {
+        self.usage = usage
     }
-    
-    private var logs: [TaskLogEntry] { run.logs ?? [] }
-    
+
     public var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            headerButton
-            if isExpanded {
-                logsConsoleBox
+        let input = usage.effectivePromptTokens
+        let output = usage.effectiveOutputTokens
+        let cached = usage.effectiveCachedTokens
+        let reasoning = usage.effectiveReasoningTokens
+        let total = max(1, input + output + cached + reasoning)
+
+        VStack(alignment: .leading, spacing: 5) {
+            HStack {
+                Text(L("Token usage", "Token 用量"))
+                    .font(.system(size: 8.8, weight: .bold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.7))
+                Spacer()
+                Text(TaskRun.formatTokenCount(usage.totalTokens ?? 0))
+                    .font(.system(size: 8.5, weight: .bold, design: .rounded))
+                    .foregroundColor(Color(red: 0.95, green: 0.35, blue: 0.8))
+            }
+
+            GeometryReader { proxy in
+                HStack(spacing: 1) {
+                    usageSegment(width: proxy.size.width, value: input, total: total, color: .cyan)
+                    usageSegment(width: proxy.size.width, value: output, total: total, color: .green)
+                    usageSegment(width: proxy.size.width, value: cached, total: total, color: .indigo)
+                    usageSegment(width: proxy.size.width, value: reasoning, total: total, color: .purple)
+                }
+            }
+            .frame(height: 5)
+            .clipShape(Capsule())
+
+            HStack(spacing: 8) {
+                legend(L("Input", "输入"), input, .cyan)
+                legend(L("Output", "输出"), output, .green)
+                legend(L("Cached", "缓存"), cached, .indigo)
+                if reasoning > 0 {
+                    legend(L("Reasoning", "推理"), reasoning, .purple)
+                }
             }
         }
         .padding(8)
-        .background(cardBackground)
-    }
-    
-    private var headerButton: some View {
-        Button(action: toggleExpanded) {
-            HStack {
-                HStack(spacing: 4) {
-                    Image(systemName: "doc.text.magnifyingglass")
-                        .font(.system(size: 9))
-                        .foregroundColor(.teal)
-                    Text(L("Execution Logs (\(logs.count))", "执行日志流（\(logs.count)）"))
-                        .font(.system(size: 9.5, weight: .semibold, design: .rounded))
-                        .foregroundColor(.white.opacity(0.85))
-                }
-                Spacer(minLength: 0)
-                Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                    .font(.system(size: 7.5, weight: .bold))
-                    .foregroundColor(.white.opacity(0.4))
-            }
-            .padding(.vertical, 2)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-    }
-    
-    private func toggleExpanded() {
-        withAnimation(.easeInOut(duration: 0.2)) {
-            isExpanded.toggle()
-        }
-    }
-    
-    private var logsConsoleBox: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            ForEach(Array(logs.suffix(6))) { entry in
-                logEntryRow(entry: entry)
-            }
-        }
-        .padding(6)
-        .frame(maxWidth: .infinity, alignment: .leading)
         .background(
-            RoundedRectangle(cornerRadius: 6)
-                .fill(Color.black.opacity(0.4))
-                .overlay(RoundedRectangle(cornerRadius: 6).stroke(Color.white.opacity(0.06), lineWidth: 0.5))
+            RoundedRectangle(cornerRadius: 9)
+                .fill(Color.white.opacity(0.035))
+                .overlay(RoundedRectangle(cornerRadius: 9).stroke(Color.white.opacity(0.07), lineWidth: 0.7))
         )
     }
-    
-    private func logEntryRow(entry: TaskLogEntry) -> some View {
-        let isErr = entry.level == "error"
-        let dotColor: Color = isErr ? .orange : Color(red: 0.2, green: 0.85, blue: 0.45)
-        let textColor: Color = isErr ? .orange.opacity(0.9) : .white.opacity(0.75)
-        return HStack(alignment: .top, spacing: 4) {
-            Circle()
-                .fill(dotColor)
-                .frame(width: 4, height: 4)
-                .padding(.top, 4)
-            Text(entry.message ?? "")
-                .font(.system(size: 8.0, weight: .regular, design: .monospaced))
-                .foregroundColor(textColor)
-                .lineLimit(2)
+
+    private func usageSegment(width: CGFloat, value: Int, total: Int, color: Color) -> some View {
+        color.frame(width: max(0, width * CGFloat(Double(value) / Double(total))))
+    }
+
+    private func legend(_ title: String, _ value: Int, _ color: Color) -> some View {
+        HStack(spacing: 2.5) {
+            Circle().fill(color).frame(width: 4, height: 4)
+            Text("\(title) \(TaskRun.formatTokenCount(value))")
+                .font(.system(size: 7.1, weight: .medium, design: .rounded))
+                .foregroundColor(.white.opacity(0.45))
         }
     }
-    
-    private var cardBackground: some View {
-        RoundedRectangle(cornerRadius: 10)
-            .fill(Color.white.opacity(0.04))
-            .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.white.opacity(0.08), lineWidth: 0.8))
-    }
 }
-

--- a/apps/macos-overlay/Sources/Views/SummaryView.swift
+++ b/apps/macos-overlay/Sources/Views/SummaryView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 import AppKit
 
-/// Main expanded FlowPilot surface. Account is kept as a UI-only fourth tab so
-/// the existing Inspector/History/Analytics IPC tab contract remains backward compatible.
+/// Main expanded FlowPilot surface. Account remains a UI-only fourth tab so
+/// existing Inspector/History/Analytics IPC commands stay backward compatible.
 public struct SummaryView: View {
     @ObservedObject var state: OverlayState
     @ObservedObject private var localization = AppLocalization.shared
@@ -53,12 +53,13 @@ public struct SummaryView: View {
         }
     }
 
-    // MARK: Chrome
+    // MARK: - Chrome
 
     private var topBar: some View {
         HStack(spacing: 7) {
             FlowPilotLogoView(size: 29, showGlow: true, withBolt: false, text: "FP")
                 .frame(width: 29, height: 29)
+
             VStack(alignment: .leading, spacing: 0) {
                 Text("FlowPilot")
                     .font(.system(size: 11.5, weight: .heavy, design: .rounded))
@@ -67,13 +68,21 @@ public struct SummaryView: View {
                     .font(.system(size: 7.8, weight: .medium, design: .rounded))
                     .foregroundColor(statusColor.opacity(0.85))
             }
+
             Spacer()
-            chromeButton(state.isPrivacyMode ? "eye.slash.fill" : "eye.fill", state.isPrivacyMode ? .orange : .white.opacity(0.55), L("Privacy mode", "隐私模式")) {
-                state.isPrivacyMode.toggle()
-            }
-            chromeButton(state.isPinned ? "pin.fill" : "pin", state.isPinned ? .cyan : .white.opacity(0.55), L("Pin window", "置顶窗口")) {
-                state.isPinned.toggle()
-            }
+
+            chromeButton(
+                state.isPrivacyMode ? "eye.slash.fill" : "eye.fill",
+                state.isPrivacyMode ? .orange : .white.opacity(0.55),
+                L("Privacy mode", "隐私模式")
+            ) { state.isPrivacyMode.toggle() }
+
+            chromeButton(
+                state.isPinned ? "pin.fill" : "pin",
+                state.isPinned ? .cyan : .white.opacity(0.55),
+                L("Pin window", "置顶窗口")
+            ) { state.isPinned.toggle() }
+
             chromeButton("chevron.down", .white.opacity(0.55), L("Collapse", "收起")) {
                 state.collapse()
             }
@@ -102,6 +111,7 @@ public struct SummaryView: View {
                     state.selectTab(tab)
                 }
             }
+
             tabButton(L("Account", "账户"), "person.crop.circle.fill", showingAccount) {
                 showingAccount = true
             }
@@ -113,7 +123,8 @@ public struct SummaryView: View {
     private func tabButton(_ title: String, _ icon: String, _ selected: Bool, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             HStack(spacing: 3) {
-                Image(systemName: icon).font(.system(size: 7.8, weight: .semibold))
+                Image(systemName: icon)
+                    .font(.system(size: 7.8, weight: .semibold))
                 Text(title)
                     .font(.system(size: 8.4, weight: selected ? .bold : .medium, design: .rounded))
                     .lineLimit(1)
@@ -124,7 +135,10 @@ public struct SummaryView: View {
             .background(
                 RoundedRectangle(cornerRadius: 7)
                     .fill(selected ? Color.cyan.opacity(0.22) : Color.clear)
-                    .overlay(RoundedRectangle(cornerRadius: 7).stroke(selected ? Color.cyan.opacity(0.32) : Color.clear, lineWidth: 0.6))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 7)
+                            .stroke(selected ? Color.cyan.opacity(0.32) : Color.clear, lineWidth: 0.6)
+                    )
             )
         }
         .buttonStyle(.plain)
@@ -134,7 +148,10 @@ public struct SummaryView: View {
         RoundedRectangle(cornerRadius: 18, style: .continuous)
             .fill(
                 LinearGradient(
-                    colors: [Color(red: 0.055, green: 0.062, blue: 0.085).opacity(0.98), Color(red: 0.035, green: 0.041, blue: 0.058).opacity(0.98)],
+                    colors: [
+                        Color(red: 0.055, green: 0.062, blue: 0.085).opacity(0.98),
+                        Color(red: 0.035, green: 0.041, blue: 0.058).opacity(0.98)
+                    ],
                     startPoint: .topLeading,
                     endPoint: .bottomTrailing
                 )
@@ -142,7 +159,7 @@ public struct SummaryView: View {
             .shadow(color: .black.opacity(0.48), radius: 18, y: 8)
     }
 
-    // MARK: Inspector
+    // MARK: - Inspector
 
     @ViewBuilder
     private var inspectorSurface: some View {
@@ -165,14 +182,27 @@ public struct SummaryView: View {
             if state.inspectedRun != nil { historicalBanner }
             projectHeader(run)
             metricsGrid(run)
+
             if !run.effectiveQuotaWindows.isEmpty {
                 QuotaWindowsView(windows: run.effectiveQuotaWindows)
             }
+
             taskNarrativeCard(run)
             participantsCard(run)
             TokenUsageBreakdownView(usage: run.aggregatedUsage)
-            if !run.allWorkers.isEmpty { workerOutcomesCard(run) }
-            if run.hasTrajectory || run.hasLogs { executionDetailCard(run) }
+
+            if run.hasSkillsOrTools {
+                InspectorSkillsToolsView(run: run)
+            }
+
+            if !run.allWorkers.isEmpty {
+                workerOutcomesCard(run)
+            }
+
+            if run.hasTrajectory || run.hasLogs {
+                executionDetailCard(run)
+            }
+
             actionFooter(run)
         }
         .padding(.top, 8)
@@ -180,15 +210,20 @@ public struct SummaryView: View {
 
     private var historicalBanner: some View {
         HStack(spacing: 5) {
-            Image(systemName: "clock.arrow.circlepath").font(.system(size: 8.5)).foregroundColor(.cyan)
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.system(size: 8.5))
+                .foregroundColor(.cyan)
             Text(L("Viewing historical task", "正在查看历史任务"))
-                .font(.system(size: 8.8, weight: .semibold)).foregroundColor(.cyan)
+                .font(.system(size: 8.8, weight: .semibold))
+                .foregroundColor(.cyan)
             Spacer()
+            recentTaskMenu
             Button(L("Live", "当前任务")) { state.jumpToLive() }
                 .buttonStyle(.plain)
                 .font(.system(size: 8, weight: .bold))
                 .foregroundColor(.white)
-                .padding(.horizontal, 6).padding(.vertical, 2)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
                 .background(Capsule().fill(Color.cyan.opacity(0.3)))
         }
         .padding(7)
@@ -198,29 +233,137 @@ public struct SummaryView: View {
     private func projectHeader(_ run: TaskRun) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 5) {
-                Image(systemName: "folder.fill").font(.system(size: 8)).foregroundColor(.white.opacity(0.48))
-                HoverRevealText(run.projectName, font: .system(size: 10, weight: .bold, design: .rounded), foregroundColor: .white.opacity(0.94), lineLimit: 1, privacyBlur: state.isPrivacyMode, popoverWidth: 300)
+                Image(systemName: "folder.fill")
+                    .font(.system(size: 8))
+                    .foregroundColor(.white.opacity(0.48))
+
+                HoverRevealText(
+                    run.projectName,
+                    font: .system(size: 10, weight: .bold, design: .rounded),
+                    foregroundColor: .white.opacity(0.94),
+                    lineLimit: 1,
+                    privacyBlur: state.isPrivacyMode,
+                    popoverWidth: 300
+                )
+
                 if let branch = run.gitBranch, !branch.isEmpty {
                     Text("·").foregroundColor(.white.opacity(0.25))
-                    HoverRevealText(branch, font: .system(size: 8.8, weight: .medium, design: .monospaced), foregroundColor: .cyan.opacity(0.88), lineLimit: 1, privacyBlur: state.isPrivacyMode, popoverWidth: 320)
+                    HoverRevealText(
+                        branch,
+                        font: .system(size: 8.8, weight: .medium, design: .monospaced),
+                        foregroundColor: .cyan.opacity(0.88),
+                        lineLimit: 1,
+                        privacyBlur: state.isPrivacyMode,
+                        popoverWidth: 320
+                    )
                 }
+
+                if !state.isPrivacyMode && !isFullHeight {
+                    recentTaskMenu
+                }
+
                 Spacer(minLength: 2)
                 statusBadge(run)
             }
-            HoverRevealText(run.thread?.preview ?? run.summary ?? run.sessionTitle, font: .system(size: 9.4), foregroundColor: .white.opacity(0.63), lineLimit: 1, privacyBlur: state.isPrivacyMode, popoverWidth: 390)
-                .frame(maxWidth: .infinity, alignment: .leading)
+
+            HoverRevealText(
+                run.thread?.preview ?? run.summary ?? run.sessionTitle,
+                font: .system(size: 9.4),
+                foregroundColor: .white.opacity(0.63),
+                lineLimit: 1,
+                privacyBlur: state.isPrivacyMode,
+                popoverWidth: 390
+            )
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(8)
         .background(cardBackground())
     }
 
+    private var recentTaskMenu: some View {
+        Menu {
+            if let latest = state.latestRun {
+                Section(L("Live Session", "当前会话")) {
+                    Button {
+                        state.jumpToLive()
+                    } label: {
+                        Text(L("⚡ Live · \(latest.projectName) · \(latest.localizedFormattedDate)", "⚡ 当前 · \(latest.projectName) · \(latest.localizedFormattedDate)"))
+                    }
+                }
+            }
+
+            if !state.recentChats.isEmpty {
+                Section(L("Recent Chats & Tasks", "最近对话任务")) {
+                    ForEach(Array(state.recentChats.prefix(10).enumerated()), id: \.element.id) { index, chat in
+                        if let latest = chat.latestRun {
+                            Button {
+                                if latest.id == state.latestRun?.id {
+                                    state.jumpToLive()
+                                } else {
+                                    state.inspect(run: latest)
+                                }
+                            } label: {
+                                Text("#\(index + 1) \(chat.projectName) · \(chat.localizedFormattedDate) · \(shortMenuText(chat.title))")
+                            }
+                        }
+                    }
+                }
+            }
+
+            Divider()
+
+            Button {
+                state.selectTab(.history)
+            } label: {
+                Label(L("Browse All History", "浏览全部历史"), systemImage: "clock.arrow.circlepath")
+            }
+        } label: {
+            Image(systemName: "chevron.down.circle.fill")
+                .font(.system(size: 9))
+                .foregroundColor(.white.opacity(0.42))
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .help(L("Switch task", "切换任务"))
+    }
+
+    private func shortMenuText(_ text: String) -> String {
+        let cleaned = text.replacingOccurrences(of: "\n", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return cleaned.count > 34 ? String(cleaned.prefix(34)) + "…" : cleaned
+    }
+
     private func metricsGrid(_ run: TaskRun) -> some View {
         let usage = run.aggregatedUsage
         return HStack(spacing: 6) {
-            InspectorMetricView(title: L("Time", "耗时"), value: run.formattedDuration, detail: L("wall time", "任务时长"), icon: "timer", accent: .cyan, progress: min(1, run.durationSeconds / 600.0))
-            InspectorMetricView(title: L("Tokens", "Token"), value: run.formattedCompactTokens, detail: L("total", "总用量"), icon: "circle.grid.cross.fill", accent: Color(red: 0.95, green: 0.35, blue: 0.8), progress: min(1, Double(usage.totalTokens ?? 0) / 100_000.0))
-            // Replaces the ambiguous old Cost ring. Optional credits are not USD.
-            InspectorMetricView(title: L("Output", "输出"), value: TaskRun.formatTokenCount(usage.effectiveOutputTokens), detail: L("tokens", "Token"), icon: "arrow.up.circle.fill", accent: Color(red: 0.25, green: 0.88, blue: 0.58), progress: outputShare(usage))
+            InspectorMetricView(
+                title: L("Time", "耗时"),
+                value: run.formattedDuration,
+                detail: L("wall time", "任务时长"),
+                icon: "timer",
+                accent: .cyan,
+                progress: min(1, run.durationSeconds / 600.0)
+            )
+
+            InspectorMetricView(
+                title: L("Tokens", "Token"),
+                value: run.formattedCompactTokens,
+                detail: L("total", "总用量"),
+                icon: "circle.grid.cross.fill",
+                accent: Color(red: 0.95, green: 0.35, blue: 0.8),
+                progress: min(1, Double(usage.totalTokens ?? 0) / 100_000.0)
+            )
+
+            // The old Cost ring treated optional credit telemetry like USD and was
+            // frequently empty. Output tokens are deterministic and unambiguous.
+            InspectorMetricView(
+                title: L("Output", "输出"),
+                value: TaskRun.formatTokenCount(usage.effectiveOutputTokens),
+                detail: L("tokens", "Token"),
+                icon: "arrow.up.circle.fill",
+                accent: Color(red: 0.25, green: 0.88, blue: 0.58),
+                progress: outputShare(usage)
+            )
         }
     }
 
@@ -231,9 +374,11 @@ public struct SummaryView: View {
     private func taskNarrativeCard(_ run: TaskRun) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             sectionHeader("sparkles.rectangle.stack.fill", L("Task Objective & Summary", "任务目标与概要说明"), .cyan)
+
             if let goal = run.effectiveGoal, !goal.isEmpty {
                 narrativeBlock(L("Objective", "目标"), "target", goal, .cyan, 3)
             }
+
             if let conclusion = run.effectiveConclusion, !conclusion.isEmpty {
                 narrativeBlock(L("Outcome / Conclusion", "交付结论"), "checkmark.seal.fill", conclusion, .green, 4)
             }
@@ -245,9 +390,18 @@ public struct SummaryView: View {
     private func narrativeBlock(_ label: String, _ icon: String, _ text: String, _ tint: Color, _ lines: Int) -> some View {
         VStack(alignment: .leading, spacing: 3) {
             Label(label, systemImage: icon)
-                .font(.system(size: 8.2, weight: .bold)).foregroundColor(tint.opacity(0.9))
-            HoverRevealText(text, font: .system(size: 9.3), foregroundColor: .white.opacity(0.88), lineLimit: lines, privacyBlur: state.isPrivacyMode, popoverWidth: 390)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .font(.system(size: 8.2, weight: .bold))
+                .foregroundColor(tint.opacity(0.9))
+
+            HoverRevealText(
+                text,
+                font: .system(size: 9.3),
+                foregroundColor: .white.opacity(0.88),
+                lineLimit: lines,
+                privacyBlur: state.isPrivacyMode,
+                popoverWidth: 390
+            )
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(6)
         .background(RoundedRectangle(cornerRadius: 7).fill(tint.opacity(0.07)))
@@ -255,8 +409,21 @@ public struct SummaryView: View {
 
     private func participantsCard(_ run: TaskRun) -> some View {
         HStack(spacing: 6) {
-            participantBlock("brain.head.profile", L("Parent", "父 Agent"), run.parent?.displayModel ?? L("Direct CLI", "直接 CLI"), participantSubtitle(run.parent), .indigo)
-            participantBlock("person.2.fill", L("Workers", "Worker"), workerSummaryText(run), L("\(run.allWorkers.count) subagents", "\(run.allWorkers.count) 个子 Agent"), .teal)
+            participantBlock(
+                "brain.head.profile",
+                L("Parent", "父 Agent"),
+                run.parent?.displayModel ?? L("Direct CLI", "直接 CLI"),
+                participantSubtitle(run.parent),
+                .indigo
+            )
+
+            participantBlock(
+                "person.2.fill",
+                L("Workers", "Worker"),
+                workerSummaryText(run),
+                L("\(run.allWorkers.count) subagents", "\(run.allWorkers.count) 个子 Agent"),
+                .teal
+            )
         }
     }
 
@@ -269,9 +436,21 @@ public struct SummaryView: View {
     private func participantBlock(_ icon: String, _ title: String, _ name: String, _ subtitle: String, _ tint: Color) -> some View {
         VStack(alignment: .leading, spacing: 3) {
             Label(title, systemImage: icon)
-                .font(.system(size: 8.5, weight: .semibold)).foregroundColor(tint.opacity(0.9))
-            HoverRevealText(name, font: .system(size: 9.8, weight: .bold, design: .rounded), foregroundColor: .white.opacity(0.9), lineLimit: 1, popoverWidth: 280)
-            Text(subtitle).font(.system(size: 7.8)).foregroundColor(.white.opacity(0.4)).lineLimit(1)
+                .font(.system(size: 8.5, weight: .semibold))
+                .foregroundColor(tint.opacity(0.9))
+
+            HoverRevealText(
+                name,
+                font: .system(size: 9.8, weight: .bold, design: .rounded),
+                foregroundColor: .white.opacity(0.9),
+                lineLimit: 1,
+                popoverWidth: 280
+            )
+
+            Text(subtitle)
+                .font(.system(size: 7.8))
+                .foregroundColor(.white.opacity(0.4))
+                .lineLimit(1)
         }
         .padding(7)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -281,23 +460,46 @@ public struct SummaryView: View {
     private func participantSubtitle(_ participant: ParticipantInfo?) -> String {
         guard let participant else { return L("No usage data", "暂无用量数据") }
         let tokens = participant.effectiveUsage?.totalTokens ?? 0
-        if let effort = participant.displayEffort { return "\(effort) · \(TaskRun.formatTokenCount(tokens)) tokens" }
+        if let effort = participant.displayEffort {
+            return "\(effort) · \(TaskRun.formatTokenCount(tokens)) tokens"
+        }
         return "\(TaskRun.formatTokenCount(tokens)) tokens"
     }
 
     private func workerOutcomesCard(_ run: TaskRun) -> some View {
         VStack(alignment: .leading, spacing: 5) {
             sectionHeader("checkmark.bubble.fill", L("Worker Outcomes", "Worker 执行结果"), .teal)
+
             ForEach(run.allWorkers) { worker in
                 VStack(alignment: .leading, spacing: 2) {
                     HStack(spacing: 4) {
-                        HoverRevealText(worker.agentType ?? worker.name ?? L("Worker", "Worker"), font: .system(size: 8.7, weight: .semibold, design: .rounded), foregroundColor: .white.opacity(0.88), lineLimit: 1, popoverWidth: 300)
+                        HoverRevealText(
+                            worker.agentType ?? worker.name ?? L("Worker", "Worker"),
+                            font: .system(size: 8.7, weight: .semibold, design: .rounded),
+                            foregroundColor: .white.opacity(0.88),
+                            lineLimit: 1,
+                            popoverWidth: 300
+                        )
                         Spacer(minLength: 4)
-                        HoverRevealText(worker.displayModel, font: .system(size: 7.7, weight: .medium, design: .monospaced), foregroundColor: .teal.opacity(0.78), lineLimit: 1, popoverWidth: 280)
+                        HoverRevealText(
+                            worker.displayModel,
+                            font: .system(size: 7.7, weight: .medium, design: .monospaced),
+                            foregroundColor: .teal.opacity(0.78),
+                            lineLimit: 1,
+                            popoverWidth: 280
+                        )
                     }
+
                     if let conclusion = worker.conclusion, !conclusion.isEmpty {
-                        HoverRevealText(conclusion, font: .system(size: 8.8), foregroundColor: .white.opacity(0.64), lineLimit: 3, privacyBlur: state.isPrivacyMode, popoverWidth: 390)
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                        HoverRevealText(
+                            conclusion,
+                            font: .system(size: 8.8),
+                            foregroundColor: .white.opacity(0.64),
+                            lineLimit: 3,
+                            privacyBlur: state.isPrivacyMode,
+                            popoverWidth: 390
+                        )
+                        .frame(maxWidth: .infinity, alignment: .leading)
                     }
                 }
                 .padding(6)
@@ -311,22 +513,53 @@ public struct SummaryView: View {
     private func executionDetailCard(_ run: TaskRun) -> some View {
         VStack(alignment: .leading, spacing: 5) {
             sectionHeader("point.filled.topleft.down.curvedto.point.bottomright.up", L("Execution Details", "执行详情"), .indigo)
+
             ForEach(Array((run.trajectory ?? []).prefix(6))) { step in
                 HStack(alignment: .top, spacing: 5) {
-                    Circle().fill(step.status == "error" ? Color.orange : Color.cyan).frame(width: 4.5, height: 4.5).padding(.top, 4)
+                    Circle()
+                        .fill(step.status == "error" ? Color.orange : Color.cyan)
+                        .frame(width: 4.5, height: 4.5)
+                        .padding(.top, 4)
+
                     VStack(alignment: .leading, spacing: 1) {
-                        HoverRevealText(step.title ?? step.name ?? "Step", font: .system(size: 8.6, weight: .semibold), foregroundColor: .white.opacity(0.82), lineLimit: 1, popoverWidth: 360)
+                        HoverRevealText(
+                            step.title ?? step.name ?? "Step",
+                            font: .system(size: 8.6, weight: .semibold),
+                            foregroundColor: .white.opacity(0.82),
+                            lineLimit: 1,
+                            popoverWidth: 360
+                        )
+
                         if let detail = step.detail, !detail.isEmpty {
-                            HoverRevealText(detail, font: .system(size: 7.8, design: .monospaced), foregroundColor: .white.opacity(0.5), lineLimit: 1, privacyBlur: state.isPrivacyMode, popoverWidth: 410)
+                            HoverRevealText(
+                                detail,
+                                font: .system(size: 7.8, design: .monospaced),
+                                foregroundColor: .white.opacity(0.5),
+                                lineLimit: 1,
+                                privacyBlur: state.isPrivacyMode,
+                                popoverWidth: 410
+                            )
                         }
                     }
                 }
             }
+
             ForEach(Array((run.logs ?? []).suffix(4))) { entry in
                 HStack(alignment: .top, spacing: 5) {
-                    Circle().fill(entry.level == "error" ? Color.orange : Color.green).frame(width: 4, height: 4).padding(.top, 4)
-                    HoverRevealText(entry.message ?? "", font: .system(size: 7.7, design: .monospaced), foregroundColor: entry.level == "error" ? .orange.opacity(0.85) : .white.opacity(0.58), lineLimit: 2, privacyBlur: state.isPrivacyMode, popoverWidth: 420)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Circle()
+                        .fill(entry.level == "error" ? Color.orange : Color.green)
+                        .frame(width: 4, height: 4)
+                        .padding(.top, 4)
+
+                    HoverRevealText(
+                        entry.message ?? "",
+                        font: .system(size: 7.7, design: .monospaced),
+                        foregroundColor: entry.level == "error" ? .orange.opacity(0.85) : .white.opacity(0.58),
+                        lineLimit: 2,
+                        privacyBlur: state.isPrivacyMode,
+                        popoverWidth: 420
+                    )
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
         }
@@ -339,46 +572,89 @@ public struct SummaryView: View {
             Button {
                 copySummary(run)
             } label: {
-                Label(copiedSummary ? L("Copied", "已复制") : L("Copy summary", "复制摘要"), systemImage: copiedSummary ? "checkmark" : "doc.on.doc")
+                Label(
+                    copiedSummary ? L("Copied", "已复制") : L("Copy summary", "复制摘要"),
+                    systemImage: copiedSummary ? "checkmark" : "doc.on.doc"
+                )
+                .font(.system(size: 8.6, weight: .semibold))
+                .foregroundColor(copiedSummary ? .green : .white.opacity(0.75))
+                .padding(.horizontal, 7)
+                .padding(.vertical, 4)
+                .background(RoundedRectangle(cornerRadius: 6).fill(Color.white.opacity(0.05)))
+            }
+            .buttonStyle(.plain)
+
+            Button {
+                openConsole()
+            } label: {
+                Label(L("Console", "控制台"), systemImage: "terminal.fill")
                     .font(.system(size: 8.6, weight: .semibold))
-                    .foregroundColor(copiedSummary ? .green : .white.opacity(0.75))
-                    .padding(.horizontal, 7).padding(.vertical, 4)
+                    .foregroundColor(.white.opacity(0.75))
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 4)
                     .background(RoundedRectangle(cornerRadius: 6).fill(Color.white.opacity(0.05)))
             }
             .buttonStyle(.plain)
+
             Spacer()
-            Text(run.localizedFormattedDate).font(.system(size: 7.8)).foregroundColor(.white.opacity(0.35))
+            Text(run.localizedFormattedDate)
+                .font(.system(size: 7.8))
+                .foregroundColor(.white.opacity(0.35))
         }
     }
 
     private var idleInspector: some View {
         VStack(spacing: 10) {
             FlowPilotLogoView(size: 58, showGlow: true, withBolt: true, text: "FlowPilot")
-                .frame(width: 58, height: 58).padding(.top, 20)
+                .frame(width: 58, height: 58)
+                .padding(.top, 20)
+
             Text(L("FlowPilot is Ready", "FlowPilot 已就绪"))
-                .font(.system(size: 13, weight: .bold, design: .rounded)).foregroundColor(.white)
+                .font(.system(size: 13, weight: .bold, design: .rounded))
+                .foregroundColor(.white)
+
             Text(L("Listening for live task and usage telemetry", "正在监听任务与用量遥测"))
-                .font(.system(size: 9.5)).foregroundColor(.white.opacity(0.48))
-            Button { showingAccount = true } label: {
-                Label(L("View Account Limits", "查看账户额度"), systemImage: "person.crop.circle")
-                    .font(.system(size: 9, weight: .semibold)).foregroundColor(.cyan)
-                    .padding(.horizontal, 9).padding(.vertical, 5)
-                    .background(Capsule().fill(Color.cyan.opacity(0.12)))
-            }.buttonStyle(.plain)
+                .font(.system(size: 9.5))
+                .foregroundColor(.white.opacity(0.48))
+
+            HStack(spacing: 7) {
+                Button { showingAccount = true } label: {
+                    Label(L("Account Limits", "账户额度"), systemImage: "person.crop.circle")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundColor(.cyan)
+                        .padding(.horizontal, 9)
+                        .padding(.vertical, 5)
+                        .background(Capsule().fill(Color.cyan.opacity(0.12)))
+                }
+                .buttonStyle(.plain)
+
+                Button { openConsole() } label: {
+                    Label(L("Console", "控制台"), systemImage: "terminal.fill")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundColor(.white.opacity(0.72))
+                        .padding(.horizontal, 9)
+                        .padding(.vertical, 5)
+                        .background(Capsule().fill(Color.white.opacity(0.06)))
+                }
+                .buttonStyle(.plain)
+            }
+
             Spacer(minLength: 12)
         }
         .frame(maxWidth: .infinity, minHeight: 300)
     }
 
-    // MARK: Helpers
+    // MARK: - Helpers
 
     private func statusBadge(_ run: TaskRun) -> some View {
         HStack(spacing: 3) {
             Circle().fill(runStatusColor(run)).frame(width: 4.5, height: 4.5)
-            Text(runStatusText(run)).font(.system(size: 7.4, weight: .bold, design: .rounded))
+            Text(runStatusText(run))
+                .font(.system(size: 7.4, weight: .bold, design: .rounded))
         }
         .foregroundColor(runStatusColor(run))
-        .padding(.horizontal, 5).padding(.vertical, 2)
+        .padding(.horizontal, 5)
+        .padding(.vertical, 2)
         .background(Capsule().fill(runStatusColor(run).opacity(0.12)))
     }
 
@@ -387,7 +663,9 @@ public struct SummaryView: View {
     }
 
     private func runStatusText(_ run: TaskRun) -> String {
-        run.isRunning ? L("RUNNING", "运行中") : (run.isError ? L("FAILED", "失败") : L("COMPLETED", "已完成"))
+        run.isRunning
+            ? L("RUNNING", "运行中")
+            : (run.isError ? L("FAILED", "失败") : L("COMPLETED", "已完成"))
     }
 
     private var statusText: String { currentRun.map(runStatusText) ?? L("READY", "就绪") }
@@ -395,8 +673,12 @@ public struct SummaryView: View {
 
     private func sectionHeader(_ icon: String, _ title: String, _ tint: Color) -> some View {
         HStack(spacing: 4) {
-            Image(systemName: icon).font(.system(size: 8)).foregroundColor(tint)
-            Text(title).font(.system(size: 8.8, weight: .bold, design: .rounded)).foregroundColor(.white.opacity(0.7))
+            Image(systemName: icon)
+                .font(.system(size: 8))
+                .foregroundColor(tint)
+            Text(title)
+                .font(.system(size: 8.8, weight: .bold, design: .rounded))
+                .foregroundColor(.white.opacity(0.7))
             Spacer()
         }
     }
@@ -405,7 +687,10 @@ public struct SummaryView: View {
         let base = tint ?? Color.white
         return RoundedRectangle(cornerRadius: 9)
             .fill(base.opacity(tint == nil ? 0.04 : 0.07))
-            .overlay(RoundedRectangle(cornerRadius: 9).stroke(base.opacity(tint == nil ? 0.075 : 0.18), lineWidth: 0.7))
+            .overlay(
+                RoundedRectangle(cornerRadius: 9)
+                    .stroke(base.opacity(tint == nil ? 0.075 : 0.18), lineWidth: 0.7)
+            )
     }
 
     private func copySummary(_ run: TaskRun) {
@@ -417,7 +702,22 @@ public struct SummaryView: View {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(text, forType: .string)
         copiedSummary = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { copiedSummary = false }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            copiedSummary = false
+        }
+    }
+
+    private func openConsole() {
+        let script = """
+        tell application "Terminal"
+            activate
+            do script "codex-flow"
+        end tell
+        """
+        if let appleScript = NSAppleScript(source: script) {
+            var error: NSDictionary?
+            appleScript.executeAndReturnError(&error)
+        }
     }
 }
 
@@ -439,16 +739,32 @@ public struct InspectorMetricView: View {
                     .trim(from: 0, to: CGFloat(max(0.015, min(1, progress))))
                     .stroke(accent, style: StrokeStyle(lineWidth: 3, lineCap: .round))
                     .rotationEffect(.degrees(-90))
-                Image(systemName: icon).font(.system(size: 8.5, weight: .semibold)).foregroundColor(accent)
+                Image(systemName: icon)
+                    .font(.system(size: 8.5, weight: .semibold))
+                    .foregroundColor(accent)
             }
             .frame(width: 29, height: 29)
-            Text(title).font(.system(size: 7.6, weight: .semibold, design: .rounded)).foregroundColor(.white.opacity(0.48)).textCase(.uppercase)
-            Text(value).font(.system(size: 10.5, weight: .bold, design: .rounded)).foregroundColor(.white).lineLimit(1)
-            Text(detail).font(.system(size: 6.9)).foregroundColor(.white.opacity(0.32)).lineLimit(1)
+
+            Text(title)
+                .font(.system(size: 7.6, weight: .semibold, design: .rounded))
+                .foregroundColor(.white.opacity(0.48))
+                .textCase(.uppercase)
+            Text(value)
+                .font(.system(size: 10.5, weight: .bold, design: .rounded))
+                .foregroundColor(.white)
+                .lineLimit(1)
+            Text(detail)
+                .font(.system(size: 6.9))
+                .foregroundColor(.white.opacity(0.32))
+                .lineLimit(1)
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 7)
-        .background(RoundedRectangle(cornerRadius: 9).fill(Color.white.opacity(0.035)).overlay(RoundedRectangle(cornerRadius: 9).stroke(Color.white.opacity(0.07), lineWidth: 0.7)))
+        .background(
+            RoundedRectangle(cornerRadius: 9)
+                .fill(Color.white.opacity(0.035))
+                .overlay(RoundedRectangle(cornerRadius: 9).stroke(Color.white.opacity(0.07), lineWidth: 0.7))
+        )
     }
 }
 
@@ -456,7 +772,10 @@ public struct InspectorMetricView: View {
 
 public struct QuotaWindowsView: View {
     public let windows: [QuotaWindow]
-    public init(windows: [QuotaWindow]) { self.windows = windows }
+
+    public init(windows: [QuotaWindow]) {
+        self.windows = windows
+    }
 
     private var ordered: [QuotaWindow] {
         windows.sorted { ($0.windowDurationMins ?? Int.max) < ($1.windowDurationMins ?? Int.max) }
@@ -466,37 +785,60 @@ public struct QuotaWindowsView: View {
         VStack(alignment: .leading, spacing: 6) {
             HStack {
                 Label(L("Quota remaining", "额度剩余"), systemImage: "gauge.with.needle.fill")
-                    .font(.system(size: 8.8, weight: .bold, design: .rounded)).foregroundColor(.white.opacity(0.7))
+                    .font(.system(size: 8.8, weight: .bold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.7))
                 Spacer()
                 if let reset = ordered.first?.localizedFormattedResetsAt {
-                    Text(reset).font(.system(size: 7.4, weight: .medium, design: .monospaced)).foregroundColor(.white.opacity(0.4))
+                    Text(reset)
+                        .font(.system(size: 7.4, weight: .medium, design: .monospaced))
+                        .foregroundColor(.white.opacity(0.4))
                 }
             }
+
             ForEach(ordered) { quotaRow($0) }
         }
         .padding(8)
-        .background(RoundedRectangle(cornerRadius: 9).fill(Color.white.opacity(0.035)).overlay(RoundedRectangle(cornerRadius: 9).stroke(Color.white.opacity(0.07), lineWidth: 0.7)))
+        .background(
+            RoundedRectangle(cornerRadius: 9)
+                .fill(Color.white.opacity(0.035))
+                .overlay(RoundedRectangle(cornerRadius: 9).stroke(Color.white.opacity(0.07), lineWidth: 0.7))
+        )
     }
 
     private func quotaRow(_ window: QuotaWindow) -> some View {
         let used = max(0, min(100, window.usedPercent ?? 0))
         let remaining = window.remainingPercent
         let tint: Color = used >= 85 ? .orange : (used >= 60 ? .yellow : .cyan)
+
         return VStack(spacing: 3) {
             HStack {
-                Text(window.label).font(.system(size: 8, weight: .heavy, design: .monospaced)).foregroundColor(tint).frame(width: 34, alignment: .leading)
-                Text(String(format: L("%.0f%% left", "剩余 %.0f%%"), remaining)).font(.system(size: 8, weight: .bold, design: .rounded)).foregroundColor(.white.opacity(0.72))
+                Text(window.label)
+                    .font(.system(size: 8, weight: .heavy, design: .monospaced))
+                    .foregroundColor(tint)
+                    .frame(width: 34, alignment: .leading)
+
+                Text(String(format: L("%.0f%% left", "剩余 %.0f%%"), remaining))
+                    .font(.system(size: 8, weight: .bold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.72))
+
                 Spacer()
+
                 if let reset = window.localizedFormattedResetsAt {
-                    Text(reset).font(.system(size: 7.3, weight: .medium, design: .monospaced)).foregroundColor(.white.opacity(0.42))
+                    Text(reset)
+                        .font(.system(size: 7.3, weight: .medium, design: .monospaced))
+                        .foregroundColor(.white.opacity(0.42))
                 }
             }
+
             GeometryReader { proxy in
                 ZStack(alignment: .leading) {
                     Capsule().fill(Color.white.opacity(0.075))
-                    Capsule().fill(tint).frame(width: proxy.size.width * CGFloat(max(0, min(1, remaining / 100.0))))
+                    Capsule()
+                        .fill(tint)
+                        .frame(width: proxy.size.width * CGFloat(max(0, min(1, remaining / 100.0))))
                 }
-            }.frame(height: 4)
+            }
+            .frame(height: 4)
         }
     }
 }
@@ -505,7 +847,10 @@ public struct QuotaWindowsView: View {
 
 public struct TokenUsageBreakdownView: View {
     public let usage: TokenUsage
-    public init(usage: TokenUsage) { self.usage = usage }
+
+    public init(usage: TokenUsage) {
+        self.usage = usage
+    }
 
     public var body: some View {
         let input = usage.effectivePromptTokens
@@ -516,10 +861,15 @@ public struct TokenUsageBreakdownView: View {
 
         return VStack(alignment: .leading, spacing: 5) {
             HStack {
-                Text(L("Token usage", "Token 用量")).font(.system(size: 8.8, weight: .bold, design: .rounded)).foregroundColor(.white.opacity(0.7))
+                Text(L("Token usage", "Token 用量"))
+                    .font(.system(size: 8.8, weight: .bold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.7))
                 Spacer()
-                Text(TaskRun.formatTokenCount(usage.totalTokens ?? 0)).font(.system(size: 8.5, weight: .bold, design: .rounded)).foregroundColor(Color(red: 0.95, green: 0.35, blue: 0.8))
+                Text(TaskRun.formatTokenCount(usage.totalTokens ?? 0))
+                    .font(.system(size: 8.5, weight: .bold, design: .rounded))
+                    .foregroundColor(Color(red: 0.95, green: 0.35, blue: 0.8))
             }
+
             GeometryReader { proxy in
                 HStack(spacing: 1) {
                     segment(proxy.size.width, input, total, .cyan)
@@ -530,15 +880,22 @@ public struct TokenUsageBreakdownView: View {
             }
             .frame(height: 5)
             .clipShape(Capsule())
+
             HStack(spacing: 8) {
                 legend(L("Input", "输入"), input, .cyan)
                 legend(L("Output", "输出"), output, .green)
                 legend(L("Cached", "缓存"), cached, .indigo)
-                if reasoning > 0 { legend(L("Reasoning", "推理"), reasoning, .purple) }
+                if reasoning > 0 {
+                    legend(L("Reasoning", "推理"), reasoning, .purple)
+                }
             }
         }
         .padding(8)
-        .background(RoundedRectangle(cornerRadius: 9).fill(Color.white.opacity(0.035)).overlay(RoundedRectangle(cornerRadius: 9).stroke(Color.white.opacity(0.07), lineWidth: 0.7)))
+        .background(
+            RoundedRectangle(cornerRadius: 9)
+                .fill(Color.white.opacity(0.035))
+                .overlay(RoundedRectangle(cornerRadius: 9).stroke(Color.white.opacity(0.07), lineWidth: 0.7))
+        )
     }
 
     private func segment(_ width: CGFloat, _ value: Int, _ total: Int, _ color: Color) -> some View {
@@ -548,7 +905,9 @@ public struct TokenUsageBreakdownView: View {
     private func legend(_ title: String, _ value: Int, _ color: Color) -> some View {
         HStack(spacing: 2.5) {
             Circle().fill(color).frame(width: 4, height: 4)
-            Text("\(title) \(TaskRun.formatTokenCount(value))").font(.system(size: 7.1, weight: .medium, design: .rounded)).foregroundColor(.white.opacity(0.45))
+            Text("\(title) \(TaskRun.formatTokenCount(value))")
+                .font(.system(size: 7.1, weight: .medium, design: .rounded))
+                .foregroundColor(.white.opacity(0.45))
         }
     }
 }

--- a/apps/macos-overlay/Sources/Views/SummaryView.swift
+++ b/apps/macos-overlay/Sources/Views/SummaryView.swift
@@ -853,11 +853,18 @@ public struct TokenUsageBreakdownView: View {
     }
 
     public var body: some View {
+        // `inputTokens` includes cached input and `outputTokens` can include
+        // reasoning output. Make the rendered segments mutually exclusive so
+        // the bar and legend do not double-count those subsets.
         let input = usage.effectivePromptTokens
         let output = usage.effectiveOutputTokens
-        let cached = usage.effectiveCachedTokens
-        let reasoning = usage.effectiveReasoningTokens
-        let total = max(1, input + output + cached + reasoning)
+        let cached = min(max(0, usage.effectiveCachedTokens), max(0, input))
+        let reasoning = min(max(0, usage.effectiveReasoningTokens), max(0, output))
+        let newInput = max(0, input - cached)
+        let visibleOutput = max(0, output - reasoning)
+        let segmentedTotal = newInput + cached + visibleOutput + reasoning
+        let total = max(1, segmentedTotal)
+        let reportedTotal = usage.totalTokens ?? segmentedTotal
 
         return VStack(alignment: .leading, spacing: 5) {
             HStack {
@@ -865,16 +872,16 @@ public struct TokenUsageBreakdownView: View {
                     .font(.system(size: 8.8, weight: .bold, design: .rounded))
                     .foregroundColor(.white.opacity(0.7))
                 Spacer()
-                Text(TaskRun.formatTokenCount(usage.totalTokens ?? 0))
+                Text(TaskRun.formatTokenCount(reportedTotal))
                     .font(.system(size: 8.5, weight: .bold, design: .rounded))
                     .foregroundColor(Color(red: 0.95, green: 0.35, blue: 0.8))
             }
 
             GeometryReader { proxy in
                 HStack(spacing: 1) {
-                    segment(proxy.size.width, input, total, .cyan)
-                    segment(proxy.size.width, output, total, .green)
+                    segment(proxy.size.width, newInput, total, .cyan)
                     segment(proxy.size.width, cached, total, .indigo)
+                    segment(proxy.size.width, visibleOutput, total, .green)
                     segment(proxy.size.width, reasoning, total, .purple)
                 }
             }
@@ -882,9 +889,11 @@ public struct TokenUsageBreakdownView: View {
             .clipShape(Capsule())
 
             HStack(spacing: 8) {
-                legend(L("Input", "输入"), input, .cyan)
-                legend(L("Output", "输出"), output, .green)
-                legend(L("Cached", "缓存"), cached, .indigo)
+                legend(L("New input", "新输入"), newInput, .cyan)
+                if cached > 0 {
+                    legend(L("Cached", "缓存"), cached, .indigo)
+                }
+                legend(L("Output", "输出"), visibleOutput, .green)
                 if reasoning > 0 {
                     legend(L("Reasoning", "推理"), reasoning, .purple)
                 }

--- a/apps/macos-overlay/Sources/Views/SummaryView.swift
+++ b/apps/macos-overlay/Sources/Views/SummaryView.swift
@@ -1,11 +1,8 @@
 import SwiftUI
 import AppKit
 
-/// Main expanded FlowPilot surface.
-///
-/// The Account surface is intentionally a UI-level fourth tab instead of a
-/// persisted `OverlayTab` enum case so older IPC clients that only know
-/// inspector/history/analytics remain wire-compatible.
+/// Main expanded FlowPilot surface. Account is kept as a UI-only fourth tab so
+/// the existing Inspector/History/Analytics IPC tab contract remains backward compatible.
 public struct SummaryView: View {
     @ObservedObject var state: OverlayState
     @ObservedObject private var localization = AppLocalization.shared
@@ -19,9 +16,7 @@ public struct SummaryView: View {
         self.isFullHeight = isFullHeight
     }
 
-    private var currentRun: TaskRun? {
-        state.inspectedRun ?? state.latestRun
-    }
+    private var currentRun: TaskRun? { state.inspectedRun ?? state.latestRun }
 
     public var body: some View {
         VStack(spacing: 0) {
@@ -53,21 +48,17 @@ public struct SummaryView: View {
             RoundedRectangle(cornerRadius: 18, style: .continuous)
                 .stroke(Color.white.opacity(0.11), lineWidth: 0.8)
         )
-        .onChange(of: state.activeTab) { _ in
-            // An IPC tab command should take precedence over the local Account tab.
-            if showingAccount {
-                showingAccount = false
-            }
+        .onChange(of: state.activeTab) { _, _ in
+            if showingAccount { showingAccount = false }
         }
     }
 
-    // MARK: - Chrome
+    // MARK: Chrome
 
     private var topBar: some View {
         HStack(spacing: 7) {
             FlowPilotLogoView(size: 29, showGlow: true, withBolt: false, text: "FP")
                 .frame(width: 29, height: 29)
-
             VStack(alignment: .leading, spacing: 0) {
                 Text("FlowPilot")
                     .font(.system(size: 11.5, weight: .heavy, design: .rounded))
@@ -76,30 +67,14 @@ public struct SummaryView: View {
                     .font(.system(size: 7.8, weight: .medium, design: .rounded))
                     .foregroundColor(statusColor.opacity(0.85))
             }
-
             Spacer()
-
-            chromeButton(
-                icon: state.isPrivacyMode ? "eye.slash.fill" : "eye.fill",
-                tint: state.isPrivacyMode ? .orange : .white.opacity(0.55),
-                help: L("Privacy mode", "隐私模式")
-            ) {
+            chromeButton(state.isPrivacyMode ? "eye.slash.fill" : "eye.fill", state.isPrivacyMode ? .orange : .white.opacity(0.55), L("Privacy mode", "隐私模式")) {
                 state.isPrivacyMode.toggle()
             }
-
-            chromeButton(
-                icon: state.isPinned ? "pin.fill" : "pin",
-                tint: state.isPinned ? .cyan : .white.opacity(0.55),
-                help: L("Pin window", "置顶窗口")
-            ) {
+            chromeButton(state.isPinned ? "pin.fill" : "pin", state.isPinned ? .cyan : .white.opacity(0.55), L("Pin window", "置顶窗口")) {
                 state.isPinned.toggle()
             }
-
-            chromeButton(
-                icon: "chevron.down",
-                tint: .white.opacity(0.55),
-                help: L("Collapse", "收起")
-            ) {
+            chromeButton("chevron.down", .white.opacity(0.55), L("Collapse", "收起")) {
                 state.collapse()
             }
         }
@@ -107,7 +82,7 @@ public struct SummaryView: View {
         .padding(.vertical, 8)
     }
 
-    private func chromeButton(icon: String, tint: Color, help: String, action: @escaping () -> Void) -> some View {
+    private func chromeButton(_ icon: String, _ tint: Color, _ help: String, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Image(systemName: icon)
                 .font(.system(size: 9, weight: .semibold))
@@ -122,21 +97,12 @@ public struct SummaryView: View {
     private var tabBar: some View {
         HStack(spacing: 3) {
             ForEach(OverlayTab.allCases) { tab in
-                tabButton(
-                    title: tab.localizedTitle,
-                    icon: tab.iconName,
-                    selected: !showingAccount && state.activeTab == tab
-                ) {
+                tabButton(tab.localizedTitle, tab.iconName, !showingAccount && state.activeTab == tab) {
                     showingAccount = false
                     state.selectTab(tab)
                 }
             }
-
-            tabButton(
-                title: L("Account", "账户"),
-                icon: "person.crop.circle.fill",
-                selected: showingAccount
-            ) {
+            tabButton(L("Account", "账户"), "person.crop.circle.fill", showingAccount) {
                 showingAccount = true
             }
         }
@@ -144,11 +110,10 @@ public struct SummaryView: View {
         .background(Color.black.opacity(0.12))
     }
 
-    private func tabButton(title: String, icon: String, selected: Bool, action: @escaping () -> Void) -> some View {
+    private func tabButton(_ title: String, _ icon: String, _ selected: Bool, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             HStack(spacing: 3) {
-                Image(systemName: icon)
-                    .font(.system(size: 7.8, weight: .semibold))
+                Image(systemName: icon).font(.system(size: 7.8, weight: .semibold))
                 Text(title)
                     .font(.system(size: 8.4, weight: selected ? .bold : .medium, design: .rounded))
                     .lineLimit(1)
@@ -159,10 +124,7 @@ public struct SummaryView: View {
             .background(
                 RoundedRectangle(cornerRadius: 7)
                     .fill(selected ? Color.cyan.opacity(0.22) : Color.clear)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 7)
-                            .stroke(selected ? Color.cyan.opacity(0.32) : Color.clear, lineWidth: 0.6)
-                    )
+                    .overlay(RoundedRectangle(cornerRadius: 7).stroke(selected ? Color.cyan.opacity(0.32) : Color.clear, lineWidth: 0.6))
             )
         }
         .buttonStyle(.plain)
@@ -172,10 +134,7 @@ public struct SummaryView: View {
         RoundedRectangle(cornerRadius: 18, style: .continuous)
             .fill(
                 LinearGradient(
-                    colors: [
-                        Color(red: 0.055, green: 0.062, blue: 0.085).opacity(0.98),
-                        Color(red: 0.035, green: 0.041, blue: 0.058).opacity(0.98)
-                    ],
+                    colors: [Color(red: 0.055, green: 0.062, blue: 0.085).opacity(0.98), Color(red: 0.035, green: 0.041, blue: 0.058).opacity(0.98)],
                     startPoint: .topLeading,
                     endPoint: .bottomTrailing
                 )
@@ -183,47 +142,16 @@ public struct SummaryView: View {
             .shadow(color: .black.opacity(0.48), radius: 18, y: 8)
     }
 
-    // MARK: - Inspector
+    // MARK: Inspector
 
     @ViewBuilder
     private var inspectorSurface: some View {
         if let run = currentRun {
-            let content = VStack(spacing: 8) {
-                if state.inspectedRun != nil {
-                    historicalBanner
-                }
-                projectHeader(run)
-                metricsGrid(run)
-
-                if !run.effectiveQuotaWindows.isEmpty {
-                    QuotaWindowsView(windows: run.effectiveQuotaWindows)
-                }
-
-                taskNarrativeCard(run)
-                participantsCard(run)
-                TokenUsageBreakdownView(usage: run.aggregatedUsage)
-
-                if run.allWorkers.contains(where: { !($0.conclusion ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) {
-                    workerOutcomesCard(run)
-                }
-
-                if run.hasTrajectory {
-                    trajectoryCard(run)
-                }
-
-                if run.hasLogs {
-                    logsCard(run)
-                }
-
-                actionFooter(run)
-            }
-            .padding(.top, 8)
-
             if isFullHeight {
-                content
+                inspectorContent(run)
             } else {
                 ScrollView(.vertical, showsIndicators: true) {
-                    content
+                    inspectorContent(run)
                 }
                 .frame(maxHeight: 440)
             }
@@ -232,26 +160,36 @@ public struct SummaryView: View {
         }
     }
 
+    private func inspectorContent(_ run: TaskRun) -> some View {
+        VStack(spacing: 8) {
+            if state.inspectedRun != nil { historicalBanner }
+            projectHeader(run)
+            metricsGrid(run)
+            if !run.effectiveQuotaWindows.isEmpty {
+                QuotaWindowsView(windows: run.effectiveQuotaWindows)
+            }
+            taskNarrativeCard(run)
+            participantsCard(run)
+            TokenUsageBreakdownView(usage: run.aggregatedUsage)
+            if !run.allWorkers.isEmpty { workerOutcomesCard(run) }
+            if run.hasTrajectory || run.hasLogs { executionDetailCard(run) }
+            actionFooter(run)
+        }
+        .padding(.top, 8)
+    }
+
     private var historicalBanner: some View {
         HStack(spacing: 5) {
-            Image(systemName: "clock.arrow.circlepath")
-                .font(.system(size: 8.5))
-                .foregroundColor(.cyan)
+            Image(systemName: "clock.arrow.circlepath").font(.system(size: 8.5)).foregroundColor(.cyan)
             Text(L("Viewing historical task", "正在查看历史任务"))
-                .font(.system(size: 8.8, weight: .semibold))
-                .foregroundColor(.cyan)
+                .font(.system(size: 8.8, weight: .semibold)).foregroundColor(.cyan)
             Spacer()
-            Button {
-                state.jumpToLive()
-            } label: {
-                Text(L("Live", "当前任务"))
-                    .font(.system(size: 8, weight: .bold))
-                    .foregroundColor(.white)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(Capsule().fill(Color.cyan.opacity(0.3)))
-            }
-            .buttonStyle(.plain)
+            Button(L("Live", "当前任务")) { state.jumpToLive() }
+                .buttonStyle(.plain)
+                .font(.system(size: 8, weight: .bold))
+                .foregroundColor(.white)
+                .padding(.horizontal, 6).padding(.vertical, 2)
+                .background(Capsule().fill(Color.cyan.opacity(0.3)))
         }
         .padding(7)
         .background(cardBackground(tint: .cyan))
@@ -260,49 +198,17 @@ public struct SummaryView: View {
     private func projectHeader(_ run: TaskRun) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 5) {
-                Image(systemName: "folder.fill")
-                    .font(.system(size: 8))
-                    .foregroundColor(.white.opacity(0.48))
-
-                HoverRevealText(
-                    run.projectName,
-                    font: .system(size: 10, weight: .bold, design: .rounded),
-                    foregroundColor: .white.opacity(0.94),
-                    lineLimit: 1,
-                    privacyBlur: state.isPrivacyMode,
-                    popoverWidth: 300
-                )
-
+                Image(systemName: "folder.fill").font(.system(size: 8)).foregroundColor(.white.opacity(0.48))
+                HoverRevealText(run.projectName, font: .system(size: 10, weight: .bold, design: .rounded), foregroundColor: .white.opacity(0.94), lineLimit: 1, privacyBlur: state.isPrivacyMode, popoverWidth: 300)
                 if let branch = run.gitBranch, !branch.isEmpty {
-                    Text("·")
-                        .foregroundColor(.white.opacity(0.25))
-                    Image(systemName: "point.topleft.down.curvedto.point.bottomright.up")
-                        .font(.system(size: 7))
-                        .foregroundColor(.cyan.opacity(0.85))
-                    HoverRevealText(
-                        branch,
-                        font: .system(size: 8.8, weight: .medium, design: .monospaced),
-                        foregroundColor: .cyan.opacity(0.88),
-                        lineLimit: 1,
-                        privacyBlur: state.isPrivacyMode,
-                        popoverWidth: 320
-                    )
+                    Text("·").foregroundColor(.white.opacity(0.25))
+                    HoverRevealText(branch, font: .system(size: 8.8, weight: .medium, design: .monospaced), foregroundColor: .cyan.opacity(0.88), lineLimit: 1, privacyBlur: state.isPrivacyMode, popoverWidth: 320)
                 }
-
                 Spacer(minLength: 2)
                 statusBadge(run)
             }
-
-            let preview = run.thread?.preview ?? run.summary ?? run.sessionTitle
-            HoverRevealText(
-                preview,
-                font: .system(size: 9.4),
-                foregroundColor: .white.opacity(0.63),
-                lineLimit: 1,
-                privacyBlur: state.isPrivacyMode,
-                popoverWidth: 380
-            )
-            .frame(maxWidth: .infinity, alignment: .leading)
+            HoverRevealText(run.thread?.preview ?? run.summary ?? run.sessionTitle, font: .system(size: 9.4), foregroundColor: .white.opacity(0.63), lineLimit: 1, privacyBlur: state.isPrivacyMode, popoverWidth: 390)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(8)
         .background(cardBackground())
@@ -311,90 +217,37 @@ public struct SummaryView: View {
     private func metricsGrid(_ run: TaskRun) -> some View {
         let usage = run.aggregatedUsage
         return HStack(spacing: 6) {
-            InspectorMetricView(
-                title: L("Time", "耗时"),
-                value: run.formattedDuration,
-                detail: L("wall time", "任务时长"),
-                icon: "timer",
-                accent: .cyan,
-                progress: min(1, run.durationSeconds / 600.0)
-            )
-
-            InspectorMetricView(
-                title: L("Tokens", "Token"),
-                value: run.formattedCompactTokens,
-                detail: L("total", "总用量"),
-                icon: "circle.grid.cross.fill",
-                accent: Color(red: 0.95, green: 0.35, blue: 0.8),
-                progress: min(1, Double(usage.totalTokens ?? 0) / 100_000.0)
-            )
-
-            // This intentionally replaces the old "Cost" ring. Credits are not
-            // monetary USD and are often unavailable, so presenting them as cost
-            // was both ambiguous and commonly blank.
-            InspectorMetricView(
-                title: L("Output", "输出"),
-                value: TaskRun.formatTokenCount(usage.effectiveOutputTokens),
-                detail: L("tokens", "Token"),
-                icon: "arrow.up.circle.fill",
-                accent: Color(red: 0.25, green: 0.88, blue: 0.58),
-                progress: outputShare(usage)
-            )
+            InspectorMetricView(title: L("Time", "耗时"), value: run.formattedDuration, detail: L("wall time", "任务时长"), icon: "timer", accent: .cyan, progress: min(1, run.durationSeconds / 600.0))
+            InspectorMetricView(title: L("Tokens", "Token"), value: run.formattedCompactTokens, detail: L("total", "总用量"), icon: "circle.grid.cross.fill", accent: Color(red: 0.95, green: 0.35, blue: 0.8), progress: min(1, Double(usage.totalTokens ?? 0) / 100_000.0))
+            // Replaces the ambiguous old Cost ring. Optional credits are not USD.
+            InspectorMetricView(title: L("Output", "输出"), value: TaskRun.formatTokenCount(usage.effectiveOutputTokens), detail: L("tokens", "Token"), icon: "arrow.up.circle.fill", accent: Color(red: 0.25, green: 0.88, blue: 0.58), progress: outputShare(usage))
         }
     }
 
     private func outputShare(_ usage: TokenUsage) -> Double {
-        let total = max(1, usage.totalTokens ?? 0)
-        return min(1, Double(usage.effectiveOutputTokens) / Double(total))
+        Double(usage.effectiveOutputTokens) / Double(max(1, usage.totalTokens ?? 0))
     }
 
     private func taskNarrativeCard(_ run: TaskRun) -> some View {
         VStack(alignment: .leading, spacing: 6) {
-            sectionHeader(icon: "sparkles.rectangle.stack.fill", title: L("Task Objective & Summary", "任务目标与概要说明"), tint: .cyan)
-
+            sectionHeader("sparkles.rectangle.stack.fill", L("Task Objective & Summary", "任务目标与概要说明"), .cyan)
             if let goal = run.effectiveGoal, !goal.isEmpty {
-                narrativeBlock(
-                    label: L("Objective", "目标"),
-                    icon: "target",
-                    text: goal,
-                    tint: .cyan,
-                    lineLimit: 3
-                )
+                narrativeBlock(L("Objective", "目标"), "target", goal, .cyan, 3)
             }
-
             if let conclusion = run.effectiveConclusion, !conclusion.isEmpty {
-                narrativeBlock(
-                    label: L("Outcome / Conclusion", "交付结论"),
-                    icon: "checkmark.seal.fill",
-                    text: conclusion,
-                    tint: Color(red: 0.25, green: 0.88, blue: 0.58),
-                    lineLimit: 4
-                )
+                narrativeBlock(L("Outcome / Conclusion", "交付结论"), "checkmark.seal.fill", conclusion, .green, 4)
             }
         }
         .padding(8)
         .background(cardBackground())
     }
 
-    private func narrativeBlock(label: String, icon: String, text: String, tint: Color, lineLimit: Int) -> some View {
+    private func narrativeBlock(_ label: String, _ icon: String, _ text: String, _ tint: Color, _ lines: Int) -> some View {
         VStack(alignment: .leading, spacing: 3) {
-            HStack(spacing: 3) {
-                Image(systemName: icon)
-                    .font(.system(size: 7.5))
-                Text(label)
-                    .font(.system(size: 8.2, weight: .bold))
-            }
-            .foregroundColor(tint.opacity(0.9))
-
-            HoverRevealText(
-                text,
-                font: .system(size: 9.3),
-                foregroundColor: .white.opacity(0.88),
-                lineLimit: lineLimit,
-                privacyBlur: state.isPrivacyMode,
-                popoverWidth: 390
-            )
-            .frame(maxWidth: .infinity, alignment: .leading)
+            Label(label, systemImage: icon)
+                .font(.system(size: 8.2, weight: .bold)).foregroundColor(tint.opacity(0.9))
+            HoverRevealText(text, font: .system(size: 9.3), foregroundColor: .white.opacity(0.88), lineLimit: lines, privacyBlur: state.isPrivacyMode, popoverWidth: 390)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(6)
         .background(RoundedRectangle(cornerRadius: 7).fill(tint.opacity(0.07)))
@@ -402,57 +255,23 @@ public struct SummaryView: View {
 
     private func participantsCard(_ run: TaskRun) -> some View {
         HStack(spacing: 6) {
-            participantBlock(
-                icon: "brain.head.profile",
-                title: L("Parent", "父 Agent"),
-                name: run.parent?.displayModel ?? L("Direct CLI", "直接 CLI"),
-                subtitle: participantSubtitle(run.parent),
-                tint: .indigo
-            )
-
-            let workerSummary: String
-            if run.allWorkers.isEmpty {
-                workerSummary = L("Direct execution", "直接执行")
-            } else if run.allWorkers.count == 1 {
-                workerSummary = run.allWorkers[0].name ?? run.allWorkers[0].displayModel
-            } else {
-                workerSummary = L("\(run.allWorkers.count) workers", "\(run.allWorkers.count) 个 Worker")
-            }
-
-            participantBlock(
-                icon: "person.2.fill",
-                title: L("Workers", "Worker"),
-                name: workerSummary,
-                subtitle: L("\(run.allWorkers.count) subagents", "\(run.allWorkers.count) 个子 Agent"),
-                tint: .teal
-            )
+            participantBlock("brain.head.profile", L("Parent", "父 Agent"), run.parent?.displayModel ?? L("Direct CLI", "直接 CLI"), participantSubtitle(run.parent), .indigo)
+            participantBlock("person.2.fill", L("Workers", "Worker"), workerSummaryText(run), L("\(run.allWorkers.count) subagents", "\(run.allWorkers.count) 个子 Agent"), .teal)
         }
     }
 
-    private func participantBlock(icon: String, title: String, name: String, subtitle: String, tint: Color) -> some View {
+    private func workerSummaryText(_ run: TaskRun) -> String {
+        if run.allWorkers.isEmpty { return L("Direct execution", "直接执行") }
+        if run.allWorkers.count == 1 { return run.allWorkers[0].name ?? run.allWorkers[0].displayModel }
+        return L("\(run.allWorkers.count) workers", "\(run.allWorkers.count) 个 Worker")
+    }
+
+    private func participantBlock(_ icon: String, _ title: String, _ name: String, _ subtitle: String, _ tint: Color) -> some View {
         VStack(alignment: .leading, spacing: 3) {
-            HStack(spacing: 3) {
-                Image(systemName: icon)
-                    .font(.system(size: 8))
-                    .foregroundColor(tint.opacity(0.9))
-                Text(title)
-                    .font(.system(size: 8.5, weight: .semibold))
-                    .foregroundColor(.white.opacity(0.58))
-            }
-
-            HoverRevealText(
-                name,
-                font: .system(size: 9.8, weight: .bold, design: .rounded),
-                foregroundColor: .white.opacity(0.9),
-                lineLimit: 1,
-                privacyBlur: false,
-                popoverWidth: 280
-            )
-
-            Text(subtitle)
-                .font(.system(size: 7.8))
-                .foregroundColor(.white.opacity(0.4))
-                .lineLimit(1)
+            Label(title, systemImage: icon)
+                .font(.system(size: 8.5, weight: .semibold)).foregroundColor(tint.opacity(0.9))
+            HoverRevealText(name, font: .system(size: 9.8, weight: .bold, design: .rounded), foregroundColor: .white.opacity(0.9), lineLimit: 1, popoverWidth: 280)
+            Text(subtitle).font(.system(size: 7.8)).foregroundColor(.white.opacity(0.4)).lineLimit(1)
         }
         .padding(7)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -462,49 +281,24 @@ public struct SummaryView: View {
     private func participantSubtitle(_ participant: ParticipantInfo?) -> String {
         guard let participant else { return L("No usage data", "暂无用量数据") }
         let tokens = participant.effectiveUsage?.totalTokens ?? 0
-        if let effort = participant.displayEffort {
-            return "\(effort) · \(TaskRun.formatTokenCount(tokens)) tokens"
-        }
+        if let effort = participant.displayEffort { return "\(effort) · \(TaskRun.formatTokenCount(tokens)) tokens" }
         return "\(TaskRun.formatTokenCount(tokens)) tokens"
     }
 
     private func workerOutcomesCard(_ run: TaskRun) -> some View {
-        let workers = run.allWorkers.filter {
-            !($0.conclusion ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        }
-
-        return VStack(alignment: .leading, spacing: 5) {
-            sectionHeader(icon: "checkmark.bubble.fill", title: L("Worker Outcomes", "Worker 执行结果"), tint: .teal)
-
-            ForEach(workers) { worker in
+        VStack(alignment: .leading, spacing: 5) {
+            sectionHeader("checkmark.bubble.fill", L("Worker Outcomes", "Worker 执行结果"), .teal)
+            ForEach(run.allWorkers) { worker in
                 VStack(alignment: .leading, spacing: 2) {
                     HStack(spacing: 4) {
-                        HoverRevealText(
-                            worker.agentType ?? worker.name ?? L("Worker", "Worker"),
-                            font: .system(size: 8.7, weight: .semibold, design: .rounded),
-                            foregroundColor: .white.opacity(0.88),
-                            lineLimit: 1,
-                            popoverWidth: 300
-                        )
+                        HoverRevealText(worker.agentType ?? worker.name ?? L("Worker", "Worker"), font: .system(size: 8.7, weight: .semibold, design: .rounded), foregroundColor: .white.opacity(0.88), lineLimit: 1, popoverWidth: 300)
                         Spacer(minLength: 4)
-                        HoverRevealText(
-                            worker.displayModel,
-                            font: .system(size: 7.7, weight: .medium, design: .monospaced),
-                            foregroundColor: .teal.opacity(0.78),
-                            lineLimit: 1,
-                            popoverWidth: 280
-                        )
+                        HoverRevealText(worker.displayModel, font: .system(size: 7.7, weight: .medium, design: .monospaced), foregroundColor: .teal.opacity(0.78), lineLimit: 1, popoverWidth: 280)
                     }
-
-                    HoverRevealText(
-                        worker.conclusion ?? "",
-                        font: .system(size: 8.8),
-                        foregroundColor: .white.opacity(0.64),
-                        lineLimit: 3,
-                        privacyBlur: state.isPrivacyMode,
-                        popoverWidth: 390
-                    )
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                    if let conclusion = worker.conclusion, !conclusion.isEmpty {
+                        HoverRevealText(conclusion, font: .system(size: 8.8), foregroundColor: .white.opacity(0.64), lineLimit: 3, privacyBlur: state.isPrivacyMode, popoverWidth: 390)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
                 }
                 .padding(6)
                 .background(RoundedRectangle(cornerRadius: 7).fill(Color.white.opacity(0.025)))
@@ -514,77 +308,30 @@ public struct SummaryView: View {
         .background(cardBackground())
     }
 
-    private func trajectoryCard(_ run: TaskRun) -> some View {
-        let steps = run.trajectory ?? []
-        return VStack(alignment: .leading, spacing: 5) {
-            sectionHeader(icon: "point.filled.topleft.down.curvedto.point.bottomright.up", title: L("Execution Trajectory", "执行步骤轨迹"), tint: .indigo)
-
-            ForEach(Array(steps.prefix(8))) { step in
+    private func executionDetailCard(_ run: TaskRun) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            sectionHeader("point.filled.topleft.down.curvedto.point.bottomright.up", L("Execution Details", "执行详情"), .indigo)
+            ForEach(Array((run.trajectory ?? []).prefix(6))) { step in
                 HStack(alignment: .top, spacing: 5) {
-                    Circle()
-                        .fill(step.status == "error" ? Color.orange : Color.cyan)
-                        .frame(width: 4.5, height: 4.5)
-                        .padding(.top, 4)
-
+                    Circle().fill(step.status == "error" ? Color.orange : Color.cyan).frame(width: 4.5, height: 4.5).padding(.top, 4)
                     VStack(alignment: .leading, spacing: 1) {
-                        HoverRevealText(
-                            step.title ?? step.name ?? "Step",
-                            font: .system(size: 8.7, weight: .semibold),
-                            foregroundColor: .white.opacity(0.82),
-                            lineLimit: 1,
-                            popoverWidth: 360
-                        )
+                        HoverRevealText(step.title ?? step.name ?? "Step", font: .system(size: 8.6, weight: .semibold), foregroundColor: .white.opacity(0.82), lineLimit: 1, popoverWidth: 360)
                         if let detail = step.detail, !detail.isEmpty {
-                            HoverRevealText(
-                                detail,
-                                font: .system(size: 7.8, design: .monospaced),
-                                foregroundColor: .white.opacity(0.5),
-                                lineLimit: 1,
-                                privacyBlur: state.isPrivacyMode,
-                                popoverWidth: 410
-                            )
+                            HoverRevealText(detail, font: .system(size: 7.8, design: .monospaced), foregroundColor: .white.opacity(0.5), lineLimit: 1, privacyBlur: state.isPrivacyMode, popoverWidth: 410)
                         }
                     }
                 }
             }
-
-            if steps.count > 8 {
-                Text(L("+\(steps.count - 8) more steps", "还有 \(steps.count - 8) 个步骤"))
-                    .font(.system(size: 7.8))
-                    .foregroundColor(.white.opacity(0.38))
-            }
-        }
-        .padding(8)
-        .background(cardBackground())
-    }
-
-    private func logsCard(_ run: TaskRun) -> some View {
-        let logs = Array((run.logs ?? []).suffix(6))
-        return VStack(alignment: .leading, spacing: 4) {
-            sectionHeader(icon: "doc.text.magnifyingglass", title: L("Execution Logs", "执行日志流"), tint: .teal)
-
-            ForEach(logs) { entry in
-                HStack(alignment: .top, spacing: 4) {
-                    Circle()
-                        .fill(entry.level == "error" ? Color.orange : Color.green)
-                        .frame(width: 4, height: 4)
-                        .padding(.top, 4)
-                    HoverRevealText(
-                        entry.message ?? "",
-                        font: .system(size: 7.8, design: .monospaced),
-                        foregroundColor: entry.level == "error" ? .orange.opacity(0.85) : .white.opacity(0.65),
-                        lineLimit: 2,
-                        privacyBlur: state.isPrivacyMode,
-                        popoverWidth: 420
-                    )
-                    .frame(maxWidth: .infinity, alignment: .leading)
+            ForEach(Array((run.logs ?? []).suffix(4))) { entry in
+                HStack(alignment: .top, spacing: 5) {
+                    Circle().fill(entry.level == "error" ? Color.orange : Color.green).frame(width: 4, height: 4).padding(.top, 4)
+                    HoverRevealText(entry.message ?? "", font: .system(size: 7.7, design: .monospaced), foregroundColor: entry.level == "error" ? .orange.opacity(0.85) : .white.opacity(0.58), lineLimit: 2, privacyBlur: state.isPrivacyMode, popoverWidth: 420)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
         }
         .padding(8)
-        .background(RoundedRectangle(cornerRadius: 9).fill(Color.black.opacity(0.28)).overlay(
-            RoundedRectangle(cornerRadius: 9).stroke(Color.white.opacity(0.06), lineWidth: 0.6)
-        ))
+        .background(cardBackground())
     }
 
     private func actionFooter(_ run: TaskRun) -> some View {
@@ -595,164 +342,82 @@ public struct SummaryView: View {
                 Label(copiedSummary ? L("Copied", "已复制") : L("Copy summary", "复制摘要"), systemImage: copiedSummary ? "checkmark" : "doc.on.doc")
                     .font(.system(size: 8.6, weight: .semibold))
                     .foregroundColor(copiedSummary ? .green : .white.opacity(0.75))
-                    .padding(.horizontal, 7)
-                    .padding(.vertical, 4)
+                    .padding(.horizontal, 7).padding(.vertical, 4)
                     .background(RoundedRectangle(cornerRadius: 6).fill(Color.white.opacity(0.05)))
             }
             .buttonStyle(.plain)
-
-            Button {
-                openConsole()
-            } label: {
-                Label(L("Console", "控制台"), systemImage: "terminal.fill")
-                    .font(.system(size: 8.6, weight: .semibold))
-                    .foregroundColor(.white.opacity(0.75))
-                    .padding(.horizontal, 7)
-                    .padding(.vertical, 4)
-                    .background(RoundedRectangle(cornerRadius: 6).fill(Color.white.opacity(0.05)))
-            }
-            .buttonStyle(.plain)
-
             Spacer()
-
-            Text(run.localizedFormattedDate)
-                .font(.system(size: 7.8))
-                .foregroundColor(.white.opacity(0.35))
+            Text(run.localizedFormattedDate).font(.system(size: 7.8)).foregroundColor(.white.opacity(0.35))
         }
     }
 
     private var idleInspector: some View {
         VStack(spacing: 10) {
             FlowPilotLogoView(size: 58, showGlow: true, withBolt: true, text: "FlowPilot")
-                .frame(width: 58, height: 58)
-                .padding(.top, 20)
+                .frame(width: 58, height: 58).padding(.top, 20)
             Text(L("FlowPilot is Ready", "FlowPilot 已就绪"))
-                .font(.system(size: 13, weight: .bold, design: .rounded))
-                .foregroundColor(.white)
+                .font(.system(size: 13, weight: .bold, design: .rounded)).foregroundColor(.white)
             Text(L("Listening for live task and usage telemetry", "正在监听任务与用量遥测"))
-                .font(.system(size: 9.5))
-                .foregroundColor(.white.opacity(0.48))
-            Button {
-                showingAccount = true
-            } label: {
+                .font(.system(size: 9.5)).foregroundColor(.white.opacity(0.48))
+            Button { showingAccount = true } label: {
                 Label(L("View Account Limits", "查看账户额度"), systemImage: "person.crop.circle")
-                    .font(.system(size: 9, weight: .semibold))
-                    .foregroundColor(.cyan)
-                    .padding(.horizontal, 9)
-                    .padding(.vertical, 5)
+                    .font(.system(size: 9, weight: .semibold)).foregroundColor(.cyan)
+                    .padding(.horizontal, 9).padding(.vertical, 5)
                     .background(Capsule().fill(Color.cyan.opacity(0.12)))
-            }
-            .buttonStyle(.plain)
+            }.buttonStyle(.plain)
             Spacer(minLength: 12)
         }
         .frame(maxWidth: .infinity, minHeight: 300)
     }
 
-    // MARK: - Helpers
+    // MARK: Helpers
 
     private func statusBadge(_ run: TaskRun) -> some View {
         HStack(spacing: 3) {
             Circle().fill(runStatusColor(run)).frame(width: 4.5, height: 4.5)
-            Text(runStatusText(run))
-                .font(.system(size: 7.4, weight: .bold, design: .rounded))
+            Text(runStatusText(run)).font(.system(size: 7.4, weight: .bold, design: .rounded))
         }
         .foregroundColor(runStatusColor(run))
-        .padding(.horizontal, 5)
-        .padding(.vertical, 2)
+        .padding(.horizontal, 5).padding(.vertical, 2)
         .background(Capsule().fill(runStatusColor(run).opacity(0.12)))
     }
 
     private func runStatusColor(_ run: TaskRun) -> Color {
-        if run.isRunning { return .cyan }
-        if run.isError { return .orange }
-        return Color(red: 0.25, green: 0.88, blue: 0.58)
+        run.isRunning ? .cyan : (run.isError ? .orange : .green)
     }
 
     private func runStatusText(_ run: TaskRun) -> String {
-        if run.isRunning { return L("RUNNING", "运行中") }
-        if run.isError { return L("FAILED", "失败") }
-        return L("COMPLETED", "已完成")
+        run.isRunning ? L("RUNNING", "运行中") : (run.isError ? L("FAILED", "失败") : L("COMPLETED", "已完成"))
     }
 
-    private var statusText: String {
-        guard let run = currentRun else { return L("READY", "就绪") }
-        return runStatusText(run)
-    }
+    private var statusText: String { currentRun.map(runStatusText) ?? L("READY", "就绪") }
+    private var statusColor: Color { currentRun.map(runStatusColor) ?? .green }
 
-    private var statusColor: Color {
-        guard let run = currentRun else { return Color(red: 0.25, green: 0.88, blue: 0.58) }
-        return runStatusColor(run)
-    }
-
-    private func sectionHeader(icon: String, title: String, tint: Color) -> some View {
+    private func sectionHeader(_ icon: String, _ title: String, _ tint: Color) -> some View {
         HStack(spacing: 4) {
-            Image(systemName: icon)
-                .font(.system(size: 8))
-                .foregroundColor(tint)
-            Text(title)
-                .font(.system(size: 8.8, weight: .bold, design: .rounded))
-                .foregroundColor(.white.opacity(0.7))
+            Image(systemName: icon).font(.system(size: 8)).foregroundColor(tint)
+            Text(title).font(.system(size: 8.8, weight: .bold, design: .rounded)).foregroundColor(.white.opacity(0.7))
             Spacer()
         }
     }
 
     private func cardBackground(tint: Color? = nil) -> some View {
-        RoundedRectangle(cornerRadius: 9)
-            .fill((tint ?? .white).opacity(tint == nil ? 0.04 : 0.07))
-            .overlay(
-                RoundedRectangle(cornerRadius: 9)
-                    .stroke((tint ?? .white).opacity(tint == nil ? 0.075 : 0.18), lineWidth: 0.7)
-            )
+        let base = tint ?? Color.white
+        return RoundedRectangle(cornerRadius: 9)
+            .fill(base.opacity(tint == nil ? 0.04 : 0.07))
+            .overlay(RoundedRectangle(cornerRadius: 9).stroke(base.opacity(tint == nil ? 0.075 : 0.18), lineWidth: 0.7))
     }
 
     private func copySummary(_ run: TaskRun) {
         let usage = run.aggregatedUsage
         let text = L(
-            """
-            FlowPilot Task Summary
-            Project: \(run.projectName) (\(run.gitBranch ?? "main"))
-            Duration: \(run.formattedDuration)
-            Total tokens: \(run.formattedTotalTokens)
-            Input tokens: \(TaskRun.formatTokenCount(usage.effectivePromptTokens))
-            Output tokens: \(TaskRun.formatTokenCount(usage.effectiveOutputTokens))
-            Cached input: \(TaskRun.formatTokenCount(usage.effectiveCachedTokens))
-            Parent: \(run.parent?.displayModel ?? "unknown")
-            Workers: \(run.allWorkers.count)
-            Summary: \(run.summary ?? run.sessionTitle)
-            """,
-            """
-            FlowPilot 任务摘要
-            项目：\(run.projectName)（\(run.gitBranch ?? "main")）
-            耗时：\(run.formattedDuration)
-            总 Token：\(run.formattedTotalTokens)
-            输入 Token：\(TaskRun.formatTokenCount(usage.effectivePromptTokens))
-            输出 Token：\(TaskRun.formatTokenCount(usage.effectiveOutputTokens))
-            缓存输入：\(TaskRun.formatTokenCount(usage.effectiveCachedTokens))
-            父 Agent：\(run.parent?.displayModel ?? "unknown")
-            Worker：\(run.allWorkers.count)
-            摘要：\(run.summary ?? run.sessionTitle)
-            """
+            "FlowPilot Task Summary\nProject: \(run.projectName)\nDuration: \(run.formattedDuration)\nTotal tokens: \(run.formattedTotalTokens)\nInput tokens: \(TaskRun.formatTokenCount(usage.effectivePromptTokens))\nOutput tokens: \(TaskRun.formatTokenCount(usage.effectiveOutputTokens))\nWorkers: \(run.allWorkers.count)\nSummary: \(run.summary ?? run.sessionTitle)",
+            "FlowPilot 任务摘要\n项目：\(run.projectName)\n耗时：\(run.formattedDuration)\n总 Token：\(run.formattedTotalTokens)\n输入 Token：\(TaskRun.formatTokenCount(usage.effectivePromptTokens))\n输出 Token：\(TaskRun.formatTokenCount(usage.effectiveOutputTokens))\nWorker：\(run.allWorkers.count)\n摘要：\(run.summary ?? run.sessionTitle)"
         )
-
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(text, forType: .string)
         copiedSummary = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-            copiedSummary = false
-        }
-    }
-
-    private func openConsole() {
-        let script = """
-        tell application "Terminal"
-            activate
-            do script "codex-flow"
-        end tell
-        """
-        if let appleScript = NSAppleScript(source: script) {
-            var error: NSDictionary?
-            appleScript.executeAndReturnError(&error)
-        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { copiedSummary = false }
     }
 }
 
@@ -769,40 +434,21 @@ public struct InspectorMetricView: View {
     public var body: some View {
         VStack(spacing: 3) {
             ZStack {
-                Circle()
-                    .stroke(Color.white.opacity(0.07), lineWidth: 3)
+                Circle().stroke(Color.white.opacity(0.07), lineWidth: 3)
                 Circle()
                     .trim(from: 0, to: CGFloat(max(0.015, min(1, progress))))
                     .stroke(accent, style: StrokeStyle(lineWidth: 3, lineCap: .round))
                     .rotationEffect(.degrees(-90))
-                Image(systemName: icon)
-                    .font(.system(size: 8.5, weight: .semibold))
-                    .foregroundColor(accent)
+                Image(systemName: icon).font(.system(size: 8.5, weight: .semibold)).foregroundColor(accent)
             }
             .frame(width: 29, height: 29)
-
-            Text(title)
-                .font(.system(size: 7.6, weight: .semibold, design: .rounded))
-                .foregroundColor(.white.opacity(0.48))
-                .textCase(.uppercase)
-
-            Text(value)
-                .font(.system(size: 10.5, weight: .bold, design: .rounded))
-                .foregroundColor(.white)
-                .lineLimit(1)
-
-            Text(detail)
-                .font(.system(size: 6.9))
-                .foregroundColor(.white.opacity(0.32))
-                .lineLimit(1)
+            Text(title).font(.system(size: 7.6, weight: .semibold, design: .rounded)).foregroundColor(.white.opacity(0.48)).textCase(.uppercase)
+            Text(value).font(.system(size: 10.5, weight: .bold, design: .rounded)).foregroundColor(.white).lineLimit(1)
+            Text(detail).font(.system(size: 6.9)).foregroundColor(.white.opacity(0.32)).lineLimit(1)
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 7)
-        .background(
-            RoundedRectangle(cornerRadius: 9)
-                .fill(Color.white.opacity(0.035))
-                .overlay(RoundedRectangle(cornerRadius: 9).stroke(Color.white.opacity(0.07), lineWidth: 0.7))
-        )
+        .background(RoundedRectangle(cornerRadius: 9).fill(Color.white.opacity(0.035)).overlay(RoundedRectangle(cornerRadius: 9).stroke(Color.white.opacity(0.07), lineWidth: 0.7)))
     }
 }
 
@@ -810,12 +456,9 @@ public struct InspectorMetricView: View {
 
 public struct QuotaWindowsView: View {
     public let windows: [QuotaWindow]
+    public init(windows: [QuotaWindow]) { self.windows = windows }
 
-    public init(windows: [QuotaWindow]) {
-        self.windows = windows
-    }
-
-    private var orderedWindows: [QuotaWindow] {
+    private var ordered: [QuotaWindow] {
         windows.sorted { ($0.windowDurationMins ?? Int.max) < ($1.windowDurationMins ?? Int.max) }
     }
 
@@ -823,26 +466,16 @@ public struct QuotaWindowsView: View {
         VStack(alignment: .leading, spacing: 6) {
             HStack {
                 Label(L("Quota remaining", "额度剩余"), systemImage: "gauge.with.needle.fill")
-                    .font(.system(size: 8.8, weight: .bold, design: .rounded))
-                    .foregroundColor(.white.opacity(0.7))
+                    .font(.system(size: 8.8, weight: .bold, design: .rounded)).foregroundColor(.white.opacity(0.7))
                 Spacer()
-                if let reset = orderedWindows.first?.localizedFormattedResetsAt {
-                    Text(reset)
-                        .font(.system(size: 7.4, weight: .medium, design: .monospaced))
-                        .foregroundColor(.white.opacity(0.4))
+                if let reset = ordered.first?.localizedFormattedResetsAt {
+                    Text(reset).font(.system(size: 7.4, weight: .medium, design: .monospaced)).foregroundColor(.white.opacity(0.4))
                 }
             }
-
-            ForEach(orderedWindows) { window in
-                quotaRow(window)
-            }
+            ForEach(ordered) { quotaRow($0) }
         }
         .padding(8)
-        .background(
-            RoundedRectangle(cornerRadius: 9)
-                .fill(Color.white.opacity(0.035))
-                .overlay(RoundedRectangle(cornerRadius: 9).stroke(Color.white.opacity(0.07), lineWidth: 0.7))
-        )
+        .background(RoundedRectangle(cornerRadius: 9).fill(Color.white.opacity(0.035)).overlay(RoundedRectangle(cornerRadius: 9).stroke(Color.white.opacity(0.07), lineWidth: 0.7)))
     }
 
     private func quotaRow(_ window: QuotaWindow) -> some View {
@@ -851,42 +484,28 @@ public struct QuotaWindowsView: View {
         let tint: Color = used >= 85 ? .orange : (used >= 60 ? .yellow : .cyan)
         return VStack(spacing: 3) {
             HStack {
-                Text(window.label)
-                    .font(.system(size: 8, weight: .heavy, design: .monospaced))
-                    .foregroundColor(tint)
-                    .frame(width: 34, alignment: .leading)
-                Text(String(format: L("%.0f%% left", "剩余 %.0f%%"), remaining))
-                    .font(.system(size: 8, weight: .bold, design: .rounded))
-                    .foregroundColor(.white.opacity(0.72))
+                Text(window.label).font(.system(size: 8, weight: .heavy, design: .monospaced)).foregroundColor(tint).frame(width: 34, alignment: .leading)
+                Text(String(format: L("%.0f%% left", "剩余 %.0f%%"), remaining)).font(.system(size: 8, weight: .bold, design: .rounded)).foregroundColor(.white.opacity(0.72))
                 Spacer()
                 if let reset = window.localizedFormattedResetsAt {
-                    Text(reset)
-                        .font(.system(size: 7.3, weight: .medium, design: .monospaced))
-                        .foregroundColor(.white.opacity(0.42))
+                    Text(reset).font(.system(size: 7.3, weight: .medium, design: .monospaced)).foregroundColor(.white.opacity(0.42))
                 }
             }
-
             GeometryReader { proxy in
                 ZStack(alignment: .leading) {
                     Capsule().fill(Color.white.opacity(0.075))
-                    Capsule()
-                        .fill(tint)
-                        .frame(width: proxy.size.width * CGFloat(max(0, min(1, remaining / 100.0))))
+                    Capsule().fill(tint).frame(width: proxy.size.width * CGFloat(max(0, min(1, remaining / 100.0))))
                 }
-            }
-            .frame(height: 4)
+            }.frame(height: 4)
         }
     }
 }
 
-// MARK: - Token Usage Breakdown
+// MARK: - Token Usage
 
 public struct TokenUsageBreakdownView: View {
     public let usage: TokenUsage
-
-    public init(usage: TokenUsage) {
-        self.usage = usage
-    }
+    public init(usage: TokenUsage) { self.usage = usage }
 
     public var body: some View {
         let input = usage.effectivePromptTokens
@@ -895,55 +514,41 @@ public struct TokenUsageBreakdownView: View {
         let reasoning = usage.effectiveReasoningTokens
         let total = max(1, input + output + cached + reasoning)
 
-        VStack(alignment: .leading, spacing: 5) {
+        return VStack(alignment: .leading, spacing: 5) {
             HStack {
-                Text(L("Token usage", "Token 用量"))
-                    .font(.system(size: 8.8, weight: .bold, design: .rounded))
-                    .foregroundColor(.white.opacity(0.7))
+                Text(L("Token usage", "Token 用量")).font(.system(size: 8.8, weight: .bold, design: .rounded)).foregroundColor(.white.opacity(0.7))
                 Spacer()
-                Text(TaskRun.formatTokenCount(usage.totalTokens ?? 0))
-                    .font(.system(size: 8.5, weight: .bold, design: .rounded))
-                    .foregroundColor(Color(red: 0.95, green: 0.35, blue: 0.8))
+                Text(TaskRun.formatTokenCount(usage.totalTokens ?? 0)).font(.system(size: 8.5, weight: .bold, design: .rounded)).foregroundColor(Color(red: 0.95, green: 0.35, blue: 0.8))
             }
-
             GeometryReader { proxy in
                 HStack(spacing: 1) {
-                    usageSegment(width: proxy.size.width, value: input, total: total, color: .cyan)
-                    usageSegment(width: proxy.size.width, value: output, total: total, color: .green)
-                    usageSegment(width: proxy.size.width, value: cached, total: total, color: .indigo)
-                    usageSegment(width: proxy.size.width, value: reasoning, total: total, color: .purple)
+                    segment(proxy.size.width, input, total, .cyan)
+                    segment(proxy.size.width, output, total, .green)
+                    segment(proxy.size.width, cached, total, .indigo)
+                    segment(proxy.size.width, reasoning, total, .purple)
                 }
             }
             .frame(height: 5)
             .clipShape(Capsule())
-
             HStack(spacing: 8) {
                 legend(L("Input", "输入"), input, .cyan)
                 legend(L("Output", "输出"), output, .green)
                 legend(L("Cached", "缓存"), cached, .indigo)
-                if reasoning > 0 {
-                    legend(L("Reasoning", "推理"), reasoning, .purple)
-                }
+                if reasoning > 0 { legend(L("Reasoning", "推理"), reasoning, .purple) }
             }
         }
         .padding(8)
-        .background(
-            RoundedRectangle(cornerRadius: 9)
-                .fill(Color.white.opacity(0.035))
-                .overlay(RoundedRectangle(cornerRadius: 9).stroke(Color.white.opacity(0.07), lineWidth: 0.7))
-        )
+        .background(RoundedRectangle(cornerRadius: 9).fill(Color.white.opacity(0.035)).overlay(RoundedRectangle(cornerRadius: 9).stroke(Color.white.opacity(0.07), lineWidth: 0.7)))
     }
 
-    private func usageSegment(width: CGFloat, value: Int, total: Int, color: Color) -> some View {
+    private func segment(_ width: CGFloat, _ value: Int, _ total: Int, _ color: Color) -> some View {
         color.frame(width: max(0, width * CGFloat(Double(value) / Double(total))))
     }
 
     private func legend(_ title: String, _ value: Int, _ color: Color) -> some View {
         HStack(spacing: 2.5) {
             Circle().fill(color).frame(width: 4, height: 4)
-            Text("\(title) \(TaskRun.formatTokenCount(value))")
-                .font(.system(size: 7.1, weight: .medium, design: .rounded))
-                .foregroundColor(.white.opacity(0.45))
+            Text("\(title) \(TaskRun.formatTokenCount(value))").font(.system(size: 7.1, weight: .medium, design: .rounded)).foregroundColor(.white.opacity(0.45))
         }
     }
 }

--- a/apps/macos-overlay/Sources/main.swift
+++ b/apps/macos-overlay/Sources/main.swift
@@ -6,16 +6,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var windowController: OverlayWindowController!
     var watcher: TelemetryWatcher!
     var ipcServer: IPCService.Server!
-    
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory)
-        
+        FlowPilotAutostartService.reconcileAtLaunch()
+
         state = OverlayState()
         windowController = OverlayWindowController(state: state)
         watcher = TelemetryWatcher(state: state)
         ipcServer = IPCService.Server(state: state)
     }
-    
+
     func applicationWillTerminate(_ notification: Notification) {
         watcher?.stopWatching()
         ipcServer?.stop()
@@ -35,6 +36,7 @@ func printUsage() {
           restart                   Restart the running FlowPilot daemon with fresh build
           stop, quit                Stop running FlowPilot daemon
           status                    Check if FlowPilot daemon is currently active
+          autostart [action]        Login launch: status|enable|disable
           toggle                    Toggle between circular bubble and expanded summary
           expand                    Expand summary window
           collapse                  Collapse to circular bubble
@@ -56,6 +58,7 @@ func printUsage() {
           restart                   使用最新构建重启 FlowPilot
           stop, quit                停止 FlowPilot
           status                    查看 FlowPilot 是否正在运行
+          autostart [操作]          登录启动：status|enable|disable
           toggle                    在悬浮球与展开摘要之间切换
           expand                    展开摘要窗口
           collapse                  收起为悬浮球
@@ -69,16 +72,41 @@ func printUsage() {
     ))
 }
 
+func printAutostartStatus(_ status: FlowPilotAutostartStatus, json: Bool) {
+    if json {
+        let object: [String: Any] = [
+            "enabled": status.enabled,
+            "registered": status.plistExists,
+            "launchdLoaded": status.launchdLoaded,
+            "executable": status.executablePath
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]),
+           let text = String(data: data, encoding: .utf8) {
+            print(text)
+        }
+        return
+    }
+
+    if status.enabled {
+        let detail = status.launchdLoaded
+            ? L("launchd loaded in this login session", "当前登录会话已由 launchd 加载")
+            : L("registered for the next login", "已注册，将在下次登录时启动")
+        print(L("● Login launch enabled · \(detail)", "● 登录启动已开启 · \(detail)"))
+    } else {
+        print(L("○ Login launch disabled", "○ 登录启动已关闭"))
+    }
+}
+
 let args = Array(CommandLine.arguments.dropFirst())
 
 if args.isEmpty || args[0] == "start" || args[0] == "--daemon" || args[0] == "restart" {
-    // If an older instance is already running, cleanly terminate it first so new code runs
+    // If an older instance is already running, cleanly terminate it first so new code runs.
     let statusCheck = IPCService.sendCommand("status")
     if statusCheck.success {
         _ = IPCService.sendCommand("quit")
         usleep(250_000) // 250ms for socket cleanup
     }
-    
+
     let app = NSApplication.shared
     let delegate = AppDelegate()
     app.delegate = delegate
@@ -93,6 +121,39 @@ if args.isEmpty || args[0] == "start" || args[0] == "--daemon" || args[0] == "re
             exit(0)
         } else {
             print(L("○ FlowPilot is NOT running.", "○ FlowPilot 未运行。"))
+            exit(1)
+        }
+    case "autostart":
+        let action = args.count > 1 ? args[1].lowercased() : "status"
+        let wantsJSON = args.contains("--json")
+        do {
+            switch action {
+            case "status":
+                printAutostartStatus(FlowPilotAutostartService.status(), json: wantsJSON)
+            case "enable", "on":
+                let status = try FlowPilotAutostartService.enable()
+                printAutostartStatus(status, json: wantsJSON)
+            case "disable", "off":
+                let status = try FlowPilotAutostartService.disable()
+                printAutostartStatus(status, json: wantsJSON)
+            default:
+                print(L(
+                    "Usage: FlowPilot autostart status|enable|disable [--json]",
+                    "用法：FlowPilot autostart status|enable|disable [--json]"
+                ))
+                exit(2)
+            }
+            exit(0)
+        } catch {
+            if wantsJSON {
+                let object: [String: Any] = ["error": error.localizedDescription]
+                if let data = try? JSONSerialization.data(withJSONObject: object),
+                   let text = String(data: data, encoding: .utf8) {
+                    print(text)
+                }
+            } else {
+                print(L("Autostart update failed: \(error.localizedDescription)", "登录启动设置失败：\(error.localizedDescription)"))
+            }
             exit(1)
         }
     case "toggle":

--- a/scripts/uninstall
+++ b/scripts/uninstall
@@ -9,6 +9,18 @@ STATE_DIR="$CODEX_HOME/codex-flow"
 
 if [[ -f "$STATE_DIR/shell/bin_dir" ]]; then BIN_DIR="$(cat "$STATE_DIR/shell/bin_dir")"; fi
 
+# Remove the user LaunchAgent before deleting FlowPilot itself. A full uninstall
+# is the one place where terminating a launchd-managed running instance is
+# expected; simply disabling login launch from the app intentionally keeps the
+# current widget alive.
+if [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]]; then
+  FLOWPILOT_LAUNCH_LABEL="com.parsifalc.codex-flow.flowpilot"
+  FLOWPILOT_LAUNCH_PLIST="$HOME/Library/LaunchAgents/$FLOWPILOT_LAUNCH_LABEL.plist"
+  launchctl bootout "gui/$(id -u)/$FLOWPILOT_LAUNCH_LABEL" >/dev/null 2>&1 || true
+  launchctl bootout "gui/$(id -u)" "$FLOWPILOT_LAUNCH_PLIST" >/dev/null 2>&1 || true
+  rm -f "$FLOWPILOT_LAUNCH_PLIST"
+fi
+
 SHELL_HELPER="$STATE_DIR/shell/manage-shell.py"
 if [[ -f "$SHELL_HELPER" ]] && command -v python3 >/dev/null 2>&1; then
   python3 "$SHELL_HELPER" uninstall --state-dir "$STATE_DIR"
@@ -61,5 +73,6 @@ fi
 printf '\n%s🗑️  codex-flow uninstalled successfully%s\n\n' "$C_BOLD" "$C_RESET"
 printf '  %s✔%s FlowPilot skill and worker agents removed\n' "$C_GREEN" "$C_RESET"
 printf '  %s✔%s Telemetry hooks and shell integration removed\n' "$C_GREEN" "$C_RESET"
+printf '  %s✔%s FlowPilot login LaunchAgent removed\n' "$C_GREEN" "$C_RESET"
 printf '  %s✔%s CLI binary (%s) removed\n' "$C_GREEN" "$C_RESET" "$BIN_DIR/codex-flow"
 printf '  %s✔%s Configuration cleaned up (existing backups preserved)\n\n' "$C_GREEN" "$C_RESET"


### PR DESCRIPTION
## Summary

This PR upgrades the FlowPilot macOS overlay across account visibility, history inspection, long-text UX, usage semantics, analytics, strategy controls, and login launch behavior.

### Account
- Add an Account tab using Codex/app-server account and rate-limit data.
- Show current plan/account type, quota windows (including 5h/weekly when reported), reset credits, reset/expiry times, credits, rate-limit state, auth/spend-control status, and refresh state.
- Do not estimate values that Codex does not report.
- Show reset timestamps with calendar date + local time to avoid ambiguous time-only labels.

### Strategy mode
- Add in-app global strategy switching for the profiles reported by `codex-flow strategy profiles` (currently efficient/balanced/quality/speed).
- Read the real active strategy via the existing CLI/runtime path.
- Persist changes through `codex-flow strategy set` and re-read to verify the switch before reporting success.
- Resolve the CLI robustly for Finder/login-item launches, including the installer-default `~/.local/bin` path and common Homebrew locations.
- Explain repository-level `.codex-flow.toml` override precedence.

### Login launch
- Add an Account-page `Launch at Login / 登录时启动` switch backed by a real per-user LaunchAgent.
- Default to enabled on first FlowPilot launch, while persisting an explicit user disable so later launches/updates do not silently re-enable it.
- Prefer the stable installed `~/.codex/codex-flow/bin/FlowPilot` executable for the LaunchAgent, with a dev-build fallback.
- Support `codex-flow overlay autostart status|enable|disable` (and JSON status via the underlying FlowPilot command).
- Disabling login launch removes future-login registration without killing the currently running widget; uninstall performs the full launchd cleanup.

### History and long text
- Keep history task inspection inside History instead of navigating back to Inspector.
- Add dismissible hover/detail overlays with delayed mouse-leave close behavior.
- Introduce reusable hover reveal behavior for truncated task titles, summaries, branches, worker conclusions, logs, model names, and other long text.
- Respect privacy mode so hover does not reveal blurred/private content.

### Usage and analytics
- Remove the ambiguous Cost metric from the task surface; use deterministic token/usage metrics instead.
- Add token usage breakdown and aggregate trend charts.
- Add 7/30-day usage trend visualization and retain model/project/worker distribution analytics.

### Compatibility / cleanup
- Preserve task switching plus Skills & Tools sections during the UI refresh.
- Update SwiftUI `onChange` usage to the macOS 14-compatible form and review the touched overlay code for deprecated API warnings.
- Keep Chinese/English localization and system-language behavior for the new surfaces.

## Validation
- Main CI smoke/runtime suites: passing on current head.
- macOS native overlay build: passing on current head.
- macOS build output has no Swift compile/deprecation warnings from the overlay code; the only workflow warning is GitHub Actions' own checkout Node runtime deprecation.
- Reviewed account empty states, invalid strategy recovery, strategy write/read-back verification, privacy-mode hover behavior, reset-date formatting, history overlay close behavior, and login-launch registration semantics.

## Notes
- The Account view intentionally shows unavailable/unknown states instead of synthesizing plan/quota/cost data.
- Repository strategy configuration remains higher priority than the global strategy selected in the app.