### PR TITLE
fix(overlay): stabilize FlowPilot startup and rebuild lifecycle

### DIFF
--- a/.github/workflows/macos-overlay.yml
+++ b/.github/workflows/macos-overlay.yml
@@ -4,10 +4,12 @@ on:
   push:
     paths:
       - 'apps/macos-overlay/**'
+      - 'bin/codex-flow'
       - '.github/workflows/macos-overlay.yml'
   pull_request:
     paths:
       - 'apps/macos-overlay/**'
+      - 'bin/codex-flow'
       - '.github/workflows/macos-overlay.yml'
 
 jobs:
@@ -22,8 +24,10 @@ jobs:
         run: |
           set -euo pipefail
           export CODEX_HOME="$RUNNER_TEMP/flowpilot-smoke-codex-home"
-          mkdir -p "$CODEX_HOME"
+          mkdir -p "$CODEX_HOME/codex-flow"
+          printf '%s\n' "$GITHUB_WORKSPACE" >"$CODEX_HOME/codex-flow/source"
           BIN="$GITHUB_WORKSPACE/apps/macos-overlay/bin/FlowPilot"
+          CLI="$GITHUB_WORKSPACE/bin/codex-flow"
           LOG1="$RUNNER_TEMP/flowpilot-smoke-1.log"
           LOG2="$RUNNER_TEMP/flowpilot-smoke-2.log"
 
@@ -85,11 +89,22 @@ jobs:
           "$BIN" stop >/dev/null 2>&1 || true
           for _ in {1..30}; do
             if ! kill -0 "$START2_PID" 2>/dev/null; then
-              exit 0
+              break
             fi
             sleep 0.1
           done
+          if kill -0 "$START2_PID" 2>/dev/null; then
+            echo "FlowPilot replacement did not terminate after stop" >&2
+            kill "$START2_PID" 2>/dev/null || true
+            exit 1
+          fi
 
-          echo "FlowPilot replacement did not terminate after stop" >&2
-          kill "$START2_PID" 2>/dev/null || true
-          exit 1
+          # Exercise the user-facing wrapper too. It must wait for the exact new
+          # PID on both start and restart before printing success.
+          bash "$CLI" overlay start
+          WRAPPER_PID1="$(status_pid)"
+          [[ -n "$WRAPPER_PID1" ]]
+          bash "$CLI" overlay restart
+          WRAPPER_PID2="$(status_pid)"
+          [[ -n "$WRAPPER_PID2" && "$WRAPPER_PID2" != "$WRAPPER_PID1" ]]
+          "$BIN" stop >/dev/null 2>&1 || true

--- a/.github/workflows/macos-overlay.yml
+++ b/.github/workflows/macos-overlay.yml
@@ -17,3 +17,46 @@ jobs:
       - uses: actions/checkout@v4
       - name: Compile native overlay
         run: bash apps/macos-overlay/build.sh
+      - name: Smoke test overlay lifecycle
+        shell: bash
+        run: |
+          set -euo pipefail
+          export CODEX_HOME="$RUNNER_TEMP/flowpilot-smoke-codex-home"
+          mkdir -p "$CODEX_HOME"
+          BIN="$GITHUB_WORKSPACE/apps/macos-overlay/bin/FlowPilot"
+          LOG="$RUNNER_TEMP/flowpilot-smoke.log"
+
+          "$BIN" autostart status --json
+          "$BIN" start >"$LOG" 2>&1 &
+          START_PID=$!
+
+          running=0
+          for _ in {1..30}; do
+            if "$BIN" status >/dev/null 2>&1; then
+              running=1
+              break
+            fi
+            if ! kill -0 "$START_PID" 2>/dev/null; then
+              break
+            fi
+            sleep 0.2
+          done
+
+          if [[ "$running" != "1" ]]; then
+            echo "FlowPilot failed to become reachable over IPC" >&2
+            cat "$LOG" >&2 || true
+            wait "$START_PID" || true
+            exit 1
+          fi
+
+          "$BIN" stop >/dev/null 2>&1 || true
+          for _ in {1..20}; do
+            if ! kill -0 "$START_PID" 2>/dev/null; then
+              exit 0
+            fi
+            sleep 0.1
+          done
+
+          echo "FlowPilot did not terminate after stop" >&2
+          kill "$START_PID" 2>/dev/null || true
+          exit 1

--- a/.github/workflows/macos-overlay.yml
+++ b/.github/workflows/macos-overlay.yml
@@ -24,39 +24,72 @@ jobs:
           export CODEX_HOME="$RUNNER_TEMP/flowpilot-smoke-codex-home"
           mkdir -p "$CODEX_HOME"
           BIN="$GITHUB_WORKSPACE/apps/macos-overlay/bin/FlowPilot"
-          LOG="$RUNNER_TEMP/flowpilot-smoke.log"
+          LOG1="$RUNNER_TEMP/flowpilot-smoke-1.log"
+          LOG2="$RUNNER_TEMP/flowpilot-smoke-2.log"
+
+          status_pid() {
+            local json
+            json="$("$BIN" status --json 2>/dev/null || true)"
+            printf '%s\n' "$json" | sed -nE 's/.*"pid"[[:space:]]*:[[:space:]]*([0-9]+).*/\1/p'
+          }
+
+          wait_for_pid() {
+            local expected="$1"
+            for _ in {1..50}; do
+              if [[ "$(status_pid)" == "$expected" ]]; then
+                return 0
+              fi
+              sleep 0.1
+            done
+            return 1
+          }
 
           "$BIN" autostart status --json
-          "$BIN" start >"$LOG" 2>&1 &
-          START_PID=$!
 
-          running=0
+          "$BIN" start >"$LOG1" 2>&1 &
+          START1_PID=$!
+          if ! wait_for_pid "$START1_PID"; then
+            echo "First FlowPilot instance failed to own IPC" >&2
+            cat "$LOG1" >&2 || true
+            kill "$START1_PID" 2>/dev/null || true
+            exit 1
+          fi
+
+          # Starting again exercises the real single-instance restart path. The
+          # status endpoint must transition to the new PID rather than allowing
+          # the old instance to create a false-positive startup result.
+          "$BIN" start >"$LOG2" 2>&1 &
+          START2_PID=$!
+          if ! wait_for_pid "$START2_PID"; then
+            echo "Replacement FlowPilot instance failed to take IPC ownership" >&2
+            echo "--- first instance log ---" >&2
+            cat "$LOG1" >&2 || true
+            echo "--- replacement log ---" >&2
+            cat "$LOG2" >&2 || true
+            kill "$START1_PID" "$START2_PID" 2>/dev/null || true
+            exit 1
+          fi
+
           for _ in {1..30}; do
-            if "$BIN" status >/dev/null 2>&1; then
-              running=1
+            if ! kill -0 "$START1_PID" 2>/dev/null; then
               break
             fi
-            if ! kill -0 "$START_PID" 2>/dev/null; then
-              break
-            fi
-            sleep 0.2
+            sleep 0.1
           done
-
-          if [[ "$running" != "1" ]]; then
-            echo "FlowPilot failed to become reachable over IPC" >&2
-            cat "$LOG" >&2 || true
-            wait "$START_PID" || true
+          if kill -0 "$START1_PID" 2>/dev/null; then
+            echo "Previous FlowPilot instance survived restart handover" >&2
+            kill "$START1_PID" "$START2_PID" 2>/dev/null || true
             exit 1
           fi
 
           "$BIN" stop >/dev/null 2>&1 || true
-          for _ in {1..20}; do
-            if ! kill -0 "$START_PID" 2>/dev/null; then
+          for _ in {1..30}; do
+            if ! kill -0 "$START2_PID" 2>/dev/null; then
               exit 0
             fi
             sleep 0.1
           done
 
-          echo "FlowPilot did not terminate after stop" >&2
-          kill "$START_PID" 2>/dev/null || true
+          echo "FlowPilot replacement did not terminate after stop" >&2
+          kill "$START2_PID" 2>/dev/null || true
           exit 1

--- a/apps/macos-overlay/Sources/Services/IPCServer.swift
+++ b/apps/macos-overlay/Sources/Services/IPCServer.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Cocoa
+import Darwin
 
 public class IPCService {
     public static var socketPath: String {
@@ -9,67 +10,86 @@ public class IPCService {
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         return dir.appendingPathComponent("overlay.sock").path
     }
-    
+
     // MARK: - Server Implementation
     public class Server {
         public let state: OverlayState
         private var serverSource: DispatchSourceRead?
         private var serverSocket: Int32 = -1
         private let path: String
-        
+        private var boundSocketFileNumber: UInt64?
+
         public init(state: OverlayState, socketPath: String = IPCService.socketPath) {
             self.state = state
             self.path = socketPath
             start()
         }
-        
+
         public func start() {
             unlink(path)
-            
+
             serverSocket = socket(AF_UNIX, SOCK_STREAM, 0)
             guard serverSocket >= 0 else { return }
-            
+
             var addr = sockaddr_un()
             addr.sun_family = sa_family_t(AF_UNIX)
             let pathMax = MemoryLayout.size(ofValue: addr.sun_path)
-            
+
             withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
                 let rawPtr = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: CChar.self)
                 _ = path.withCString { cstr in
                     strncpy(rawPtr, cstr, pathMax - 1)
                 }
             }
-            
+
             let addrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
             let bindResult = withUnsafePointer(to: &addr) { ptr in
                 ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
                     bind(serverSocket, sa, addrLen)
                 }
             }
-            
+
             guard bindResult == 0 else {
                 close(serverSocket)
+                serverSocket = -1
                 return
             }
-            
+
+            // Remember the filesystem socket node we actually bound. During a
+            // restart an older process can finish after a newer process has
+            // rebound the same path; only the owner of the current node may
+            // unlink it during shutdown.
+            boundSocketFileNumber = socketFileNumber(at: path)
+
             listen(serverSocket, 5)
-            
+
             let source = DispatchSource.makeReadSource(fileDescriptor: serverSocket, queue: .main)
             source.setEventHandler { [weak self] in
                 self?.acceptConnection()
             }
             source.setCancelHandler { [weak self] in
-                if let fd = self?.serverSocket, fd >= 0 {
-                    close(fd)
+                guard let self else { return }
+                if self.serverSocket >= 0 {
+                    close(self.serverSocket)
+                    self.serverSocket = -1
                 }
-                if let p = self?.path {
-                    unlink(p)
+                if let expected = self.boundSocketFileNumber,
+                   self.socketFileNumber(at: self.path) == expected {
+                    unlink(self.path)
                 }
             }
             source.resume()
             self.serverSource = source
         }
-        
+
+        private func socketFileNumber(at path: String) -> UInt64? {
+            guard let attributes = try? FileManager.default.attributesOfItem(atPath: path),
+                  let number = attributes[.systemFileNumber] as? NSNumber else {
+                return nil
+            }
+            return number.uint64Value
+        }
+
         private func acceptConnection() {
             var clientAddr = sockaddr_un()
             var clientAddrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
@@ -78,7 +98,7 @@ public class IPCService {
                     accept(serverSocket, sa, &clientAddrLen)
                 }
             }
-            
+
             guard clientSocket >= 0 else { return }
             var noSigPipe: Int32 = 1
             _ = setsockopt(
@@ -88,7 +108,7 @@ public class IPCService {
                 &noSigPipe,
                 socklen_t(MemoryLayout<Int32>.size)
             )
-            
+
             var buffer = [UInt8](repeating: 0, count: 4096)
             let bytesRead = read(clientSocket, &buffer, buffer.count)
             if bytesRead > 0 {
@@ -104,10 +124,10 @@ public class IPCService {
             }
             close(clientSocket)
         }
-        
+
         private func handleCommand(_ cmd: String) -> String {
             if cmd == "status" {
-                return "{\"running\": true, \"isExpanded\": \(state.isExpanded), \"isPinned\": \(state.isPinned), \"activeTab\": \"\(state.activeTab.rawValue)\"}\n"
+                return "{\"running\": true, \"pid\": \(getpid()), \"isExpanded\": \(state.isExpanded), \"isPinned\": \(state.isPinned), \"activeTab\": \"\(state.activeTab.rawValue)\"}\n"
             } else if cmd == "toggle" {
                 state.toggle()
                 return "{\"ok\": true, \"action\": \"toggle\", \"isExpanded\": \(state.isExpanded)}\n"
@@ -191,19 +211,19 @@ public class IPCService {
             }
             return "{\"ok\": false, \"error\": \"unknown command\"}\n"
         }
-        
+
         public func stop() {
             serverSource?.cancel()
             serverSource = nil
         }
     }
-    
+
     // MARK: - Client Implementation
     public static func sendCommand(_ cmd: String, socketPath: String = IPCService.socketPath) -> (success: Bool, response: String) {
         guard FileManager.default.fileExists(atPath: socketPath) else {
             return (false, L("Overlay is not running (socket not found).", "悬浮窗未运行（未找到 socket）。"))
         }
-        
+
         let clientSocket = socket(AF_UNIX, SOCK_STREAM, 0)
         guard clientSocket >= 0 else {
             return (false, L("Failed to create client socket.", "创建客户端 socket 失败。"))
@@ -217,44 +237,44 @@ public class IPCService {
             &noSigPipe,
             socklen_t(MemoryLayout<Int32>.size)
         )
-        
+
         var addr = sockaddr_un()
         addr.sun_family = sa_family_t(AF_UNIX)
         let pathMax = MemoryLayout.size(ofValue: addr.sun_path)
-        
+
         withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
             let rawPtr = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: CChar.self)
             _ = socketPath.withCString { cstr in
                 strncpy(rawPtr, cstr, pathMax - 1)
             }
         }
-        
+
         let addrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
         let connectResult = withUnsafePointer(to: &addr) { ptr in
             ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
                 connect(clientSocket, sa, addrLen)
             }
         }
-        
+
         guard connectResult == 0 else {
             return (false, L("Failed to connect to overlay socket.", "连接悬浮窗 socket 失败。"))
         }
-        
+
         guard let data = cmd.data(using: .utf8) else {
             return (false, L("Encoding error.", "编码错误。"))
         }
-        
+
         _ = data.withUnsafeBytes { raw in
             write(clientSocket, raw.baseAddress, data.count)
         }
-        
+
         var buffer = [UInt8](repeating: 0, count: 4096)
         let bytesRead = read(clientSocket, &buffer, buffer.count)
         if bytesRead > 0 {
             let response = String(data: Data(buffer[0..<bytesRead]), encoding: .utf8) ?? ""
             return (true, response.trimmingCharacters(in: .whitespacesAndNewlines))
         }
-        
+
         return (true, "OK")
     }
 }

--- a/apps/macos-overlay/Sources/Views/AutostartView.swift
+++ b/apps/macos-overlay/Sources/Views/AutostartView.swift
@@ -24,10 +24,11 @@ public enum FlowPilotAutostartService {
     private static var plistURL: URL { launchAgentsDirectory.appendingPathComponent("\(label).plist") }
 
     public static func status() -> FlowPilotAutostartStatus {
-        // Login launch is explicit opt-in. Merely starting FlowPilot must never
-        // mutate launchd state or create a second process during manual startup.
-        let configured = configuredPreference() ?? false
+        // New installations are explicit opt-in, but a pre-existing LaunchAgent
+        // without the newer preference file is still an enabled registration and
+        // must be reported honestly instead of appearing disabled in the UI.
         let exists = FileManager.default.fileExists(atPath: plistURL.path)
+        let configured = configuredPreference() ?? exists
         return FlowPilotAutostartStatus(
             enabled: configured && exists,
             plistExists: exists,

--- a/apps/macos-overlay/Sources/Views/AutostartView.swift
+++ b/apps/macos-overlay/Sources/Views/AutostartView.swift
@@ -23,25 +23,10 @@ public enum FlowPilotAutostartService {
     private static var launchAgentsDirectory: URL { home.appendingPathComponent("Library/LaunchAgents") }
     private static var plistURL: URL { launchAgentsDirectory.appendingPathComponent("\(label).plist") }
 
-    /// Reconcile the registration when FlowPilot starts. The first launch opts in
-    /// by default; an explicit user disable is persisted and never overwritten by
-    /// later app launches or updates.
-    public static func reconcileAtLaunch() {
-        do {
-            if configuredPreference() == false {
-                try removeRegistration()
-            } else {
-                try writePreference(enabled: true)
-                try writeRegistration()
-            }
-        } catch {
-            // Startup must remain non-fatal. The Account card and CLI surface the
-            // registration error when the user explicitly interacts with it.
-        }
-    }
-
     public static func status() -> FlowPilotAutostartStatus {
-        let configured = configuredPreference() ?? true
+        // Login launch is explicit opt-in. Merely starting FlowPilot must never
+        // mutate launchd state or create a second process during manual startup.
+        let configured = configuredPreference() ?? false
         let exists = FileManager.default.fileExists(atPath: plistURL.path)
         return FlowPilotAutostartStatus(
             enabled: configured && exists,
@@ -227,8 +212,8 @@ public struct AutostartCard: View {
                 Image(systemName: "info.circle")
                     .font(.system(size: 7.2))
                 Text(L(
-                    "Registered as a user LaunchAgent; disabling it does not close the currently running widget.",
-                    "使用用户级 LaunchAgent 注册；关闭开机启动不会退出当前正在运行的悬浮窗。"
+                    "Registered as a user LaunchAgent; enabling it affects the next login and does not restart the current widget.",
+                    "使用用户级 LaunchAgent 注册；开启后从下次登录生效，不会重启当前悬浮窗。"
                 ))
                     .font(.system(size: 7.2))
             }

--- a/apps/macos-overlay/Sources/main.swift
+++ b/apps/macos-overlay/Sources/main.swift
@@ -9,8 +9,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory)
-        FlowPilotAutostartService.reconcileAtLaunch()
 
+        // Keep application startup side-effect free. Login-launch registration
+        // is managed explicitly from the Account switch / CLI instead of being
+        // rewritten every time the widget process starts. This avoids launchd
+        // lifecycle races with manual start/restart and rebuild flows.
         state = OverlayState()
         windowController = OverlayWindowController(state: state)
         watcher = TelemetryWatcher(state: state)

--- a/apps/macos-overlay/Sources/main.swift
+++ b/apps/macos-overlay/Sources/main.swift
@@ -108,9 +108,22 @@ func printStatusFailureJSON(_ message: String) {
     }
 }
 
+func writeStandardError(_ message: String) {
+    guard let data = message.data(using: .utf8) else { return }
+    FileHandle.standardError.write(data)
+}
+
 func waitForPreviousInstanceToReleaseSocket(timeout: TimeInterval = 3.0) -> Bool {
     let deadline = Date().addingTimeInterval(timeout)
     while FileManager.default.fileExists(atPath: IPCService.socketPath) {
+        let probe = IPCService.sendCommand("status")
+        if !probe.success || !probe.response.contains("\"running\": true") {
+            // A process can exit before its dispatch-source cancel handler gets
+            // enough runtime to unlink the filesystem socket. At this point no
+            // server answers the endpoint, so removing the stale node is safe.
+            try? FileManager.default.removeItem(atPath: IPCService.socketPath)
+            return !FileManager.default.fileExists(atPath: IPCService.socketPath)
+        }
         if Date() >= deadline {
             return false
         }
@@ -129,10 +142,10 @@ if args.isEmpty || args[0] == "start" || args[0] == "--daemon" || args[0] == "re
     if statusCheck.success {
         _ = IPCService.sendCommand("quit")
         if !waitForPreviousInstanceToReleaseSocket() {
-            fputs(L(
+            writeStandardError(L(
                 "FlowPilot restart timed out waiting for the previous IPC socket to close.\n",
                 "FlowPilot 重启等待旧 IPC socket 关闭超时。\n"
-            ), stderr)
+            ))
             exit(1)
         }
     }

--- a/apps/macos-overlay/Sources/main.swift
+++ b/apps/macos-overlay/Sources/main.swift
@@ -38,7 +38,7 @@ func printUsage() {
           start, --daemon           Start/Restart the FlowPilot floating daemon (default)
           restart                   Restart the running FlowPilot daemon with fresh build
           stop, quit                Stop running FlowPilot daemon
-          status                    Check if FlowPilot daemon is currently active
+          status [--json]           Check if FlowPilot daemon is currently active
           autostart [action]        Login launch: status|enable|disable
           toggle                    Toggle between circular bubble and expanded summary
           expand                    Expand summary window
@@ -60,7 +60,7 @@ func printUsage() {
           start, --daemon           启动/重启 FlowPilot 悬浮窗（默认）
           restart                   使用最新构建重启 FlowPilot
           stop, quit                停止 FlowPilot
-          status                    查看 FlowPilot 是否正在运行
+          status [--json]           查看 FlowPilot 是否正在运行
           autostart [操作]          登录启动：status|enable|disable
           toggle                    在悬浮球与展开摘要之间切换
           expand                    展开摘要窗口
@@ -100,14 +100,41 @@ func printAutostartStatus(_ status: FlowPilotAutostartStatus, json: Bool) {
     }
 }
 
+func printStatusFailureJSON(_ message: String) {
+    let object: [String: Any] = ["running": false, "error": message]
+    if let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]),
+       let text = String(data: data, encoding: .utf8) {
+        print(text)
+    }
+}
+
+func waitForPreviousInstanceToReleaseSocket(timeout: TimeInterval = 3.0) -> Bool {
+    let deadline = Date().addingTimeInterval(timeout)
+    while FileManager.default.fileExists(atPath: IPCService.socketPath) {
+        if Date() >= deadline {
+            return false
+        }
+        usleep(20_000)
+    }
+    return true
+}
+
 let args = Array(CommandLine.arguments.dropFirst())
 
 if args.isEmpty || args[0] == "start" || args[0] == "--daemon" || args[0] == "restart" {
-    // If an older instance is already running, cleanly terminate it first so new code runs.
+    // If an older instance is already running, cleanly terminate it and wait for
+    // its IPC endpoint to be released before binding a replacement. A fixed sleep
+    // can let the old shutdown race the new bind and delete the new socket.
     let statusCheck = IPCService.sendCommand("status")
     if statusCheck.success {
         _ = IPCService.sendCommand("quit")
-        usleep(250_000) // 250ms for socket cleanup
+        if !waitForPreviousInstanceToReleaseSocket() {
+            fputs(L(
+                "FlowPilot restart timed out waiting for the previous IPC socket to close.\n",
+                "FlowPilot 重启等待旧 IPC socket 关闭超时。\n"
+            ), stderr)
+            exit(1)
+        }
     }
 
     let app = NSApplication.shared
@@ -118,12 +145,21 @@ if args.isEmpty || args[0] == "start" || args[0] == "--daemon" || args[0] == "re
     let cmd = args[0]
     switch cmd {
     case "status":
+        let wantsJSON = args.contains("--json")
         let res = IPCService.sendCommand("status")
         if res.success {
-            print(L("● FlowPilot is RUNNING: \(res.response)", "● FlowPilot 正在运行：\(res.response)"))
+            if wantsJSON {
+                print(res.response)
+            } else {
+                print(L("● FlowPilot is RUNNING: \(res.response)", "● FlowPilot 正在运行：\(res.response)"))
+            }
             exit(0)
         } else {
-            print(L("○ FlowPilot is NOT running.", "○ FlowPilot 未运行。"))
+            if wantsJSON {
+                printStatusFailureJSON(res.response)
+            } else {
+                print(L("○ FlowPilot is NOT running.", "○ FlowPilot 未运行。"))
+            }
             exit(1)
         }
     case "autostart":

--- a/apps/macos-overlay/build.sh
+++ b/apps/macos-overlay/build.sh
@@ -5,6 +5,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BIN_DIR="$SCRIPT_DIR/bin"
 OUTPUT="$BIN_DIR/codex-flow-overlay"
 FLOWPILOT_OUTPUT="$BIN_DIR/FlowPilot"
+TMP_OUTPUT="$BIN_DIR/.codex-flow-overlay.$$"
+TMP_FLOWPILOT="$BIN_DIR/.FlowPilot.$$"
+
+cleanup() {
+    rm -f "$TMP_OUTPUT" "$TMP_FLOWPILOT"
+}
+trap cleanup EXIT
 
 mkdir -p "$BIN_DIR"
 
@@ -20,6 +27,10 @@ if [ "$CORES" -gt 4 ]; then
     CORES=4
 fi
 
+# Build to a fresh inode first. Replacing a currently executing macOS binary in
+# place can invalidate mapped executable pages and SIGKILL the running process.
+# Atomic rename keeps the old inode alive for the current process while new
+# launches immediately see the freshly built binary.
 swiftc \
     -num-threads "$CORES" \
     -j "$CORES" \
@@ -27,19 +38,26 @@ swiftc \
     -framework SwiftUI \
     -framework Combine \
     "${SWIFT_FILES[@]}" \
-    -o "$OUTPUT"
+    -o "$TMP_OUTPUT"
 
-chmod +x "$OUTPUT"
-cp -f "$OUTPUT" "$FLOWPILOT_OUTPUT"
-chmod +x "$FLOWPILOT_OUTPUT"
+chmod +x "$TMP_OUTPUT"
+mv -f "$TMP_OUTPUT" "$OUTPUT"
+cp "$OUTPUT" "$TMP_FLOWPILOT"
+chmod +x "$TMP_FLOWPILOT"
+mv -f "$TMP_FLOWPILOT" "$FLOWPILOT_OUTPUT"
 ln -sf "codex-flow-overlay" "$BIN_DIR/flow-pilot"
 
-# Sync to installed state dir if it exists
+# Sync to installed state dir if it exists. Use the same atomic replacement so
+# rebuilding from the console never corrupts a currently running installed copy.
 STATE_BIN="$HOME/.codex/codex-flow/bin"
 if [[ -d "$STATE_BIN" ]]; then
-    cp -f "$FLOWPILOT_OUTPUT" "$STATE_BIN/FlowPilot"
-    cp -f "$OUTPUT" "$STATE_BIN/codex-flow-overlay"
-    chmod +x "$STATE_BIN/FlowPilot" "$STATE_BIN/codex-flow-overlay"
+    state_tmp_flowpilot="$STATE_BIN/.FlowPilot.$$"
+    state_tmp_overlay="$STATE_BIN/.codex-flow-overlay.$$"
+    cp "$FLOWPILOT_OUTPUT" "$state_tmp_flowpilot"
+    cp "$OUTPUT" "$state_tmp_overlay"
+    chmod +x "$state_tmp_flowpilot" "$state_tmp_overlay"
+    mv -f "$state_tmp_flowpilot" "$STATE_BIN/FlowPilot"
+    mv -f "$state_tmp_overlay" "$STATE_BIN/codex-flow-overlay"
 fi
 
 echo "✨ Build succeeded: $FLOWPILOT_OUTPUT"

--- a/apps/macos-overlay/build.sh
+++ b/apps/macos-overlay/build.sh
@@ -7,9 +7,14 @@ OUTPUT="$BIN_DIR/codex-flow-overlay"
 FLOWPILOT_OUTPUT="$BIN_DIR/FlowPilot"
 TMP_OUTPUT="$BIN_DIR/.codex-flow-overlay.$$"
 TMP_FLOWPILOT="$BIN_DIR/.FlowPilot.$$"
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+state_tmp_flowpilot=""
+state_tmp_overlay=""
 
 cleanup() {
     rm -f "$TMP_OUTPUT" "$TMP_FLOWPILOT"
+    [[ -z "$state_tmp_flowpilot" ]] || rm -f "$state_tmp_flowpilot"
+    [[ -z "$state_tmp_overlay" ]] || rm -f "$state_tmp_overlay"
 }
 trap cleanup EXIT
 
@@ -49,7 +54,7 @@ ln -sf "codex-flow-overlay" "$BIN_DIR/flow-pilot"
 
 # Sync to installed state dir if it exists. Use the same atomic replacement so
 # rebuilding from the console never corrupts a currently running installed copy.
-STATE_BIN="$HOME/.codex/codex-flow/bin"
+STATE_BIN="$CODEX_HOME/codex-flow/bin"
 if [[ -d "$STATE_BIN" ]]; then
     state_tmp_flowpilot="$STATE_BIN/.FlowPilot.$$"
     state_tmp_overlay="$STATE_BIN/.codex-flow-overlay.$$"
@@ -57,7 +62,9 @@ if [[ -d "$STATE_BIN" ]]; then
     cp "$OUTPUT" "$state_tmp_overlay"
     chmod +x "$state_tmp_flowpilot" "$state_tmp_overlay"
     mv -f "$state_tmp_flowpilot" "$STATE_BIN/FlowPilot"
+    state_tmp_flowpilot=""
     mv -f "$state_tmp_overlay" "$STATE_BIN/codex-flow-overlay"
+    state_tmp_overlay=""
 fi
 
 echo "✨ Build succeeded: $FLOWPILOT_OUTPUT"

--- a/bin/codex-flow
+++ b/bin/codex-flow
@@ -157,11 +157,31 @@ case "$cmd" in
     sub="${1:-toggle}"
     case "$sub" in
       start|restart)
-        "$overlay_bin" stop >/dev/null 2>&1 || true
-        pkill -f "FlowPilot.*start|codex-flow-overlay.*start|bin/FlowPilot" 2>/dev/null || true
-        sleep 0.2
-        nohup "$overlay_bin" start >/dev/null 2>&1 &
-        printf '%s\n' "$(cf_t '🚀 Launched FlowPilot in background.' '🚀 FlowPilot 已在后台启动。')"
+        # FlowPilot already owns single-instance restart semantics through IPC.
+        # Do not pre-emptively spawn a separate `stop` process or broad `pkill`:
+        # both can race a launchd-managed instance and can kill command helpers.
+        mkdir -p "$STATE_DIR/logs"
+        start_log="$STATE_DIR/logs/flowpilot-start.log"
+        nohup "$overlay_bin" start >>"$start_log" 2>&1 &
+        start_pid=$!
+        started=false
+        for _ in {1..30}; do
+          if "$overlay_bin" status >/dev/null 2>&1; then
+            started=true
+            break
+          fi
+          if ! kill -0 "$start_pid" 2>/dev/null; then
+            break
+          fi
+          sleep 0.1
+        done
+        if [[ "$started" == "true" ]]; then
+          printf '%s\n' "$(cf_t '🚀 Launched FlowPilot in background.' '🚀 FlowPilot 已在后台启动。')"
+        else
+          printf '%s\n' "$(cf_t 'FlowPilot failed to start. Recent log output:' 'FlowPilot 启动失败，最近日志如下：')" >&2
+          tail -n 40 "$start_log" >&2 2>/dev/null || true
+          fail "$(cf_t "startup verification failed; log: $start_log" "启动校验失败；日志：$start_log")"
+        fi
         ;;
       *) exec "$overlay_bin" "$@" ;;
     esac

--- a/bin/codex-flow
+++ b/bin/codex-flow
@@ -157,16 +157,19 @@ case "$cmd" in
     sub="${1:-toggle}"
     case "$sub" in
       start|restart)
-        # FlowPilot already owns single-instance restart semantics through IPC.
-        # Do not pre-emptively spawn a separate `stop` process or broad `pkill`:
-        # both can race a launchd-managed instance and can kill command helpers.
+        # FlowPilot owns single-instance restart semantics through IPC. Verify
+        # the exact process we just launched rather than accepting a successful
+        # status response from the old instance during the handover window.
         mkdir -p "$STATE_DIR/logs"
         start_log="$STATE_DIR/logs/flowpilot-start.log"
+        : >"$start_log"
         nohup "$overlay_bin" start >>"$start_log" 2>&1 &
         start_pid=$!
         started=false
-        for _ in {1..30}; do
-          if "$overlay_bin" status >/dev/null 2>&1; then
+        for _ in {1..50}; do
+          status_json="$("$overlay_bin" status --json 2>/dev/null || true)"
+          status_pid="$(printf '%s\n' "$status_json" | sed -nE 's/.*"pid"[[:space:]]*:[[:space:]]*([0-9]+).*/\1/p')"
+          if [[ -n "$status_pid" && "$status_pid" == "$start_pid" ]]; then
             started=true
             break
           fi


### PR DESCRIPTION
## Problem

After #9 merged, FlowPilot could compile successfully but fail to stay running. `codex-flow overlay start/restart` also emitted `Killed: 9` from the helper `FlowPilot stop` process and still printed a false-positive “started” message.

## Root causes addressed

- App startup was mutating LaunchAgent registration on every launch, coupling normal app startup to launchd state.
- The shell wrapper duplicated FlowPilot's own single-instance restart logic with an extra `stop` process plus a broad `pkill -f`, creating process-race / helper-kill risk.
- Rebuilds replaced the executable in place; on macOS, modifying a currently mapped executable can invalidate executable pages and terminate the running process.
- Restart verification accepted a healthy response from the *old* process during IPC handover, so it could still report success before the replacement was ready.
- The old IPC server could unlink the shared socket path late in shutdown after a newer process had already rebound it.
- The macOS workflow only compiled the binary, so startup/restart/runtime regressions were not covered.

## Fix

- Keep FlowPilot startup side-effect free; login launch is an explicit Account/CLI opt-in rather than auto-registering during every app launch.
- Remove the wrapper's pre-stop/broad-pkill sequence. `FlowPilot start` owns single-instance restart via IPC.
- Add the FlowPilot PID to the IPC status payload and expose `FlowPilot status --json`.
- Verify `codex-flow overlay start/restart` against the exact PID launched by the wrapper before reporting success.
- Replace the fixed restart sleep with bounded IPC handover waiting; stale socket files are removed only after the previous server no longer answers.
- Track the filesystem socket node owned by each IPC server so an older shutdown cannot unlink a newer server's socket.
- Build to temporary files and atomically rename both repo and installed-state binaries, honoring custom `CODEX_HOME` and cleaning temporary artifacts on failure.
- Truncate the per-launch startup diagnostic log instead of growing it without bound.
- Preserve pre-existing LaunchAgent registrations when upgrading from a version without the explicit autostart preference file.
- Expand native macOS CI to verify first start, PID-verified restart, previous-process exit, stop, and the user-facing `codex-flow overlay start/restart` wrapper.

## Compatibility

- Existing users with an autostart preference keep it; legacy users with an existing LaunchAgent but no preference file are still reported as enabled.
- New users explicitly opt in from the Account switch or `codex-flow overlay autostart enable`.
- Disabling login launch still does not kill the currently running widget.

## Validation

- Main CI: passing on current head.
- macOS native compile: passing on current head.
- macOS lifecycle smoke: passing for direct start → PID-verified restart → previous-process exit → stop.
- User-facing wrapper smoke: passing for `codex-flow overlay start` and `codex-flow overlay restart`, with verified PID handover.
- No Swift compile/deprecation warnings were emitted; the only workflow warning is GitHub Actions' own `actions/checkout@v4` Node runtime deprecation.