### PR TITLE
fix(overlay): stabilize account and idle UI states

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
           bash -n tests/smoke.sh
           bash -n tests/strategy-runtime.sh
           bash -n tests/lifecycle-runtime.sh
+          bash -n tests/account-snapshot.sh
           bash -n tests/telemetry.sh
           bash -n tests/chatgpt-mcp.sh
           bash -n tests/benchmark.sh

--- a/apps/macos-overlay/Sources/Controllers/OverlayWindowController.swift
+++ b/apps/macos-overlay/Sources/Controllers/OverlayWindowController.swift
@@ -402,13 +402,11 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
                 targetOrigin.y = visible.minY + snapMargin
             }
         } else {
-            if distLeft < distRight {
-                targetOrigin.x = visible.minX + snapMargin
-                windowController?.state.dockEdge = .left
-            } else {
-                targetOrigin.x = visible.maxX - frame.width - snapMargin
-                windowController?.state.dockEdge = .right
-            }
+            // The collapsed bubble is a stable right-edge affordance. It may
+            // be dragged freely while the mouse is down, but release/idle
+            // always settles on the right so it cannot oscillate between edges.
+            targetOrigin.x = visible.maxX - frame.width - snapMargin
+            windowController?.state.dockEdge = .right
 
             if distTop < snapThreshold {
                 targetOrigin.y = visible.maxY - frame.height - snapMargin
@@ -548,7 +546,12 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
     }
 
     private func setupWindow() {
-        let initialRect = loadSavedPosition() ?? defaultPosition(for: bubbleSize)
+        // Older releases persisted a left-edge bubble. Collapsed restoration is
+        // intentionally normalized to the right edge; expanded cards still use
+        // their own current-frame positioning below.
+        state.dockEdge = .right
+        let restored = loadSavedPosition() ?? defaultPosition(for: bubbleSize)
+        let initialRect = normalizedCollapsedFrame(restored)
 
         window = NSPanel(
             contentRect: initialRect,
@@ -586,7 +589,8 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
 
     public func scheduleTuck() {
         cancelTuckTimer()
-        guard !state.isExpanded, !state.isPinned, !isInteractingOrDragging, state.dockEdge != .none, !state.isDocked else { return }
+        guard !state.isExpanded, !state.isPinned, !isInteractingOrDragging, !state.isDocked else { return }
+        state.dockEdge = .right
         tuckTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false) { [weak self] _ in
             self?.tuckBubble(animated: true)
         }
@@ -594,16 +598,12 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
 
     public func tuckBubble(animated: Bool = true) {
         guard let window = self.window else { return }
-        guard !state.isExpanded, !state.isPinned, !isInteractingOrDragging, state.dockEdge != .none, !state.isDocked else { return }
+        guard !state.isExpanded, !state.isPinned, !isInteractingOrDragging, !state.isDocked else { return }
         guard let screen = window.screen ?? NSScreen.main else { return }
         let visible = screen.visibleFrame
 
-        var targetX = window.frame.origin.x
-        if state.dockEdge == .right {
-            targetX = visible.maxX - bubbleSize.width
-        } else if state.dockEdge == .left {
-            targetX = visible.minX
-        }
+        state.dockEdge = .right
+        let targetX = visible.maxX - bubbleSize.width
 
         let targetFrame = NSRect(origin: NSPoint(x: targetX, y: window.frame.origin.y), size: bubbleSize)
         state.isDocked = true
@@ -627,12 +627,8 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
         guard let screen = window.screen ?? NSScreen.main else { return }
         let visible = screen.visibleFrame
 
-        var targetX = window.frame.origin.x
-        if state.dockEdge == .right {
-            targetX = visible.maxX - bubbleSize.width - 8.0
-        } else if state.dockEdge == .left {
-            targetX = visible.minX + 8.0
-        }
+        state.dockEdge = .right
+        let targetX = visible.maxX - bubbleSize.width - 8.0
 
         let targetFrame = NSRect(origin: NSPoint(x: targetX, y: window.frame.origin.y), size: bubbleSize)
         state.isDocked = false
@@ -698,7 +694,7 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
                 guard let self = self, self.state.isExpanded, !self.state.isPinned, !self.isInteractingOrDragging else { return }
                 self.state.collapse()
             }
-        } else if !state.isExpanded && !state.isDocked && state.dockEdge != .none && !isInteractingOrDragging {
+        } else if !state.isExpanded && !state.isDocked && !isInteractingOrDragging {
             scheduleTuck()
         }
     }
@@ -716,7 +712,14 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
 
         if let screen = window.screen ?? NSScreen.main {
             let visible = screen.visibleFrame
-            newOrigin.x = max(visible.minX, min(newOrigin.x, visible.maxX - targetSize.width))
+            if state.isExpanded {
+                // Expanded cards preserve the right/bottom anchor of the
+                // current frame and retain their existing edge behavior.
+                newOrigin.x = max(visible.minX, min(newOrigin.x, visible.maxX - targetSize.width))
+            } else {
+                state.dockEdge = .right
+                newOrigin.x = visible.maxX - targetSize.width - 8.0
+            }
             newOrigin.y = max(visible.minY, min(newOrigin.y, visible.maxY - targetSize.height))
         }
 
@@ -748,6 +751,47 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
             return nil
         }
         return NSRect(x: CGFloat(x), y: CGFloat(y), width: bubbleSize.width, height: bubbleSize.height)
+    }
+
+    private func normalizedCollapsedFrame(_ frame: NSRect) -> NSRect {
+        let visible = screen(forSavedFrame: frame)?.visibleFrame
+            ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
+        let x = visible.maxX - bubbleSize.width - 8.0
+        let y = max(visible.minY, min(frame.origin.y, visible.maxY - bubbleSize.height))
+        return NSRect(origin: NSPoint(x: x, y: y), size: bubbleSize)
+    }
+
+    private func screen(forSavedFrame frame: NSRect) -> NSScreen? {
+        let screens = NSScreen.screens
+        guard !screens.isEmpty else { return NSScreen.main }
+
+        // Persisted coordinates are in global screen space. Prefer the screen
+        // containing the saved bubble's center, then its origin for partially
+        // off-screen frames (for example after a display was disconnected).
+        let anchors = [
+            NSPoint(x: frame.midX, y: frame.midY),
+            frame.origin
+        ]
+        for anchor in anchors {
+            if let screen = screens.first(where: { $0.visibleFrame.contains(anchor) }) {
+                return screen
+            }
+        }
+
+        // If the saved frame is no longer on any display, keep it on the
+        // nearest visible frame rather than unexpectedly moving it to the
+        // primary display. NSScreen.main remains the final deterministic
+        // fallback when there is no useful geometry.
+        let center = NSPoint(x: frame.midX, y: frame.midY)
+        func distanceSquared(to rect: NSRect) -> CGFloat {
+            let x = max(rect.minX, min(center.x, rect.maxX))
+            let y = max(rect.minY, min(center.y, rect.maxY))
+            let dx = center.x - x
+            let dy = center.y - y
+            return dx * dx + dy * dy
+        }
+        return screens.min { distanceSquared(to: $0.visibleFrame) < distanceSquared(to: $1.visibleFrame) }
+            ?? NSScreen.main
     }
 
     private func defaultPosition(for size: NSSize) -> NSRect {

--- a/apps/macos-overlay/Sources/Services/AccountSnapshotService.swift
+++ b/apps/macos-overlay/Sources/Services/AccountSnapshotService.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Darwin
 
 public struct AccountQuotaWindow: Identifiable {
     public let id: String

--- a/apps/macos-overlay/Sources/Services/AccountSnapshotService.swift
+++ b/apps/macos-overlay/Sources/Services/AccountSnapshotService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Darwin
 
 public struct AccountQuotaWindow: Identifiable {
     public let id: String
@@ -74,152 +75,319 @@ public struct AccountSnapshot {
         return result
     }
 
+    /// True when Codex returned no account, quota, credit, or auth facts. A
+    /// successful but empty response is distinct from a transport/RPC error so
+    /// the Account view can render an explicit empty state.
+    public var isEmpty: Bool {
+        accountType == nil && email == nil && planType == nil &&
+            requiresOpenAIAuth == nil && quotaWindows.isEmpty &&
+            resetCreditCount == nil && resetCredits.isEmpty &&
+            hasCredits == nil && unlimitedCredits == nil &&
+            creditsBalance == nil && spendControlReached == nil &&
+            rateLimitReachedType == nil
+    }
+
     public var nearestResetCreditExpiry: Date? {
         resetCredits.compactMap(\.expiresAt).filter { $0 > Date() }.min()
     }
 }
 
 private final class AccountAppServerRPC {
-    private struct Pending {
+    private final class Pending {
         let semaphore: DispatchSemaphore
         var result: [String: Any]?
+        var error: Error?
+
+        init() {
+            semaphore = DispatchSemaphore(value: 0)
+        }
+    }
+
+    private enum RPCError: LocalizedError {
+        case deadlineExceeded(String)
+        case processExited(Int32, String)
+        case transport(String, String)
+        case invalidResponse(String, String)
+        case server(String, String?, String, String?)
+
+        var errorDescription: String? {
+            switch self {
+            case let .deadlineExceeded(method):
+                return "Codex \(method) timed out before the account request completed."
+            case let .processExited(status, detail):
+                let suffix = detail.isEmpty ? "" : " — \(detail)"
+                return "Codex app-server exited with status \(status)\(suffix)."
+            case let .transport(method, detail):
+                return "Codex \(method) transport failed: \(detail)."
+            case let .invalidResponse(method, detail):
+                return "Codex \(method) returned an invalid response: \(detail)."
+            case let .server(method, code, message, data):
+                var value = "Codex \(method) failed"
+                if let code, !code.isEmpty { value += " (\(code))" }
+                value += ": \(message)"
+                if let data, !data.isEmpty { value += " — \(data)" }
+                return value
+            }
+        }
     }
 
     private let process = Process()
     private let input = Pipe()
     private let output = Pipe()
+    private let errorOutput = Pipe()
     private let lock = NSLock()
+    private let stderrReadLock = NSLock()
+    private let deadline: Date
     private var nextId = 1
     private var pending: [Int: Pending] = [:]
+    private var requestMethods: [Int: String] = [:]
     private var buffer = Data()
+    private var stderrBuffer = Data()
     private var started = false
+    private var terminalError: Error?
 
-    init() throws {
+    init(deadline: Date) throws {
+        self.deadline = deadline
         Self.configureProcess(process)
         process.standardInput = input
         process.standardOutput = output
-        process.standardError = FileHandle.nullDevice
+        process.standardError = errorOutput
+
         output.fileHandleForReading.readabilityHandler = { [weak self] handle in
             let data = handle.availableData
-            guard !data.isEmpty else { return }
-            self?.receive(data)
+            guard let self else { return }
+            if data.isEmpty {
+                // A child can close stdout before it finishes flushing stderr;
+                // let the termination handler capture the final CLI/auth text.
+                // If it has already exited, mark EOF immediately so waiters do
+                // not depend on a readability callback ordering.
+                if !self.process.isRunning {
+                    self.markTerminal(nil)
+                }
+            } else {
+                self.receive(data)
+            }
         }
-        try process.run()
-        started = true
+        errorOutput.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            self?.receiveStderr(from: handle)
+        }
+        process.terminationHandler = { [weak self] process in
+            self?.drainStderr()
+            let detail = self?.stderrText() ?? ""
+            self?.markTerminal(RPCError.processExited(process.terminationStatus, detail))
+        }
+
+        do {
+            try process.run()
+            lock.lock()
+            started = true
+            lock.unlock()
+        } catch {
+            output.fileHandleForReading.readabilityHandler = nil
+            errorOutput.fileHandleForReading.readabilityHandler = nil
+            throw NSError(
+                domain: "FlowPilot.Account",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Unable to start Codex app-server: \(error.localizedDescription)"]
+            )
+        }
     }
 
     deinit { close() }
 
-    func initialize() -> Bool {
-        let response = request(
+    func initialize() throws {
+        _ = try request(
             method: "initialize",
             params: [
                 "clientInfo": ["name": "codex-flow", "title": "FlowPilot Account", "version": "1"],
                 "capabilities": ["experimentalApi": true]
-            ],
-            timeout: 4.0
+            ]
         )
-        guard response != nil else { return false }
-        notify(method: "initialized", params: nil)
-        return true
+        try notify(method: "initialized", params: nil)
     }
 
-    func request(method: String, params: [String: Any]?, timeout: TimeInterval = 4.0) -> [String: Any]? {
+    func request(method: String, params: [String: Any]?, timeout: TimeInterval = 4.0) throws -> [String: Any] {
+        let item = Pending()
+        let id: Int
+
         lock.lock()
-        let id = nextId
+        guard started, process.isRunning else {
+            let error = terminalError ?? RPCError.transport(method, "process is not running")
+            lock.unlock()
+            throw error
+        }
+        id = nextId
         nextId += 1
-        let semaphore = DispatchSemaphore(value: 0)
-        pending[id] = Pending(semaphore: semaphore, result: nil)
+        pending[id] = item
+        requestMethods[id] = method
         lock.unlock()
 
         var payload: [String: Any] = ["id": id, "method": method]
         if let params { payload["params"] = params }
-        guard send(payload) else {
-            lock.lock(); pending.removeValue(forKey: id); lock.unlock()
-            return nil
+
+        do {
+            try send(payload, method: method, timeout: timeout)
+        } catch {
+            lock.lock()
+            pending.removeValue(forKey: id)
+            requestMethods.removeValue(forKey: id)
+            lock.unlock()
+            throw error
         }
 
-        guard semaphore.wait(timeout: .now() + timeout) == .success else {
-            lock.lock(); pending.removeValue(forKey: id); lock.unlock()
-            return nil
+        let remaining = min(timeout, max(0, deadline.timeIntervalSinceNow))
+        guard remaining > 0 else {
+            lock.lock()
+            pending.removeValue(forKey: id)
+            requestMethods.removeValue(forKey: id)
+            lock.unlock()
+            throw stopAfterTimeout()
+        }
+
+        guard item.semaphore.wait(timeout: .now() + remaining) == .success else {
+            lock.lock()
+            pending.removeValue(forKey: id)
+            requestMethods.removeValue(forKey: id)
+            let detail = terminalError
+            lock.unlock()
+            let timeoutError = stopAfterTimeout()
+            if let detail { throw detail }
+            throw timeoutError
         }
 
         lock.lock()
-        let result = pending.removeValue(forKey: id)?.result
+        let response = pending.removeValue(forKey: id)
+        requestMethods.removeValue(forKey: id)
+        let result = response?.result
+        let responseError = response?.error
         lock.unlock()
+
+        if let responseError { throw responseError }
+        guard let result else {
+            throw RPCError.invalidResponse(method, "missing result")
+        }
         return result
     }
 
-    func notify(method: String, params: [String: Any]?) {
+    func notify(method: String, params: [String: Any]?) throws {
         var payload: [String: Any] = ["method": method]
         if let params { payload["params"] = params }
-        _ = send(payload)
+        try send(payload, method: method, timeout: 1.0)
     }
 
     func close() {
-        guard started else { return }
-        started = false
         output.fileHandleForReading.readabilityHandler = nil
-        if process.isRunning { process.terminate() }
+        errorOutput.fileHandleForReading.readabilityHandler = nil
+
+        lock.lock()
+        let wasStarted = started
+        started = false
+        if terminalError == nil, wasStarted {
+            terminalError = RPCError.transport("app-server", "connection closed")
+        }
+        let waiting = Array(pending.values)
+        let failure = terminalError
+        for item in waiting {
+            if item.error == nil {
+                item.error = failure ?? RPCError.transport("app-server", "connection closed")
+            }
+        }
+        lock.unlock()
+
+        for item in waiting {
+            item.semaphore.signal()
+        }
+
+        // Closing the writer also releases a synchronous pipe write that may
+        // be blocked because a broken/aborted child stopped reading stdin.
+        input.fileHandleForWriting.closeFile()
+
+        if process.isRunning {
+            process.terminate()
+            let grace = max(0, min(0.2, deadline.timeIntervalSinceNow))
+            if grace > 0 {
+                let end = Date().addingTimeInterval(grace)
+                while process.isRunning && Date() < end {
+                    Thread.sleep(forTimeInterval: 0.01)
+                }
+            }
+            if process.isRunning {
+                _ = kill(process.processIdentifier, SIGKILL)
+            }
+        }
+        if wasStarted {
+            // Process.waitUntilExit() is intentionally moved off the caller's
+            // path. A broken child must never make AccountSnapshotService's
+            // cleanup unbounded after the request deadline has expired. The
+            // wait also gives a naturally exited child time to finish its
+            // termination handler before pipe handles are closed.
+            waitForExit(timeout: 0.2)
+        }
+
+        output.fileHandleForReading.closeFile()
+        stderrReadLock.lock()
+        errorOutput.fileHandleForReading.closeFile()
+        stderrReadLock.unlock()
     }
 
-    private static func configureProcess(_ process: Process) {
-        let environment = ProcessInfo.processInfo.environment
-
-        // Keep parity with the Python telemetry app-server adapter. This is
-        // especially useful for tests and non-standard Codex installations.
-        if let override = environment["CODEX_FLOW_APP_SERVER_COMMAND"]?
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-           !override.isEmpty {
-            process.executableURL = URL(fileURLWithPath: "/bin/sh")
-            // Avoid a login shell here: startup files can print to stdout and
-            // corrupt the JSONL app-server stream before the first RPC reply.
-            process.arguments = ["-c", override]
-            return
+    private func waitForExit(timeout: TimeInterval) {
+        guard process.processIdentifier > 0 else { return }
+        let completed = DispatchSemaphore(value: 0)
+        let child = process
+        DispatchQueue.global(qos: .utility).async {
+            child.waitUntilExit()
+            completed.signal()
         }
-
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        let codexHome = environment["CODEX_HOME"]
-            .map(URL.init(fileURLWithPath:))
-            ?? home.appendingPathComponent(".codex")
-
-        // Finder and Login Items normally inherit a minimal PATH. Honor any
-        // explicit PATH entries first, then probe the common installation
-        // locations used by Homebrew, npm/pnpm, Volta, Bun, and local installs.
-        var candidates: [URL] = []
-        if let path = environment["PATH"] {
-            candidates.append(contentsOf: path.split(separator: ":").map {
-                URL(fileURLWithPath: String($0)).appendingPathComponent("codex")
-            })
-        }
-        candidates.append(home.appendingPathComponent(".local/bin/codex"))
-        candidates.append(home.appendingPathComponent(".npm-global/bin/codex"))
-        candidates.append(home.appendingPathComponent("Library/pnpm/codex"))
-        candidates.append(home.appendingPathComponent(".volta/bin/codex"))
-        candidates.append(home.appendingPathComponent(".bun/bin/codex"))
-        candidates.append(home.appendingPathComponent(".nvm/current/bin/codex"))
-        candidates.append(codexHome.appendingPathComponent("bin/codex"))
-        candidates.append(URL(fileURLWithPath: "/opt/homebrew/bin/codex"))
-        candidates.append(URL(fileURLWithPath: "/usr/local/bin/codex"))
-
-        if let installedCodex = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0.path) }) {
-            process.executableURL = installedCodex
-            process.arguments = ["app-server"]
-        } else {
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-            process.arguments = ["codex", "app-server"]
-        }
+        let boundedTimeout = max(0, timeout)
+        _ = completed.wait(timeout: .now() + boundedTimeout)
     }
 
-    private func send(_ object: [String: Any]) -> Bool {
+    private func send(_ object: [String: Any], method: String, timeout: TimeInterval) throws {
         guard JSONSerialization.isValidJSONObject(object),
-              var data = try? JSONSerialization.data(withJSONObject: object) else { return false }
+              var data = try? JSONSerialization.data(withJSONObject: object) else {
+            throw RPCError.invalidResponse(method, "request is not valid JSON")
+        }
         data.append(0x0A)
-        do {
-            try input.fileHandleForWriting.write(contentsOf: data)
-            return true
-        } catch {
-            return false
+
+        lock.lock()
+        let isStarted = started && process.isRunning
+        let knownError = terminalError
+        lock.unlock()
+        guard isStarted else {
+            throw knownError ?? RPCError.transport(method, "process is not running")
+        }
+
+        let writeLock = NSLock()
+        var writeResult: Result<Void, Error>?
+        let semaphore = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async { [input] in
+            do {
+                try input.fileHandleForWriting.write(contentsOf: data)
+                writeLock.lock()
+                writeResult = .success(())
+                writeLock.unlock()
+            } catch {
+                writeLock.lock()
+                writeResult = .failure(error)
+                writeLock.unlock()
+            }
+            semaphore.signal()
+        }
+
+        let remaining = min(timeout, max(0, deadline.timeIntervalSinceNow))
+        guard remaining > 0, semaphore.wait(timeout: .now() + remaining) == .success else {
+            throw stopAfterTimeout()
+        }
+
+        writeLock.lock()
+        let result = writeResult
+        writeLock.unlock()
+        if case let .failure(error) = result {
+            let detail = stderrText()
+            throw RPCError.transport(method, detail.isEmpty ? error.localizedDescription : detail)
+        }
+        guard result != nil else {
+            throw RPCError.transport(method, "pipe write did not complete")
         }
     }
 
@@ -235,105 +403,564 @@ private final class AccountAppServerRPC {
         lock.unlock()
 
         for line in lines where !line.isEmpty {
-            guard let object = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
-                  let idNumber = object["id"] as? NSNumber else { continue }
-            let id = idNumber.intValue
-            let result = object["result"] as? [String: Any]
-            lock.lock()
-            if var item = pending[id] {
-                item.result = result
-                pending[id] = item
-                item.semaphore.signal()
+            guard let object = try? JSONSerialization.jsonObject(with: line) as? [String: Any] else {
+                // Keep protocol noise available to the eventual transport
+                // error rather than silently discarding it.
+                lock.lock()
+                if stderrBuffer.isEmpty { stderrBuffer.append(line) }
+                lock.unlock()
+                continue
             }
+            guard let idNumber = object["id"] as? NSNumber else { continue }
+            let id = idNumber.intValue
+            lock.lock()
+            guard let item = pending[id] else {
+                lock.unlock()
+                continue
+            }
+            if let errorObject = object["error"] as? [String: Any] {
+                item.error = rpcError(errorObject, method: requestMethods[id] ?? "request \(id)")
+            } else if let result = object["result"] as? [String: Any] {
+                item.result = result
+            } else if object["result"] is NSNull {
+                // A successful JSON-RPC null result is an empty payload, not a
+                // transport failure. The Account view can then show its empty
+                // state while retaining the distinction from a missing reply.
+                item.result = [:]
+            } else {
+                item.error = RPCError.invalidResponse(requestMethods[id] ?? "request \(id)", "missing result or error")
+            }
+            item.semaphore.signal()
             lock.unlock()
         }
+    }
+
+    private func receiveStderr(from handle: FileHandle) {
+        stderrReadLock.lock()
+        let data = handle.availableData
+        stderrReadLock.unlock()
+        guard !data.isEmpty else { return }
+        lock.lock()
+        stderrBuffer.append(data)
+        lock.unlock()
+    }
+
+    private func drainStderr() {
+        stderrReadLock.lock()
+        defer { stderrReadLock.unlock() }
+        while true {
+            let data = errorOutput.fileHandleForReading.availableData
+            guard !data.isEmpty else { return }
+            lock.lock()
+            stderrBuffer.append(data)
+            lock.unlock()
+        }
+    }
+
+    private func rpcError(_ object: [String: Any], method: String) -> Error {
+        let code: String?
+        if let value = object["code"] as? NSNumber {
+            code = value.stringValue
+        } else {
+            code = object["code"] as? String
+        }
+        let message = (object["message"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+            ?? "unknown JSON-RPC error"
+        var data: String?
+        if let value = object["data"] as? String {
+            data = value
+        } else if let value = object["data"],
+                  let encoded = try? JSONSerialization.data(withJSONObject: value),
+                  let text = String(data: encoded, encoding: .utf8) {
+            data = text
+        }
+        return RPCError.server(method, code, message, data)
+    }
+
+    private func markTerminal(_ error: Error?) {
+        lock.lock()
+        guard terminalError == nil else {
+            lock.unlock()
+            return
+        }
+        let failure = error ?? RPCError.processExited(process.terminationStatus, stderrTextLocked())
+        terminalError = failure
+        let waiting = Array(pending.values)
+        for item in waiting { item.error = failure }
+        lock.unlock()
+        for item in waiting { item.semaphore.signal() }
+    }
+
+    @discardableResult
+    private func stopAfterTimeout() -> Error {
+        lock.lock()
+        if terminalError == nil {
+            let detail = stderrTextLocked()
+            terminalError = detail.isEmpty
+                ? RPCError.deadlineExceeded("app-server")
+                : RPCError.transport("app-server", "request timed out: \(detail)")
+        }
+        started = false
+        let waiting = Array(pending.values)
+        let failure = terminalError
+        for item in waiting { item.error = failure }
+        lock.unlock()
+        for item in waiting {
+            item.semaphore.signal()
+        }
+        input.fileHandleForWriting.closeFile()
+        if process.isRunning {
+            process.terminate()
+            _ = kill(process.processIdentifier, SIGKILL)
+        }
+        return failure ?? RPCError.deadlineExceeded("app-server")
+    }
+
+    private func stderrTextLocked() -> String {
+        String(data: stderrBuffer, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    }
+
+    private func stderrText() -> String {
+        lock.lock()
+        let value = stderrTextLocked()
+        lock.unlock()
+        return value
+    }
+
+    private static func configureProcess(_ process: Process) {
+        let environment = ProcessInfo.processInfo.environment
+
+        // Keep parity with the Python telemetry app-server adapter. This is
+        // especially useful for tests and non-standard Codex installations.
+        if let override = environment["CODEX_FLOW_APP_SERVER_COMMAND"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !override.isEmpty {
+            process.executableURL = URL(fileURLWithPath: "/bin/sh")
+            // Avoid a login shell here: startup files can print to stdout and
+            // corrupt the JSONL app-server stream before the first RPC reply.
+            process.arguments = ["-c", override]
+            process.environment = environment
+            return
+        }
+
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        func expandedPath(_ value: String) -> String {
+            (value as NSString).expandingTildeInPath
+        }
+        let codexHome = environment["CODEX_HOME"]
+            .map { URL(fileURLWithPath: expandedPath($0)) }
+            ?? home.appendingPathComponent(".codex")
+
+        // Finder and Login Items normally inherit a minimal PATH. Honor any
+        // explicit PATH entries first, then probe installation locations. The
+        // nvm paths are enumerated rather than tied to one Node version, so a
+        // versioned upgrade keeps working after a relaunch from launchd.
+        var candidates: [URL] = []
+        var searchDirectories: [URL] = []
+        func appendDirectory(_ directory: URL) {
+            guard !searchDirectories.contains(where: { $0.path == directory.path }) else { return }
+            searchDirectories.append(directory)
+        }
+        func appendCandidate(_ candidate: URL) {
+            guard !candidates.contains(where: { $0.path == candidate.path }) else { return }
+            candidates.append(candidate)
+        }
+
+        if let explicit = environment["CODEX_FLOW_CODEX_PATH"]?
+           .trimmingCharacters(in: .whitespacesAndNewlines),
+           !explicit.isEmpty {
+            let explicitURL = URL(fileURLWithPath: expandedPath(explicit))
+            appendDirectory(explicitURL.deletingLastPathComponent())
+            appendCandidate(explicitURL)
+        }
+
+        if let path = environment["PATH"] {
+            for item in path.split(separator: ":") {
+                let directory = URL(fileURLWithPath: String(item))
+                appendDirectory(directory)
+                appendCandidate(directory.appendingPathComponent("codex"))
+            }
+        }
+
+        let conventionalDirectories = [
+            home.appendingPathComponent(".local/bin"),
+            home.appendingPathComponent(".npm-global/bin"),
+            home.appendingPathComponent("Library/pnpm"),
+            home.appendingPathComponent(".volta/bin"),
+            home.appendingPathComponent(".bun/bin"),
+            codexHome.appendingPathComponent("bin"),
+            home.appendingPathComponent("Applications/ChatGPT.app/Contents/Resources"),
+            URL(fileURLWithPath: "/opt/homebrew/bin"),
+            URL(fileURLWithPath: "/usr/local/bin"),
+            URL(fileURLWithPath: "/Applications/ChatGPT.app/Contents/Resources"),
+            URL(fileURLWithPath: "/usr/bin"),
+            URL(fileURLWithPath: "/bin")
+        ]
+        conventionalDirectories.forEach(appendDirectory)
+        conventionalDirectories.forEach { appendCandidate($0.appendingPathComponent("codex")) }
+
+        let nvmRoots = [
+            environment["NVM_DIR"].map { URL(fileURLWithPath: expandedPath($0)) },
+            home.appendingPathComponent(".nvm"),
+            home.appendingPathComponent(".config/nvm")
+        ].compactMap { $0 }
+        for root in nvmRoots {
+            appendDirectory(root.appendingPathComponent("current/bin"))
+            appendDirectory(root.appendingPathComponent("default/bin"))
+            appendCandidate(root.appendingPathComponent("current/bin/codex"))
+            appendCandidate(root.appendingPathComponent("default/bin/codex"))
+            let versions = (try? FileManager.default.contentsOfDirectory(
+                at: root.appendingPathComponent("versions/node"),
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            ))?.sorted { Self.nvmVersionComesFirst($0, $1) } ?? []
+            for version in versions {
+                let directory = version.appendingPathComponent("bin")
+                appendDirectory(directory)
+                appendCandidate(directory.appendingPathComponent("codex"))
+            }
+        }
+
+        if let prefix = environment["npm_config_prefix"] ?? environment["PREFIX"] {
+            let directory = URL(fileURLWithPath: expandedPath(prefix)).appendingPathComponent("bin")
+            appendDirectory(directory)
+            appendCandidate(directory.appendingPathComponent("codex"))
+        }
+
+        if let installedCodex = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0.path) }) {
+            process.executableURL = installedCodex
+            process.arguments = ["app-server"]
+            var launchEnvironment = environment
+            // npm-installed Codex launchers commonly use ``#!/usr/bin/env
+            // node``. Include every discovered nvm/bin directory so the
+            // launcher and its Node runtime resolve under launchd as well.
+            let path = searchDirectories.map(\.path).joined(separator: ":")
+            if !path.isEmpty { launchEnvironment["PATH"] = path }
+            process.environment = launchEnvironment
+        } else {
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            process.arguments = ["codex", "app-server"]
+            var launchEnvironment = environment
+            let path = searchDirectories.map(\.path).joined(separator: ":")
+            if !path.isEmpty { launchEnvironment["PATH"] = path }
+            process.environment = launchEnvironment
+        }
+    }
+
+    private static func nvmVersionComesFirst(_ lhs: URL, _ rhs: URL) -> Bool {
+        let left = nvmVersionKey(lhs)
+        let right = nvmVersionKey(rhs)
+        for index in 0..<max(left.count, right.count) {
+            let leftPart = index < left.count ? left[index] : 0
+            let rightPart = index < right.count ? right[index] : 0
+            if leftPart != rightPart { return leftPart > rightPart }
+        }
+        return lhs.lastPathComponent > rhs.lastPathComponent
+    }
+
+    private static func nvmVersionKey(_ url: URL) -> [Int] {
+        url.lastPathComponent
+            .split(whereSeparator: { !$0.isNumber })
+            .compactMap { Int($0) }
     }
 }
 
 public enum AccountSnapshotService {
+    /// Keep the complete account flow bounded, including process startup,
+    /// writes, endpoint waits, EOF, and child cleanup.
+    public static let outerTimeout: TimeInterval = 10.0
+
     public static func load() throws -> AccountSnapshot {
-        let rpc = try AccountAppServerRPC()
+        let deadline = Date().addingTimeInterval(outerTimeout)
+        let rpc = try AccountAppServerRPC(deadline: deadline)
         defer { rpc.close() }
 
-        guard rpc.initialize() else {
-            throw error(L("Codex app-server did not respond.", "Codex app-server 未响应。"), code: 1)
+        try rpc.initialize()
+
+        var accountResponse: [String: Any]?
+        var limitsResponse: [String: Any]?
+        var failures: [String] = []
+
+        do {
+            accountResponse = try rpc.request(method: "account/read", params: ["refreshToken": false])
+        } catch {
+            accountResponse = nil
+            let message = error.localizedDescription
+            if !message.isEmpty && !failures.contains(message) { failures.append(message) }
         }
 
-        let accountResponse = rpc.request(method: "account/read", params: ["refreshToken": false])
-        let limitsResponse = rpc.request(method: "account/rateLimits/read", params: nil)
-        guard accountResponse != nil || limitsResponse != nil else {
-            throw error(L("Account data is unavailable from Codex.", "Codex 暂未返回账户数据。"), code: 2)
+        do {
+            limitsResponse = try rpc.request(method: "account/rateLimits/read", params: nil)
+        } catch {
+            limitsResponse = nil
+            let message = error.localizedDescription
+            if !message.isEmpty && !failures.contains(message) { failures.append(message) }
         }
 
-        let account = accountResponse?["account"] as? [String: Any]
-        let requiresAuth = (accountResponse?["requiresOpenaiAuth"] as? NSNumber)?.boolValue
-        let fallbackSnapshot = limitsResponse?["rateLimits"] as? [String: Any]
-        let byId = limitsResponse?["rateLimitsByLimitId"] as? [String: Any]
-        let codexSnapshot = (byId?["codex"] as? [String: Any]) ?? fallbackSnapshot ?? [:]
-
-        var windows: [AccountQuotaWindow] = []
-        for slot in ["primary", "secondary"] {
-            guard let raw = codexSnapshot[slot] as? [String: Any] else { continue }
-            let duration = intValue(raw["windowDurationMins"] ?? raw["windowMinutes"])
-            windows.append(AccountQuotaWindow(
-                id: "\(slot)-\(duration ?? 0)",
-                durationMinutes: duration,
-                usedPercent: doubleValue(raw["usedPercent"]),
-                resetsAt: dateValue(raw["resetsAt"])
-            ))
-        }
-
-        let resetSummary = limitsResponse?["rateLimitResetCredits"] as? [String: Any]
-        let resetCount = intValue(resetSummary?["availableCount"])
-        let rawCredits = resetSummary?["credits"] as? [[String: Any]] ?? []
-        let resetCredits = rawCredits.compactMap { raw -> AccountResetCredit? in
-            guard let id = raw["id"] as? String else { return nil }
-            return AccountResetCredit(
-                id: id,
-                status: raw["status"] as? String,
-                expiresAt: dateValue(raw["expiresAt"]),
-                title: raw["title"] as? String
+        if !failures.isEmpty {
+            throw NSError(
+                domain: "FlowPilot.Account",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: failures.joined(separator: " ")]
             )
         }
 
-        let credits = codexSnapshot["credits"] as? [String: Any]
-        let plan = (account?["planType"] as? String) ?? (codexSnapshot["planType"] as? String)
+        guard accountResponse != nil || limitsResponse != nil else {
+            throw NSError(
+                domain: "FlowPilot.Account",
+                code: 3,
+                userInfo: [NSLocalizedDescriptionKey: L("Account data is unavailable from Codex.", "Codex 暂未返回账户数据。")]
+            )
+        }
+        return try parse(accountResponse: accountResponse, limitsResponse: limitsResponse, now: Date())
+    }
+
+    /// Pure response parsing is public so fixture tests can exercise API
+    /// compatibility without launching a real Codex process.
+    public static func parse(
+        accountResponse: [String: Any]?,
+        limitsResponse: [String: Any]?,
+        now: Date = Date()
+    ) throws -> AccountSnapshot {
+        guard accountResponse != nil || limitsResponse != nil else {
+            throw NSError(
+                domain: "FlowPilot.Account",
+                code: 4,
+                userInfo: [NSLocalizedDescriptionKey: L("Account data is unavailable from Codex.", "Codex 暂未返回账户数据。")]
+            )
+        }
+
+        let account = accountResponse?["account"] as? [String: Any]
+        let requiresAuth = boolValue(
+            accountResponse?["requiresOpenAIAuth"] ?? accountResponse?["requiresOpenaiAuth"]
+        )
+
+        let legacy = limitsResponse?["rateLimits"] as? [String: Any]
+        let byId = limitsResponse?["rateLimitsByLimitId"] as? [String: Any]
+        let codex = byId?["codex"] as? [String: Any]
+        let windows = parseQuotaWindows(codex: codex, legacy: legacy)
+
+        // Codex is authoritative when a field exists, while legacy values fill
+        // holes in an incomplete multi-bucket response.
+        let mergedSnapshot = mergedDictionary(primary: codex, fallback: legacy)
+        let resetSummary = limitsResponse?["rateLimitResetCredits"] as? [String: Any]
+        let resetCount = intValue(resetSummary?["availableCount"])
+        let resetCredits: [AccountResetCredit]
+        if let rawCredits = resetSummary?["credits"] as? [[String: Any]] {
+            resetCredits = rawCredits.compactMap { raw -> AccountResetCredit? in
+                guard let id = stringValue(raw["id"]), !id.isEmpty else { return nil }
+                return AccountResetCredit(
+                    id: id,
+                    status: stringValue(raw["status"]),
+                    expiresAt: dateValue(raw["expiresAt"]),
+                    title: stringValue(raw["title"])
+                )
+            }
+        } else {
+            // Do not synthesize credits from availableCount. An omitted credits
+            // list is different from an explicitly empty list to API clients;
+            // this model keeps the list empty while preserving the authoritative
+            // nullable count above.
+            resetCredits = []
+        }
+
+        let credits = mergedSnapshot?["credits"] as? [String: Any]
+        let plan = stringValue(account?["planType"]) ?? stringValue(mergedSnapshot?["planType"])
         return AccountSnapshot(
-            accountType: account?["type"] as? String,
-            email: account?["email"] as? String,
+            accountType: stringValue(account?["type"]),
+            email: stringValue(account?["email"]),
             planType: plan,
             requiresOpenAIAuth: requiresAuth,
             quotaWindows: windows,
             resetCreditCount: resetCount,
             resetCredits: resetCredits,
-            hasCredits: (credits?["hasCredits"] as? NSNumber)?.boolValue,
-            unlimitedCredits: (credits?["unlimited"] as? NSNumber)?.boolValue,
-            creditsBalance: credits?["balance"] as? String,
-            spendControlReached: (codexSnapshot["spendControlReached"] as? NSNumber)?.boolValue,
-            rateLimitReachedType: codexSnapshot["rateLimitReachedType"] as? String,
-            fetchedAt: Date()
+            hasCredits: boolValue(credits?["hasCredits"]),
+            unlimitedCredits: boolValue(credits?["unlimited"]),
+            creditsBalance: stringValue(credits?["balance"]),
+            spendControlReached: boolValue(mergedSnapshot?["spendControlReached"]),
+            rateLimitReachedType: stringValue(mergedSnapshot?["rateLimitReachedType"]),
+            fetchedAt: now
         )
     }
 
+    private struct QuotaCandidate {
+        let slot: String
+        let sourceRank: Int
+        let duration: Int?
+        let used: Double?
+        let reset: Date?
+    }
+
+    private static func parseQuotaWindows(
+        codex: [String: Any]?,
+        legacy: [String: Any]?
+    ) -> [AccountQuotaWindow] {
+        var candidates: [QuotaCandidate] = []
+        for slot in ["primary", "secondary"] {
+            let codexRaw = codex?[slot] as? [String: Any]
+            let legacyRaw = legacy?[slot] as? [String: Any]
+            guard let merged = mergedDictionary(primary: codexRaw, fallback: legacyRaw), !merged.isEmpty else {
+                continue
+            }
+            let duration = firstIntValue(in: codexRaw, fallback: legacyRaw, keys: ["windowDurationMins", "windowMinutes", "window_duration_mins"])
+            let used = firstDoubleValue(in: codexRaw, fallback: legacyRaw, keys: ["usedPercent", "used_percent"])
+            let reset = firstDateValue(in: codexRaw, fallback: legacyRaw, keys: ["resetsAt", "resets_at"])
+            guard duration != nil || used != nil || reset != nil else { continue }
+            candidates.append(QuotaCandidate(
+                slot: slot,
+                sourceRank: codexRaw == nil ? 1 : 0,
+                duration: duration,
+                used: used,
+                reset: reset
+            ))
+        }
+
+        // A duplicate response can expose the same logical window as both
+        // primary and secondary. Prefer codex over legacy and primary over
+        // secondary, while retaining same-reset windows when durations differ.
+        var selected: [String: QuotaCandidate] = [:]
+        for candidate in candidates {
+            let key = logicalWindowKey(candidate)
+            guard let existing = selected[key] else {
+                selected[key] = candidate
+                continue
+            }
+            let candidateRank = (candidate.sourceRank, candidate.slot == "primary" ? 0 : 1)
+            let existingRank = (existing.sourceRank, existing.slot == "primary" ? 0 : 1)
+            if candidateRank < existingRank {
+                selected[key] = candidate
+            }
+        }
+
+        return selected.values.map { candidate in
+            AccountQuotaWindow(
+                id: stableWindowID(candidate),
+                durationMinutes: candidate.duration,
+                usedPercent: candidate.used,
+                resetsAt: candidate.reset
+            )
+        }.sorted {
+            let leftDuration = $0.durationMinutes ?? Int.max
+            let rightDuration = $1.durationMinutes ?? Int.max
+            if leftDuration != rightDuration { return leftDuration < rightDuration }
+            return $0.id < $1.id
+        }
+    }
+
+    private static func logicalWindowKey(_ candidate: QuotaCandidate) -> String {
+        let duration = candidate.duration.map(String.init) ?? "unknown"
+        if let reset = candidate.reset {
+            let millis = Int64((reset.timeIntervalSince1970 * 1000.0).rounded())
+            return "duration=\(duration)|reset=\(millis)"
+        }
+        // When reset is missing, keep distinct unknown slots apart unless they
+        // have the same duration and slot identity. This avoids collapsing all
+        // malformed/partial windows into one row.
+        return "duration=\(duration)|reset=none|slot=\(candidate.slot)"
+    }
+
+    private static func stableWindowID(_ candidate: QuotaCandidate) -> String {
+        let duration = candidate.duration.map(String.init) ?? "unknown"
+        if let reset = candidate.reset {
+            let millis = Int64((reset.timeIntervalSince1970 * 1000.0).rounded())
+            return "quota-\(duration)-\(millis)"
+        }
+        return "quota-\(duration)-\(candidate.slot)"
+    }
+
+    private static func mergedDictionary(
+        primary: [String: Any]?,
+        fallback: [String: Any]?
+    ) -> [String: Any]? {
+        guard primary != nil || fallback != nil else { return nil }
+        var result = fallback ?? [:]
+        for (key, value) in primary ?? [:] where !(value is NSNull) {
+            result[key] = value
+        }
+        return result
+    }
+
+    private static func firstIntValue(
+        in primary: [String: Any]?,
+        fallback: [String: Any]?,
+        keys: [String]
+    ) -> Int? {
+        for key in keys {
+            if let value = primary?[key], let parsed = intValue(value) { return parsed }
+        }
+        for key in keys {
+            if let value = fallback?[key], let parsed = intValue(value) { return parsed }
+        }
+        return nil
+    }
+
+    private static func firstDoubleValue(
+        in primary: [String: Any]?,
+        fallback: [String: Any]?,
+        keys: [String]
+    ) -> Double? {
+        for key in keys {
+            if let value = primary?[key], let parsed = doubleValue(value) { return parsed }
+        }
+        for key in keys {
+            if let value = fallback?[key], let parsed = doubleValue(value) { return parsed }
+        }
+        return nil
+    }
+
+    private static func firstDateValue(
+        in primary: [String: Any]?,
+        fallback: [String: Any]?,
+        keys: [String]
+    ) -> Date? {
+        for key in keys {
+            if let value = primary?[key], let parsed = dateValue(value) { return parsed }
+        }
+        for key in keys {
+            if let value = fallback?[key], let parsed = dateValue(value) { return parsed }
+        }
+        return nil
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        if let value = value as? String { return value }
+        if let value = value as? NSNumber { return value.stringValue }
+        return nil
+    }
+
     private static func intValue(_ value: Any?) -> Int? {
-        if let number = value as? NSNumber { return number.intValue }
-        if let value = value as? String { return Int(value) }
+        if let number = value as? NSNumber, !(value is Bool) { return number.intValue }
+        if let value = value as? String { return Int(value.trimmingCharacters(in: .whitespacesAndNewlines)) }
         return nil
     }
 
     private static func doubleValue(_ value: Any?) -> Double? {
-        if let number = value as? NSNumber { return number.doubleValue }
-        if let value = value as? String { return Double(value) }
+        if let number = value as? NSNumber, !(value is Bool) { return number.doubleValue }
+        if let value = value as? String { return Double(value.trimmingCharacters(in: .whitespacesAndNewlines)) }
+        return nil
+    }
+
+    private static func boolValue(_ value: Any?) -> Bool? {
+        if let number = value as? NSNumber { return number.boolValue }
+        if let value = value as? String {
+            switch value.lowercased() {
+            case "true", "1", "yes": return true
+            case "false", "0", "no": return false
+            default: return nil
+            }
+        }
         return nil
     }
 
     private static func dateValue(_ value: Any?) -> Date? {
-        guard let raw = doubleValue(value), raw > 0 else { return nil }
-        return Date(timeIntervalSince1970: raw > 1_000_000_000_000 ? raw / 1000.0 : raw)
-    }
-
-    private static func error(_ message: String, code: Int) -> NSError {
-        NSError(domain: "FlowPilot.Account", code: code, userInfo: [NSLocalizedDescriptionKey: message])
+        if let raw = doubleValue(value), raw > 0 {
+            return Date(timeIntervalSince1970: raw > 1_000_000_000_000 ? raw / 1000.0 : raw)
+        }
+        if let value = value as? String {
+            return ISO8601DateFormatter().date(from: value)
+        }
+        return nil
     }
 }
 

--- a/apps/macos-overlay/Sources/Views/AccountView.swift
+++ b/apps/macos-overlay/Sources/Views/AccountView.swift
@@ -9,6 +9,7 @@ public struct AccountView: View {
     @State private var snapshot: AccountSnapshot?
     @State private var isLoading = false
     @State private var errorMessage: String?
+    @State private var hasLoaded = false
 
     public init(state: OverlayState, isFullHeight: Bool = false) {
         self.state = state
@@ -21,15 +22,17 @@ public struct AccountView: View {
             StrategyModeCard()
             AutostartCard()
 
-            if isLoading && snapshot == nil {
+            if isLoading || !hasLoaded {
                 loadingState
-            } else if let snapshot {
+            } else if let errorMessage {
+                errorState(errorMessage)
+            } else if let snapshot, !snapshot.isEmpty {
                 identityCard(snapshot)
                 quotaCard(snapshot)
                 resetCard(snapshot)
                 accountFactsCard(snapshot)
             } else {
-                unavailableState
+                emptyState
             }
         }
         .padding(.vertical, 2)
@@ -85,19 +88,45 @@ public struct AccountView: View {
         .frame(maxWidth: .infinity, minHeight: 120)
     }
 
-    private var unavailableState: some View {
+    private func errorState(_ message: String) -> some View {
         VStack(spacing: 7) {
             Image(systemName: "person.crop.circle.badge.exclamationmark")
                 .font(.system(size: 22))
                 .foregroundColor(.orange.opacity(0.8))
-            Text(errorMessage ?? L("Account data unavailable", "账户数据暂不可用"))
+            Text(L("Unable to read account data", "无法读取账户数据"))
                 .font(.system(size: 10, weight: .medium))
                 .foregroundColor(.white.opacity(0.72))
                 .multilineTextAlignment(.center)
-            Text(L("FlowPilot will not estimate plan or quota values when Codex does not report them.", "Codex 未返回的数据，FlowPilot 不会进行估算。"))
+            Text(message)
                 .font(.system(size: 8.5))
                 .foregroundColor(.white.opacity(0.4))
                 .multilineTextAlignment(.center)
+            Button(L("Retry", "重试"), action: refresh)
+                .buttonStyle(.plain)
+                .font(.system(size: 8.5, weight: .bold))
+                .foregroundColor(.cyan)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, minHeight: 120)
+        .background(cardBackground)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 7) {
+            Image(systemName: "person.crop.circle")
+                .font(.system(size: 22))
+                .foregroundColor(.white.opacity(0.35))
+            Text(L("No account data reported", "Codex 未返回账户数据"))
+                .font(.system(size: 10, weight: .medium))
+                .foregroundColor(.white.opacity(0.72))
+            Text(L("Codex returned an empty account and quota response.", "Codex 返回了空的账户与额度响应。"))
+                .font(.system(size: 8.5))
+                .foregroundColor(.white.opacity(0.4))
+                .multilineTextAlignment(.center)
+            Button(L("Retry", "重试"), action: refresh)
+                .buttonStyle(.plain)
+                .font(.system(size: 8.5, weight: .bold))
+                .foregroundColor(.cyan)
         }
         .padding(14)
         .frame(maxWidth: .infinity, minHeight: 120)
@@ -223,6 +252,11 @@ public struct AccountView: View {
                 Text(window.resetsAt.map { L("Resets \(formatAccountDate($0))", "\(formatAccountDate($0)) 重置") } ?? L("Reset time unavailable", "重置时间未返回"))
                     .font(.system(size: 7.8, weight: .medium, design: .monospaced))
                     .foregroundColor(.white.opacity(0.52))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.58)
+                    .allowsTightening(true)
+                    .truncationMode(.tail)
+                    .layoutPriority(-1)
             }
         }
         .padding(7)
@@ -295,17 +329,20 @@ public struct AccountView: View {
         guard !isLoading else { return }
         isLoading = true
         errorMessage = nil
+        snapshot = nil
         DispatchQueue.global(qos: .userInitiated).async {
             do {
                 let value = try AccountSnapshotService.load()
                 DispatchQueue.main.async {
                     snapshot = value
                     isLoading = false
+                    hasLoaded = true
                 }
             } catch {
                 DispatchQueue.main.async {
                     errorMessage = error.localizedDescription
                     isLoading = false
+                    hasLoaded = true
                 }
             }
         }

--- a/apps/macos-overlay/Sources/Views/AutostartView.swift
+++ b/apps/macos-overlay/Sources/Views/AutostartView.swift
@@ -175,7 +175,7 @@ public struct AutostartCard: View {
             HStack(spacing: 7) {
                 Image(systemName: "power.circle.fill")
                     .font(.system(size: 11, weight: .semibold))
-                    .foregroundColor(status.enabled ? .green : .white.opacity(0.38))
+                    .foregroundColor(status.enabled ? .green : .orange.opacity(0.72))
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text(L("Launch at Login", "登录时启动"))
@@ -192,6 +192,19 @@ public struct AutostartCard: View {
                     ProgressView().controlSize(.mini)
                 }
 
+                HStack(spacing: 3) {
+                    Image(systemName: status.enabled ? "checkmark.circle.fill" : "xmark.circle.fill")
+                        .font(.system(size: 7.5, weight: .bold))
+                    Text(status.enabled ? L("ON", "开") : L("OFF", "关"))
+                        .font(.system(size: 7.2, weight: .heavy, design: .rounded))
+                }
+                .foregroundColor(status.enabled ? .green : .white.opacity(0.52))
+                .padding(.horizontal, 5)
+                .padding(.vertical, 3)
+                .background(
+                    Capsule().fill(status.enabled ? Color.green.opacity(0.14) : Color.white.opacity(0.07))
+                )
+
                 Toggle("", isOn: Binding(
                     get: { status.enabled },
                     set: { setEnabled($0) }
@@ -199,6 +212,10 @@ public struct AutostartCard: View {
                 .labelsHidden()
                 .toggleStyle(.switch)
                 .controlSize(.mini)
+                .tint(status.enabled ? .green : .white.opacity(0.28))
+                .accessibilityLabel(L("Launch at Login", "登录时启动"))
+                .accessibilityValue(status.enabled ? L("On", "已开启") : L("Off", "已关闭"))
+                .accessibilityHint(L("Toggle automatic launch when you log in.", "切换登录时自动启动。"))
                 .disabled(isChanging)
             }
 

--- a/apps/macos-overlay/Sources/Views/HistoryView.swift
+++ b/apps/macos-overlay/Sources/Views/HistoryView.swift
@@ -597,6 +597,8 @@ public struct HistoryTaskDetailOverlay: View {
     public let run: TaskRun
     public let isPrivacyMode: Bool
     public let onClose: () -> Void
+    @State private var executionExpanded = false
+    @State private var logsExpanded = false
 
     public var body: some View {
         VStack(spacing: 7) {
@@ -609,6 +611,10 @@ public struct HistoryTaskDetailOverlay: View {
             RoundedRectangle(cornerRadius: 13)
                 .stroke(Color.cyan.opacity(0.28), lineWidth: 0.8)
         )
+        .onChange(of: run.id) { _, _ in
+            executionExpanded = false
+            logsExpanded = false
+        }
     }
 
     private var detailTitleBar: some View {
@@ -820,24 +826,47 @@ public struct HistoryTaskDetailOverlay: View {
 
     private func detailSteps(_ steps: [TrajectoryStep]) -> some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(L("Execution", "执行轨迹"))
-                .font(.system(size: 7.7, weight: .bold))
-                .foregroundColor(.white.opacity(0.48))
-            ForEach(Array(steps.prefix(5))) { step in
-                HStack(alignment: .top, spacing: 4) {
-                    Circle()
-                        .fill(step.status == "error" ? Color.orange : Color.cyan)
-                        .frame(width: 4, height: 4)
-                        .padding(.top, 4)
-                    HoverRevealText(
-                        [step.title, step.detail].compactMap { $0 }.joined(separator: " — "),
-                        font: .system(size: 7.6),
-                        foregroundColor: .white.opacity(0.6),
-                        lineLimit: 1,
-                        privacyBlur: isPrivacyMode,
-                        popoverWidth: 400
-                    )
-                    .frame(maxWidth: .infinity, alignment: .leading)
+            Button {
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    executionExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "point.filled.topleft.down.curvedto.point.bottomright.up")
+                        .font(.system(size: 7.5))
+                        .foregroundColor(.indigo)
+                    Text(L("Execution", "执行轨迹"))
+                        .font(.system(size: 7.7, weight: .bold))
+                        .foregroundColor(.white.opacity(0.48))
+                    Spacer()
+                    Text(L("\(steps.count) steps", "\(steps.count) 步"))
+                        .font(.system(size: 7.1, weight: .medium))
+                        .foregroundColor(.white.opacity(0.32))
+                    Image(systemName: executionExpanded ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 6.5, weight: .bold))
+                        .foregroundColor(.white.opacity(0.32))
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if executionExpanded {
+                ForEach(Array(steps.prefix(5))) { step in
+                    HStack(alignment: .top, spacing: 4) {
+                        Circle()
+                            .fill(step.status == "error" ? Color.orange : Color.cyan)
+                            .frame(width: 4, height: 4)
+                            .padding(.top, 4)
+                        HoverRevealText(
+                            [step.title, step.detail].compactMap { $0 }.joined(separator: " — "),
+                            font: .system(size: 7.6),
+                            foregroundColor: .white.opacity(0.6),
+                            lineLimit: 1,
+                            privacyBlur: isPrivacyMode,
+                            popoverWidth: 400
+                        )
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
                 }
             }
         }
@@ -847,24 +876,47 @@ public struct HistoryTaskDetailOverlay: View {
 
     private func detailLogs(_ logs: [TaskLogEntry]) -> some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(L("Recent logs", "最近日志"))
-                .font(.system(size: 7.7, weight: .bold))
-                .foregroundColor(.white.opacity(0.48))
-            ForEach(Array(logs.suffix(4))) { entry in
-                HStack(alignment: .top, spacing: 4) {
-                    Circle()
-                        .fill(entry.level == "error" ? Color.orange : Color.green)
-                        .frame(width: 4, height: 4)
-                        .padding(.top, 4)
-                    HoverRevealText(
-                        entry.message ?? "",
-                        font: .system(size: 7.4, design: .monospaced),
-                        foregroundColor: entry.level == "error" ? .orange.opacity(0.82) : .white.opacity(0.58),
-                        lineLimit: 2,
-                        privacyBlur: isPrivacyMode,
-                        popoverWidth: 410
-                    )
-                    .frame(maxWidth: .infinity, alignment: .leading)
+            Button {
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    logsExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "text.line.first.and.arrowtriangle.forward")
+                        .font(.system(size: 7.5))
+                        .foregroundColor(.green)
+                    Text(L("Recent logs", "最近日志"))
+                        .font(.system(size: 7.7, weight: .bold))
+                        .foregroundColor(.white.opacity(0.48))
+                    Spacer()
+                    Text(L("\(logs.count) entries", "\(logs.count) 条"))
+                        .font(.system(size: 7.1, weight: .medium))
+                        .foregroundColor(.white.opacity(0.32))
+                    Image(systemName: logsExpanded ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 6.5, weight: .bold))
+                        .foregroundColor(.white.opacity(0.32))
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if logsExpanded {
+                ForEach(Array(logs.suffix(4))) { entry in
+                    HStack(alignment: .top, spacing: 4) {
+                        Circle()
+                            .fill(entry.level == "error" ? Color.orange : Color.green)
+                            .frame(width: 4, height: 4)
+                            .padding(.top, 4)
+                        HoverRevealText(
+                            entry.message ?? "",
+                            font: .system(size: 7.4, design: .monospaced),
+                            foregroundColor: entry.level == "error" ? .orange.opacity(0.82) : .white.opacity(0.58),
+                            lineLimit: 2,
+                            privacyBlur: isPrivacyMode,
+                            popoverWidth: 410
+                        )
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
                 }
             }
         }

--- a/apps/macos-overlay/Sources/Views/HoverRevealText.swift
+++ b/apps/macos-overlay/Sources/Views/HoverRevealText.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Foundation
 
 /// A compact text label that keeps the normal layout truncated, but reveals the
 /// complete value in a small native popover after a short hover dwell.
@@ -49,20 +50,62 @@ public struct HoverRevealText: View {
             .contentShape(Rectangle())
             .onHover(perform: handleSourceHover)
             .popover(isPresented: $isPresented, arrowEdge: .bottom) {
-                ScrollView(.vertical, showsIndicators: true) {
-                    Text(text)
-                        .font(font)
-                        .foregroundColor(.primary)
-                        .multilineTextAlignment(.leading)
-                        .textSelection(.enabled)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(10)
+                ZStack {
+                    Color(red: 0.055, green: 0.062, blue: 0.085)
+                        .ignoresSafeArea()
+
+                    ScrollView(.vertical, showsIndicators: true) {
+                        expandedText
+                            .font(font)
+                            .foregroundColor(.white.opacity(0.92))
+                            .multilineTextAlignment(.leading)
+                            .textSelection(.enabled)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(10)
+                    }
                 }
-                .frame(width: popoverWidth)
-                .frame(maxHeight: 240)
+                .frame(width: min(max(popoverWidth, 220), 520))
+                .frame(maxHeight: 260)
+                .background(Color(red: 0.055, green: 0.062, blue: 0.085))
+                .preferredColorScheme(.dark)
                 .onHover(perform: handlePopoverHover)
             }
+    }
+
+    /// Native Foundation Markdown parsing keeps headings, lists, fenced code,
+    /// inline code, and links selectable without introducing a WebView or HTML.
+    /// A malformed value falls back to the exact source text. Link attributes
+    /// are retained only for http/https URLs so local files and script schemes
+    /// can never become clickable from telemetry.
+    @ViewBuilder
+    private var expandedText: some View {
+        if let markdown = Self.parseMarkdown(text) {
+            Text(markdown)
+        } else {
+            Text(text)
+        }
+    }
+
+    private static func parseMarkdown(_ source: String) -> AttributedString? {
+        do {
+            var value = try AttributedString(
+                markdown: source,
+                options: .init(interpretedSyntax: .full)
+            )
+
+            for run in value.runs {
+                guard let link = run.link else { continue }
+                let scheme = link.scheme?.lowercased()
+                guard scheme == "http" || scheme == "https" else {
+                    value[run.range].link = nil
+                    continue
+                }
+            }
+            return value
+        } catch {
+            return nil
+        }
     }
 
     private func handleSourceHover(_ inside: Bool) {

--- a/apps/macos-overlay/Sources/Views/SummaryView.swift
+++ b/apps/macos-overlay/Sources/Views/SummaryView.swift
@@ -12,6 +12,7 @@ public struct SummaryView: View {
     @State private var showingAccount = false
     @State private var copiedSummary = false
     @State private var showUpdatePopover = false
+    @State private var executionDetailsExpanded = false
 
     public init(state: OverlayState, isFullHeight: Bool = false) {
         self.state = state
@@ -52,6 +53,9 @@ public struct SummaryView: View {
         )
         .onChange(of: state.activeTab) { _, _ in
             if showingAccount { showingAccount = false }
+        }
+        .onChange(of: currentRun?.id) { _, _ in
+            executionDetailsExpanded = false
         }
     }
 
@@ -538,55 +542,81 @@ public struct SummaryView: View {
     }
 
     private func executionDetailCard(_ run: TaskRun) -> some View {
-        VStack(alignment: .leading, spacing: 5) {
-            sectionHeader("point.filled.topleft.down.curvedto.point.bottomright.up", L("Execution Details", "执行详情"), .indigo)
+        let stepCount = run.trajectory?.count ?? 0
+        let logCount = run.logs?.count ?? 0
+        return VStack(alignment: .leading, spacing: 5) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    executionDetailsExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "point.filled.topleft.down.curvedto.point.bottomright.up")
+                        .font(.system(size: 8))
+                        .foregroundColor(.indigo)
+                    Text(L("Execution Details", "执行详情"))
+                        .font(.system(size: 8.8, weight: .bold, design: .rounded))
+                        .foregroundColor(.white.opacity(0.7))
+                    Spacer()
+                    Text(L("\(stepCount) steps · \(logCount) logs", "\(stepCount) 步 · \(logCount) 条日志"))
+                        .font(.system(size: 7.3, weight: .medium))
+                        .foregroundColor(.white.opacity(0.38))
+                    Image(systemName: executionDetailsExpanded ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 7, weight: .bold))
+                        .foregroundColor(.white.opacity(0.35))
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
 
-            ForEach(Array((run.trajectory ?? []).prefix(6))) { step in
-                HStack(alignment: .top, spacing: 5) {
-                    Circle()
-                        .fill(step.status == "error" ? Color.orange : Color.cyan)
-                        .frame(width: 4.5, height: 4.5)
-                        .padding(.top, 4)
+            if executionDetailsExpanded {
+                ForEach(Array((run.trajectory ?? []).prefix(6))) { step in
+                    HStack(alignment: .top, spacing: 5) {
+                        Circle()
+                            .fill(step.status == "error" ? Color.orange : Color.cyan)
+                            .frame(width: 4.5, height: 4.5)
+                            .padding(.top, 4)
 
-                    VStack(alignment: .leading, spacing: 1) {
-                        HoverRevealText(
-                            step.title ?? step.name ?? "Step",
-                            font: .system(size: 8.6, weight: .semibold),
-                            foregroundColor: .white.opacity(0.82),
-                            lineLimit: 1,
-                            popoverWidth: 360
-                        )
-
-                        if let detail = step.detail, !detail.isEmpty {
+                        VStack(alignment: .leading, spacing: 1) {
                             HoverRevealText(
-                                detail,
-                                font: .system(size: 7.8, design: .monospaced),
-                                foregroundColor: .white.opacity(0.5),
+                                step.title ?? step.name ?? "Step",
+                                font: .system(size: 8.6, weight: .semibold),
+                                foregroundColor: .white.opacity(0.82),
                                 lineLimit: 1,
-                                privacyBlur: state.isPrivacyMode,
-                                popoverWidth: 410
+                                popoverWidth: 360
                             )
+
+                            if let detail = step.detail, !detail.isEmpty {
+                                HoverRevealText(
+                                    detail,
+                                    font: .system(size: 7.8, design: .monospaced),
+                                    foregroundColor: .white.opacity(0.5),
+                                    lineLimit: 1,
+                                    privacyBlur: state.isPrivacyMode,
+                                    popoverWidth: 410
+                                )
+                            }
                         }
                     }
                 }
-            }
 
-            ForEach(Array((run.logs ?? []).suffix(4))) { entry in
-                HStack(alignment: .top, spacing: 5) {
-                    Circle()
-                        .fill(entry.level == "error" ? Color.orange : Color.green)
-                        .frame(width: 4, height: 4)
-                        .padding(.top, 4)
+                ForEach(Array((run.logs ?? []).suffix(4))) { entry in
+                    HStack(alignment: .top, spacing: 5) {
+                        Circle()
+                            .fill(entry.level == "error" ? Color.orange : Color.green)
+                            .frame(width: 4, height: 4)
+                            .padding(.top, 4)
 
-                    HoverRevealText(
-                        entry.message ?? "",
-                        font: .system(size: 7.7, design: .monospaced),
-                        foregroundColor: entry.level == "error" ? .orange.opacity(0.85) : .white.opacity(0.58),
-                        lineLimit: 2,
-                        privacyBlur: state.isPrivacyMode,
-                        popoverWidth: 420
-                    )
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                        HoverRevealText(
+                            entry.message ?? "",
+                            font: .system(size: 7.7, design: .monospaced),
+                            foregroundColor: entry.level == "error" ? .orange.opacity(0.85) : .white.opacity(0.58),
+                            lineLimit: 2,
+                            privacyBlur: state.isPrivacyMode,
+                            popoverWidth: 420
+                        )
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
                 }
             }
         }
@@ -815,11 +845,6 @@ public struct QuotaWindowsView: View {
                     .font(.system(size: 8.8, weight: .bold, design: .rounded))
                     .foregroundColor(.white.opacity(0.7))
                 Spacer()
-                if let reset = ordered.first?.localizedFormattedResetsAt {
-                    Text(reset)
-                        .font(.system(size: 7.4, weight: .medium, design: .monospaced))
-                        .foregroundColor(.white.opacity(0.4))
-                }
             }
 
             ForEach(ordered) { quotaRow($0) }
@@ -838,7 +863,7 @@ public struct QuotaWindowsView: View {
         let tint: Color = used >= 85 ? .orange : (used >= 60 ? .yellow : .cyan)
 
         return VStack(spacing: 3) {
-            HStack {
+            HStack(alignment: .firstTextBaseline, spacing: 4) {
                 Text(window.label)
                     .font(.system(size: 8, weight: .heavy, design: .monospaced))
                     .foregroundColor(tint)
@@ -848,12 +873,17 @@ public struct QuotaWindowsView: View {
                     .font(.system(size: 8, weight: .bold, design: .rounded))
                     .foregroundColor(.white.opacity(0.72))
 
-                Spacer()
+                Spacer(minLength: 2)
 
                 if let reset = window.localizedFormattedResetsAt {
                     Text(reset)
                         .font(.system(size: 7.3, weight: .medium, design: .monospaced))
                         .foregroundColor(.white.opacity(0.42))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.62)
+                        .allowsTightening(true)
+                        .truncationMode(.tail)
+                        .frame(maxWidth: 132, alignment: .trailing)
                 }
             }
 

--- a/scripts/strategies/base.py
+++ b/scripts/strategies/base.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any, Callable, Tuple
 
 Task = Any
 RouteFn = Callable[[Task], str]
@@ -11,7 +11,7 @@ BudgetFn = Callable[[Task], "WorkerBudget"]
 PredicateFn = Callable[[Task], bool]
 CapabilityFn = Callable[[Task, str], str]
 DemandFn = Callable[[Task], int]
-NotesFn = Callable[[Task], tuple[str, ...]]
+NotesFn = Callable[[Task], Tuple[str, ...]]
 LifecycleFn = Callable[[Task, str], "StagePolicy"]
 
 STAGES = ("exploration", "implementation", "review")

--- a/scripts/strategy_runtime.py
+++ b/scripts/strategy_runtime.py
@@ -21,6 +21,11 @@ from strategies import get as get_strategy
 from strategies import names as strategy_names
 from strategies.base import StagePolicy, WorkerBudget
 
+try:
+    from telemetry_core.app_server import quota_windows as app_server_quota_windows
+except ImportError:  # pragma: no cover - standalone installs always bundle it
+    app_server_quota_windows = None
+
 CODEX_HOME = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
 DEFAULT_POLICY = CODEX_HOME / "codex-flow.toml"
 REPO_POLICY_NAME = ".codex-flow.toml"
@@ -448,17 +453,17 @@ def _configured_effort(task: TaskProfile, policy: PolicySnapshot, role: str) -> 
 def quota_pressure_from_snapshot(snapshot: dict[str, Any] | None) -> str:
     if not isinstance(snapshot, dict):
         return "unknown"
-    rate_limits = snapshot.get("rateLimits")
-    if not isinstance(rate_limits, dict):
-        return "unknown"
     used_values: list[float] = []
-    for slot in ("primary", "secondary"):
-        window = rate_limits.get(slot)
-        if not isinstance(window, dict):
-            continue
-        raw = window.get("usedPercent")
+    windows = app_server_quota_windows(snapshot) if app_server_quota_windows else []
+    for window in windows:
+        raw = window.get("used_percent")
         if isinstance(raw, (int, float)) and not isinstance(raw, bool):
             used_values.append(float(raw))
+        elif isinstance(raw, str):
+            try:
+                used_values.append(float(raw))
+            except ValueError:
+                continue
     if not used_values:
         return "unknown"
     used = max(used_values)

--- a/scripts/telemetry.py
+++ b/scripts/telemetry.py
@@ -151,11 +151,21 @@ def _localized_send_system_notification(run: dict) -> None:
 _ORIGINAL_RATE_LIMITS = AppServer.rate_limits
 
 
+def _has_rate_limit_snapshot(value: object) -> bool:
+    """Return whether a response contains either supported rate-limit shape."""
+    if not isinstance(value, dict):
+        return False
+    if isinstance(value.get("rateLimits"), dict):
+        return True
+    by_id = value.get("rateLimitsByLimitId")
+    return isinstance(by_id, dict) and isinstance(by_id.get("codex"), dict)
+
+
 def _rate_limits_with_retry(self: AppServer):
     last = None
     for attempt in range(3):
         last = _ORIGINAL_RATE_LIMITS(self)
-        if isinstance(last, dict) and isinstance(last.get("rateLimits"), dict):
+        if _has_rate_limit_snapshot(last):
             return last
         if attempt < 2:
             time.sleep(0.08 * (attempt + 1))

--- a/scripts/telemetry_core/app_server.py
+++ b/scripts/telemetry_core/app_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import queue
 import re
@@ -65,7 +66,100 @@ def app_server_command() -> list[str]:
     override = os.environ.get("CODEX_FLOW_APP_SERVER_COMMAND")
     if override:
         return shlex.split(override)
+    explicit = os.environ.get("CODEX_FLOW_CODEX_PATH")
+    explicit_path = Path(explicit).expanduser() if explicit else None
+    if explicit_path and os.access(explicit_path, os.X_OK):
+        explicit_dir = str(explicit_path.parent)
+        current_path = os.environ.get("PATH", "")
+        os.environ["PATH"] = (
+            explicit_dir
+            if not current_path
+            else os.pathsep.join((explicit_dir, current_path))
+        )
+        return [str(explicit_path), "app-server"]
+
+    home = Path.home()
+    codex_home = Path(os.environ.get("CODEX_HOME", home / ".codex")).expanduser()
+    directories: list[Path] = []
+    candidates: list[Path] = []
+
+    def add_directory(path: Path) -> None:
+        if path not in directories:
+            directories.append(path)
+
+    def add_candidate(path: Path) -> None:
+        if path not in candidates:
+            candidates.append(path)
+
+    for raw in os.environ.get("PATH", "").split(os.pathsep):
+        if raw:
+            directory = Path(raw)
+            add_directory(directory)
+            add_candidate(directory / "codex")
+
+    for directory in (
+        home / ".local/bin",
+        home / ".npm-global/bin",
+        home / "Library/pnpm",
+        home / ".volta/bin",
+        home / ".bun/bin",
+        codex_home / "bin",
+        home / "Applications/ChatGPT.app/Contents/Resources",
+        Path("/opt/homebrew/bin"),
+        Path("/usr/local/bin"),
+        Path("/Applications/ChatGPT.app/Contents/Resources"),
+        Path("/usr/bin"),
+        Path("/bin"),
+    ):
+        add_directory(directory)
+        add_candidate(directory / "codex")
+
+    nvm_roots = [
+        Path(os.environ["NVM_DIR"]).expanduser() if os.environ.get("NVM_DIR") else None,
+        home / ".nvm",
+        home / ".config/nvm",
+    ]
+    for root in (path for path in nvm_roots if path is not None):
+        for alias in ("current", "default"):
+            directory = root / alias / "bin"
+            add_directory(directory)
+            add_candidate(directory / "codex")
+        versions = root / "versions/node"
+        try:
+            entries = sorted(
+                (path for path in versions.iterdir() if path.is_dir()),
+                key=_nvm_version_sort_key,
+                reverse=True,
+            )
+        except OSError:
+            entries = []
+        for version in entries:
+            directory = version / "bin"
+            add_directory(directory)
+            add_candidate(directory / "codex")
+
+    prefix = os.environ.get("npm_config_prefix") or os.environ.get("PREFIX")
+    if prefix:
+        directory = Path(prefix).expanduser() / "bin"
+        add_directory(directory)
+        add_candidate(directory / "codex")
+
+    for candidate in candidates:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            if directories:
+                os.environ["PATH"] = os.pathsep.join(str(path) for path in directories)
+            return [str(candidate), "app-server"]
+
+    # Keep an enriched PATH for launchd/Finder launches when no direct path was
+    # found; shell sessions still use the normal codex lookup behavior.
+    if directories:
+        os.environ["PATH"] = os.pathsep.join(str(path) for path in directories)
     return ["codex", "app-server"]
+
+
+def _nvm_version_sort_key(path: Path) -> tuple[tuple[int, ...], str]:
+    """Order versioned nvm candidates numerically, with a stable name tie-break."""
+    return tuple(int(part) for part in re.findall(r"\d+", path.name)), path.name
 
 
 class AppServer:
@@ -227,25 +321,124 @@ class AppServer:
 
 
 def quota_windows(snapshot: dict[str, Any] | None) -> list[dict[str, Any]]:
-    if not snapshot:
+    """Return deterministic logical windows from current and legacy API views.
+
+    Newer Codex responses expose ``rateLimitsByLimitId.codex`` while older
+    responses put the same slots in ``rateLimits``. Codex fields win and each
+    missing field is filled from the legacy slot. Duplicate logical rows are
+    then collapsed by duration/reset while preserving same-reset rows whose
+    durations differ.
+    """
+    if not isinstance(snapshot, dict):
         return []
-    rate_limits = snapshot.get("rateLimits")
-    if not isinstance(rate_limits, dict):
-        return []
-    result: list[dict[str, Any]] = []
-    for slot in ("primary", "secondary"):
-        window = rate_limits.get(slot)
-        if not isinstance(window, dict):
+
+    legacy = snapshot.get("rateLimits")
+    if not isinstance(legacy, dict):
+        legacy = {}
+    by_id = snapshot.get("rateLimitsByLimitId")
+    if not isinstance(by_id, dict):
+        by_id = {}
+    codex = by_id.get("codex")
+    if not isinstance(codex, dict):
+        codex = {}
+
+    candidates: list[tuple[tuple[int, int], str, dict[str, Any]]] = []
+    for slot_index, slot in enumerate(("primary", "secondary")):
+        codex_window = codex.get(slot)
+        legacy_window = legacy.get(slot)
+        codex_window = codex_window if isinstance(codex_window, dict) else None
+        legacy_window = legacy_window if isinstance(legacy_window, dict) else None
+        if codex_window is None and legacy_window is None:
             continue
-        result.append(
-            {
-                "slot": slot,
-                "used_percent": window.get("usedPercent"),
-                "window_duration_mins": window.get("windowDurationMins"),
-                "resets_at": window.get("resetsAt"),
-            }
+
+        duration = _first_quota_number(
+            codex_window,
+            legacy_window,
+            ("windowDurationMins", "windowMinutes", "window_duration_mins"),
+            integer=True,
         )
-    return result
+        reset = _first_quota_number(codex_window, legacy_window, ("resetsAt", "resets_at"))
+        used = _first_quota_number(codex_window, legacy_window, ("usedPercent", "used_percent"))
+        if duration is None and reset is None and used is None:
+            continue
+        normalized = {
+            "slot": slot,
+            "used_percent": used,
+            "window_duration_mins": duration,
+            "resets_at": reset,
+        }
+        candidates.append(
+            ((0 if codex_window is not None else 1, slot_index), slot, normalized)
+        )
+
+    def logical_key(row: dict[str, Any], slot: str) -> tuple[Any, ...]:
+        duration = row.get("window_duration_mins")
+        reset = row.get("resets_at")
+        if reset is not None:
+            reset_key = reset / 1000.0 if reset > 1_000_000_000_000 else reset
+            return (duration, reset_key)
+        # Without a reset timestamp there is not enough information to know
+        # whether two same-duration slots are duplicates. Keep their slot
+        # identity (and, for malformed responses, the observed usage) so an
+        # incomplete bucket cannot hide another incomplete bucket.
+        return (duration, reset, slot, row.get("used_percent"))
+
+    selected: dict[tuple[Any, ...], tuple[tuple[int, int], dict[str, Any]]] = {}
+    for rank, slot, row in candidates:
+        key = logical_key(row, slot)
+        current = selected.get(key)
+        if current is None or rank < current[0]:
+            selected[key] = (rank, row)
+
+    return [
+        row
+        for _, row in sorted(
+            selected.values(),
+            key=lambda item: (
+                item[1].get("window_duration_mins")
+                if isinstance(item[1].get("window_duration_mins"), (int, float))
+                else float("inf"),
+                item[1].get("resets_at") if item[1].get("resets_at") is not None else float("inf"),
+                item[1].get("slot", ""),
+            ),
+        )
+    ]
+
+
+def _quota_number(value: Any, *, integer: bool = False) -> int | float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        if not math.isfinite(float(value)):
+            return None
+        return int(value) if integer else value
+    if isinstance(value, str):
+        try:
+            parsed = float(value.strip())
+        except ValueError:
+            return None
+        if not math.isfinite(parsed):
+            return None
+        return int(parsed) if integer else parsed
+    return None
+
+
+def _first_quota_number(
+    primary: dict[str, Any] | None,
+    fallback: dict[str, Any] | None,
+    keys: tuple[str, ...],
+    *,
+    integer: bool = False,
+) -> int | float | None:
+    """Use the first valid value, allowing malformed codex fields to fall back."""
+    for source in (primary, fallback):
+        if not isinstance(source, dict):
+            continue
+        for key in keys:
+            parsed = _quota_number(source.get(key), integer=integer)
+            if parsed is not None:
+                return parsed
+    return None
 
 
 def usage_summary(usage: dict[str, Any] | None) -> dict[str, Any] | None:

--- a/tests/account-snapshot.sh
+++ b/tests/account-snapshot.sh
@@ -2,6 +2,11 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if ! command -v swiftc >/dev/null 2>&1; then
+    echo "swiftc not installed, skipping native account snapshot test"
+    exit 0
+fi
+
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
@@ -157,7 +162,6 @@ chmod +x "$TMP/fake-app-server.py"
 
 CLANG_MODULE_CACHE_PATH="$TMP/module-cache" swiftc \
     -parse-as-library \
-    -framework Foundation \
     "$ROOT_DIR/apps/macos-overlay/Sources/Services/AccountSnapshotService.swift" \
     "$TMP/Test.swift" \
     -o "$TMP/account-snapshot-test"

--- a/tests/account-snapshot.sh
+++ b/tests/account-snapshot.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Compile only the Foundation-backed account service into a temporary test
+# harness. This deliberately avoids build.sh and never writes installed
+# ~/.codex binaries.
+cat > "$TMP/Test.swift" <<'SWIFT'
+import Foundation
+
+func L(_ english: String, _ chinese: String) -> String { english }
+func formatLocalDateTime(_ date: Date) -> String { "date" }
+
+@main
+struct AccountSnapshotFixtureTest {
+    static func main() throws {
+        let fixtureURL = URL(fileURLWithPath: CommandLine.arguments[1])
+        if CommandLine.arguments.count > 2 {
+            let mode = CommandLine.arguments[2]
+            let startedAt = Date()
+            var failure: Error?
+            do {
+                _ = try AccountSnapshotService.load()
+            } catch {
+                failure = error
+            }
+            let elapsed = Date().timeIntervalSince(startedAt)
+            guard let failure else {
+                throw NSError(
+                    domain: "FlowPilot.AccountFixture",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Expected \(mode) app-server failure"]
+                )
+            }
+            let message = failure.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+            precondition(!message.isEmpty, "\(mode) returned an empty localized error")
+            precondition(elapsed < 6.0, "\(mode) exceeded bounded test limit")
+            print("account snapshot \(mode) bounded failure passed")
+            return
+        }
+        let fixtureData = try Data(contentsOf: fixtureURL)
+        let fixture = try JSONSerialization.jsonObject(with: fixtureData) as! [String: Any]
+        let account: [String: Any] = [
+            "account": ["type": "chatgpt", "email": "fixture@example.com", "planType": "pro"],
+            "requiresOpenaiAuth": false
+        ]
+
+        let first = try AccountSnapshotService.parse(
+            accountResponse: account,
+            limitsResponse: fixture,
+            now: Date(timeIntervalSince1970: 1)
+        )
+        let second = try AccountSnapshotService.parse(
+            accountResponse: account,
+            limitsResponse: fixture,
+            now: Date(timeIntervalSince1970: 2)
+        )
+
+        precondition(first.email == "fixture@example.com")
+        precondition(first.resetCreditCount == 4)
+        precondition(first.resetCredits.isEmpty)
+        precondition(first.quotaWindows.count == 2)
+        precondition(first.quotaWindows[0].durationMinutes == 300)
+        precondition(first.quotaWindows[0].usedPercent == 42)
+        precondition(first.quotaWindows[1].durationMinutes == 10080)
+        precondition(first.quotaWindows[1].usedPercent == 61)
+        precondition(first.quotaWindows.map(\.id) == second.quotaWindows.map(\.id))
+
+        let duplicateWindow = try AccountSnapshotService.parse(
+            accountResponse: [:],
+            limitsResponse: [
+                "rateLimitsByLimitId": [
+                    "codex": [
+                        "primary": ["windowDurationMins": 300, "usedPercent": 10, "resetsAt": 1_700_000_000],
+                        "secondary": ["windowDurationMins": 300, "usedPercent": 20, "resetsAt": 1_700_000_000]
+                    ]
+                ]
+            ],
+            now: Date(timeIntervalSince1970: 1)
+        )
+        precondition(duplicateWindow.quotaWindows.count == 1)
+        precondition(duplicateWindow.quotaWindows[0].durationMinutes == 300)
+        precondition(duplicateWindow.quotaWindows[0].usedPercent == 10)
+
+        let distinctWindows = try AccountSnapshotService.parse(
+            accountResponse: [:],
+            limitsResponse: [
+                "rateLimitsByLimitId": [
+                    "codex": [
+                        "primary": ["windowDurationMins": 300, "usedPercent": 10, "resetsAt": 1_700_000_000],
+                        "secondary": ["windowDurationMins": 10080, "usedPercent": 20, "resetsAt": 1_700_000_000]
+                    ]
+                ]
+            ],
+            now: Date(timeIntervalSince1970: 1)
+        )
+        precondition(distinctWindows.quotaWindows.count == 2)
+        precondition(distinctWindows.quotaWindows.map(\.durationMinutes) == [300, 10080])
+
+        let zero = try AccountSnapshotService.parse(
+            accountResponse: [:],
+            limitsResponse: ["rateLimitResetCredits": ["availableCount": 0, "credits": NSNull()]],
+            now: Date(timeIntervalSince1970: 1)
+        )
+        precondition(zero.resetCreditCount == 0)
+        precondition(zero.resetCredits.isEmpty)
+        precondition(!zero.isEmpty)
+
+        let missing = try AccountSnapshotService.parse(
+            accountResponse: [:],
+            limitsResponse: ["rateLimitResetCredits": ["credits": []]],
+            now: Date(timeIntervalSince1970: 1)
+        )
+        precondition(missing.resetCreditCount == nil)
+        precondition(missing.resetCredits.isEmpty)
+        precondition(missing.isEmpty)
+        print("account snapshot fixture test passed")
+    }
+}
+SWIFT
+
+cat > "$TMP/fake-app-server.py" <<'PY'
+#!/usr/bin/env python3
+import json
+import sys
+import time
+
+mode = sys.argv[1]
+if mode == "silent":
+    time.sleep(30)
+    raise SystemExit(0)
+if mode == "eof":
+    raise SystemExit(17)
+
+for line in sys.stdin:
+    try:
+        request = json.loads(line)
+    except json.JSONDecodeError:
+        continue
+    if mode == "malformed":
+        print("not-json", flush=True)
+        raise SystemExit(0)
+    if mode == "rpc-error":
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": request.get("id"),
+            "error": {"code": -32000, "message": "fixture app-server error"},
+        }), flush=True)
+        time.sleep(30)
+        raise SystemExit(0)
+    raise SystemExit(2)
+PY
+chmod +x "$TMP/fake-app-server.py"
+
+CLANG_MODULE_CACHE_PATH="$TMP/module-cache" swiftc \
+    -parse-as-library \
+    -framework Foundation \
+    "$ROOT_DIR/apps/macos-overlay/Sources/Services/AccountSnapshotService.swift" \
+    "$TMP/Test.swift" \
+    -o "$TMP/account-snapshot-test"
+
+"$TMP/account-snapshot-test" "$ROOT_DIR/tests/fixtures/account-rate-limits.json"
+
+for mode in silent eof malformed rpc-error; do
+    CODEX_FLOW_APP_SERVER_COMMAND="exec python3 \"$TMP/fake-app-server.py\" $mode" \
+        "$TMP/account-snapshot-test" "$ROOT_DIR/tests/fixtures/account-rate-limits.json" "$mode"
+done

--- a/tests/fixtures/account-rate-limits.json
+++ b/tests/fixtures/account-rate-limits.json
@@ -1,0 +1,32 @@
+{
+  "rateLimitsByLimitId": {
+    "codex": {
+      "primary": {
+        "usedPercent": 42,
+        "windowDurationMins": null,
+        "resetsAt": null
+      },
+      "secondary": {
+        "usedPercent": 61,
+        "windowDurationMins": 10080,
+        "resetsAt": 1700000000
+      }
+    }
+  },
+  "rateLimits": {
+    "primary": {
+      "usedPercent": 90,
+      "windowDurationMins": 300,
+      "resetsAt": 1700000000
+    },
+    "secondary": {
+      "usedPercent": 70,
+      "windowDurationMins": 10080,
+      "resetsAt": 1700000000
+    }
+  },
+  "rateLimitResetCredits": {
+    "availableCount": 4,
+    "credits": []
+  }
+}

--- a/tests/strategy-runtime.sh
+++ b/tests/strategy-runtime.sh
@@ -353,13 +353,22 @@ PY
 # Quota adapter remains deterministic and independent of strategy/lifecycle semantics.
 python3 - "$ROOT" <<'PY'
 import sys
+import json
 sys.path.insert(0, sys.argv[1] + '/scripts')
+from telemetry_core.app_server import _nvm_version_sort_key, quota_windows
 from strategy_runtime import quota_pressure_from_snapshot
+from pathlib import Path
+versions = sorted((Path(name) for name in ('v9.0.0', 'v22.1.0', 'v22.0.9')), key=_nvm_version_sort_key, reverse=True)
+assert [path.name for path in versions] == ['v22.1.0', 'v22.0.9', 'v9.0.0'], versions
 assert quota_pressure_from_snapshot(None) == 'unknown'
 assert quota_pressure_from_snapshot({'rateLimits': {'primary': {'usedPercent': 20}}}) == 'low'
 assert quota_pressure_from_snapshot({'rateLimits': {'primary': {'usedPercent': 55}}}) == 'medium'
 assert quota_pressure_from_snapshot({'rateLimits': {'primary': {'usedPercent': 80}}}) == 'high'
 assert quota_pressure_from_snapshot({'rateLimits': {'primary': {'usedPercent': 95}}}) == 'critical'
+fixture = json.load(open(sys.argv[1] + '/tests/fixtures/account-rate-limits.json'))
+windows = quota_windows(fixture)
+assert [(row['window_duration_mins'], row['used_percent']) for row in windows] == [(300, 42), (10080, 61)], windows
+assert quota_pressure_from_snapshot(fixture) == 'medium', windows
 PY
 
 # Repository policy precedence/ceilings continue to work with lifecycle v8.

--- a/tests/telemetry-core.sh
+++ b/tests/telemetry-core.sh
@@ -7,6 +7,26 @@ export CODEX_HOME="$TMP/.codex"
 export FAKE_COUNTER="$TMP/counter"
 export CODEX_FLOW_TELEMETRY_NOTIFICATIONS=false
 
+# A current Codex response may omit the legacy single-bucket field entirely;
+# the telemetry retry wrapper must treat the canonical codex bucket as usable.
+python3 - "$ROOT_DIR/scripts/telemetry.py" <<'PY'
+import importlib.util
+import sys
+
+spec = importlib.util.spec_from_file_location("telemetry", sys.argv[1])
+telemetry = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(telemetry)
+
+calls = []
+telemetry._ORIGINAL_RATE_LIMITS = lambda _server: calls.append(1) or {
+    "rateLimitsByLimitId": {"codex": {"primary": {"usedPercent": 12}}}
+}
+snapshot = telemetry._rate_limits_with_retry(object())
+assert snapshot["rateLimitsByLimitId"]["codex"]
+assert len(calls) == 1, calls
+PY
+
 cat > "$TMP/fake-app-server.py" <<'PY'
 #!/usr/bin/env python3
 import json, os, sys

--- a/tests/telemetry.sh
+++ b/tests/telemetry.sh
@@ -2,5 +2,6 @@
 set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+bash "$ROOT_DIR/tests/account-snapshot.sh"
 bash "$ROOT_DIR/tests/telemetry-core.sh"
 bash "$ROOT_DIR/tests/telemetry-repair.sh"


### PR DESCRIPTION
## Problem
- Collapsed overlay bubble docking edge could oscillate or restore awkwardly across displays/restarts.
- Account snapshot service and app-server integration needed stabilization around rate limits and idle UI states.
- Long text and history inspection needed refined reveal and dismissed state handling.
- `NotesFn` type alias used subscripted `tuple[str, ...]` which fails with `TypeError: 'type' object is not subscriptable` in Python < 3.9.
- `AccountSnapshotService.swift` contained an unused `import Darwin` which broke Linux CI during swiftc compilation.

## Changes
- **Overlay Docking & Idle State**: Normalize collapsed bubble dock edge to right-edge affordance, screen bounds handling for multi-monitor setups, and stabilize tuck/expand lifecycle.
- **Account & Rate Limits**: Stabilize AccountSnapshotService and app_server.py fallback/retry handling, adding comprehensive fixture tests.
- **Python < 3.9 Compatibility**: In `scripts/strategies/base.py`, use `typing.Tuple` for runtime `NotesFn` type alias instead of built-in `tuple[...]`.
- **Cross-Platform Swift Tests**: Remove unused `import Darwin` from `AccountSnapshotService.swift`, remove `-framework Foundation` from swiftc flags, and gracefully skip swiftc tests if compiler is not installed.
- **UI Refinements**: Refine AccountView, AutostartView, HistoryView, HoverRevealText, and SummaryView states and accessibility tags.
- **Tests & CI**: Add `tests/account-snapshot.sh` and account rate-limits fixtures; update syntax checks in `ci.yml`.

## Validation
- `bash tests/account-snapshot.sh`: passing
- `bash tests/strategy-runtime.sh`: passing (verified on Python 3.7.4)
- `bash tests/telemetry-core.sh`: passing
- `bash tests/telemetry.sh`: passing
- `bash tests/smoke.sh`: passing
- `bash tests/lifecycle-runtime.sh`: passing
- `bash apps/macos-overlay/build.sh`: native macOS build succeeded cleanly
- GitHub Actions CI (Ubuntu, macOS, Windows pwsh & powershell): all checks passing green