### PR TITLE
fix(overlay): finish drag lifecycle before idle tuck

### DIFF
--- a/apps/macos-overlay/Sources/Controllers/OverlayWindowController.swift
+++ b/apps/macos-overlay/Sources/Controllers/OverlayWindowController.swift
@@ -74,6 +74,7 @@ public class OverlayState: ObservableObject {
         DispatchQueue.main.async {
             self.isExpanded = false
             self.isPinned = false
+            self.isDocked = false
             self.windowController?.updateWindowFrame(animated: true)
             self.windowController?.scheduleTuck()
         }
@@ -313,13 +314,17 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
     }
 
     // MARK: - Dragging & Magnetic Edge Snapping
-    private var initialLocation: NSPoint = .zero
+    private var initialMouseScreenLocation: NSPoint = .zero
+    private var initialWindowOrigin: NSPoint = .zero
     private var isDragging: Bool = false
     private let snapMargin: CGFloat = 8.0
     private let snapThreshold: CGFloat = 36.0
 
     override func mouseDown(with event: NSEvent) {
-        initialLocation = event.locationInWindow
+        if let window = self.window {
+            initialMouseScreenLocation = NSEvent.mouseLocation
+            initialWindowOrigin = window.frame.origin
+        }
         isDragging = false
         windowController?.cancelDwellTimer()
         windowController?.isInteractingOrDragging = true
@@ -331,18 +336,19 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
             super.mouseDragged(with: event)
             return
         }
-        let currentLocation = event.locationInWindow
-        let deltaX = currentLocation.x - initialLocation.x
-        let deltaY = currentLocation.y - initialLocation.y
+        let currentMouseScreenLocation = NSEvent.mouseLocation
+        let deltaX = currentMouseScreenLocation.x - initialMouseScreenLocation.x
+        let deltaY = currentMouseScreenLocation.y - initialMouseScreenLocation.y
         let dragThreshold: CGFloat = (windowController?.state.isExpanded ?? false) ? 8.0 : 4.0
-        if abs(deltaX) > dragThreshold || abs(deltaY) > dragThreshold {
+        if isDragging || abs(deltaX) > dragThreshold || abs(deltaY) > dragThreshold {
             isDragging = true
             windowController?.cancelDwellTimer()
             windowController?.isInteractingOrDragging = true
 
-            var newOrigin = window.frame.origin
-            newOrigin.x += deltaX
-            newOrigin.y += deltaY
+            var newOrigin = NSPoint(
+                x: initialWindowOrigin.x + deltaX,
+                y: initialWindowOrigin.y + deltaY
+            )
 
             if let screen = window.screen ?? NSScreen.main {
                 let visible = screen.visibleFrame
@@ -407,9 +413,10 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
                 targetOrigin.y = visible.minY + snapMargin
             }
         } else {
-            // The collapsed bubble is a stable right-edge affordance. It may
-            // be dragged freely while the mouse is down, but release/idle
-            // always settles on the right so it cannot oscillate between edges.
+            // Collapsed mode has a single stable right-edge destination. The
+            // concurrent hotfix experimented with dual-sided snapping, but that
+            // reintroduces the reported left/right ambiguity, so right-only is
+            // the deliberate conflict resolution here.
             targetOrigin.x = visible.maxX - frame.width - snapMargin
             windowController?.state.dockEdge = .right
 
@@ -541,6 +548,7 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
     private var hoverDwellTimer: Timer?
     private var collapseTimer: Timer?
     private var tuckTimer: Timer?
+    private let edgeTuckIdleInterval: TimeInterval = 30.0
     // Programmatic window moves can synthesize tracking-area enter/exit events.
     // Remember the pointer position before a collapse/tuck and require genuine
     // pointer movement before hover behavior is re-armed. This breaks the
@@ -589,6 +597,9 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
 
         window.orderFront(nil)
 
+        // Give launch/restoration a moment to settle, then start the normal
+        // 30-second idle countdown. We intentionally do not stack two 30-second
+        // delays here.
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) { [weak self] in
             self?.scheduleTuck()
         }
@@ -604,7 +615,7 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
         cancelTuckTimer()
         guard !state.isExpanded, !state.isPinned, !isInteractingOrDragging, !state.isDocked else { return }
         state.dockEdge = .right
-        tuckTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false) { [weak self] _ in
+        tuckTimer = Timer.scheduledTimer(withTimeInterval: edgeTuckIdleInterval, repeats: false) { [weak self] _ in
             self?.tuckBubble(animated: true)
         }
     }

--- a/apps/macos-overlay/Sources/Controllers/OverlayWindowController.swift
+++ b/apps/macos-overlay/Sources/Controllers/OverlayWindowController.swift
@@ -535,6 +535,13 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
     private var hoverDwellTimer: Timer?
     private var collapseTimer: Timer?
     private var tuckTimer: Timer?
+    // Programmatic window moves can synthesize tracking-area enter/exit events.
+    // Remember the pointer position before a collapse/tuck and require genuine
+    // pointer movement before hover behavior is re-armed. This breaks the
+    // feedback loop where the window moves under a stationary cursor, receives
+    // mouseEntered, reverses the move, then receives mouseExited and tucks again.
+    private var hoverRearmPointerLocation: NSPoint?
+    private let hoverRearmDistance: CGFloat = 2.0
     private let bubbleSize = NSSize(width: 76, height: 76)
     private let summarySize = NSSize(width: 384, height: 490)
 
@@ -596,6 +603,22 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
         }
     }
 
+    private func suppressHoverUntilPointerMoves() {
+        hoverRearmPointerLocation = NSEvent.mouseLocation
+        cancelDwellTimer()
+    }
+
+    private func pointerMovementRearmedHover() -> Bool {
+        guard let anchor = hoverRearmPointerLocation else { return true }
+        let current = NSEvent.mouseLocation
+        let dx = current.x - anchor.x
+        let dy = current.y - anchor.y
+        let minimumDistanceSquared = hoverRearmDistance * hoverRearmDistance
+        guard dx * dx + dy * dy >= minimumDistanceSquared else { return false }
+        hoverRearmPointerLocation = nil
+        return true
+    }
+
     public func tuckBubble(animated: Bool = true) {
         guard let window = self.window else { return }
         guard !state.isExpanded, !state.isPinned, !isInteractingOrDragging, !state.isDocked else { return }
@@ -606,6 +629,7 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
         let targetX = visible.maxX - bubbleSize.width
 
         let targetFrame = NSRect(origin: NSPoint(x: targetX, y: window.frame.origin.y), size: bubbleSize)
+        suppressHoverUntilPointerMoves()
         state.isDocked = true
 
         if animated {
@@ -655,6 +679,10 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
     }
 
     public func handleMouseEntered() {
+        // A tracking-area enter caused only by our own frame animation is not
+        // user intent. Ignoring it is what makes idle collapse/tuck idempotent.
+        guard pointerMovementRearmedHover() else { return }
+
         cancelTuckTimer()
         collapseTimer?.invalidate()
         collapseTimer = nil
@@ -668,6 +696,8 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
     }
 
     public func handleMouseMoved() {
+        guard pointerMovementRearmedHover() else { return }
+
         if state.isDocked {
             unTuckBubble(animated: true)
         }
@@ -724,6 +754,13 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
         }
 
         let newFrame = NSRect(origin: newOrigin, size: targetSize)
+
+        if !state.isExpanded {
+            // Resizing the summary into the collapsed bubble can move the new
+            // tracking area under a stationary cursor. Do not let that synthetic
+            // enter immediately expand or untuck the bubble again.
+            suppressHoverUntilPointerMoves()
+        }
 
         if animated {
             NSAnimationContext.runAnimationGroup { context in

--- a/apps/macos-overlay/Sources/Controllers/OverlayWindowController.swift
+++ b/apps/macos-overlay/Sources/Controllers/OverlayWindowController.swift
@@ -74,6 +74,7 @@ public class OverlayState: ObservableObject {
         DispatchQueue.main.async {
             self.isExpanded = false
             self.isPinned = false
+            self.isDocked = false
             self.windowController?.updateWindowFrame(animated: true)
             self.windowController?.scheduleTuck()
         }
@@ -234,14 +235,17 @@ public struct OverlayRootView: View {
     }
 
     public var body: some View {
-        ZStack(alignment: .topTrailing) {
+        let align: Alignment = (state.dockEdge == .left) ? .topLeading : .topTrailing
+        let anchorPoint: UnitPoint = (state.dockEdge == .left) ? .topLeading : .topTrailing
+
+        ZStack(alignment: align) {
             if state.isExpanded {
                 SummaryView(state: state)
                     .frame(width: 384)
                     .transition(
                         .asymmetric(
-                            insertion: .opacity.combined(with: .scale(scale: 0.95, anchor: .topTrailing)),
-                            removal: .opacity.combined(with: .scale(scale: 0.95, anchor: .topTrailing))
+                            insertion: .opacity.combined(with: .scale(scale: 0.95, anchor: anchorPoint)),
+                            removal: .opacity.combined(with: .scale(scale: 0.95, anchor: anchorPoint))
                         )
                     )
             } else {
@@ -249,14 +253,15 @@ public struct OverlayRootView: View {
                     .frame(width: 76, height: 76)
                     .transition(
                         .asymmetric(
-                            insertion: .opacity.combined(with: .scale(scale: 0.95, anchor: .topTrailing)),
-                            removal: .opacity.combined(with: .scale(scale: 0.95, anchor: .topTrailing))
+                            insertion: .opacity.combined(with: .scale(scale: 0.95, anchor: anchorPoint)),
+                            removal: .opacity.combined(with: .scale(scale: 0.95, anchor: anchorPoint))
                         )
                     )
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: align)
         .background(Color.clear)
+        .preferredColorScheme(.dark)
         .animation(.spring(response: 0.16, dampingFraction: 0.82), value: state.isExpanded)
     }
 }
@@ -313,13 +318,17 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
     }
 
     // MARK: - Dragging & Magnetic Edge Snapping
-    private var initialLocation: NSPoint = .zero
+    private var initialMouseScreenLocation: NSPoint = .zero
+    private var initialWindowOrigin: NSPoint = .zero
     private var isDragging: Bool = false
     private let snapMargin: CGFloat = 8.0
     private let snapThreshold: CGFloat = 36.0
 
     override func mouseDown(with event: NSEvent) {
-        initialLocation = event.locationInWindow
+        if let window = self.window {
+            initialMouseScreenLocation = NSEvent.mouseLocation
+            initialWindowOrigin = window.frame.origin
+        }
         isDragging = false
         windowController?.cancelDwellTimer()
         windowController?.isInteractingOrDragging = true
@@ -331,23 +340,24 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
             super.mouseDragged(with: event)
             return
         }
-        let currentLocation = event.locationInWindow
-        let deltaX = currentLocation.x - initialLocation.x
-        let deltaY = currentLocation.y - initialLocation.y
+        let currentMouseScreen = NSEvent.mouseLocation
+        let deltaX = currentMouseScreen.x - initialMouseScreenLocation.x
+        let deltaY = currentMouseScreen.y - initialMouseScreenLocation.y
         let dragThreshold: CGFloat = (windowController?.state.isExpanded ?? false) ? 8.0 : 4.0
-        if abs(deltaX) > dragThreshold || abs(deltaY) > dragThreshold {
+        if isDragging || abs(deltaX) > dragThreshold || abs(deltaY) > dragThreshold {
             isDragging = true
             windowController?.cancelDwellTimer()
             windowController?.isInteractingOrDragging = true
 
-            var newOrigin = window.frame.origin
-            newOrigin.x += deltaX
-            newOrigin.y += deltaY
+            var newOrigin = NSPoint(
+                x: initialWindowOrigin.x + deltaX,
+                y: initialWindowOrigin.y + deltaY
+            )
 
             if let screen = window.screen ?? NSScreen.main {
                 let visible = screen.visibleFrame
                 newOrigin.x = max(visible.minX, min(newOrigin.x, visible.maxX - window.frame.width))
-                newOrigin.y = max(visible.minY, min(newOrigin.y, visible.maxY - window.frame.height))
+                newOrigin.y = max(visible.minY + 24, min(newOrigin.y, visible.maxY - window.frame.height - 24))
             }
 
             window.setFrameOrigin(newOrigin)
@@ -402,18 +412,23 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
                 targetOrigin.y = visible.minY + snapMargin
             }
         } else {
-            // The collapsed bubble is a stable right-edge affordance. It may
-            // be dragged freely while the mouse is down, but release/idle
-            // always settles on the right so it cannot oscillate between edges.
-            targetOrigin.x = visible.maxX - frame.width - snapMargin
-            windowController?.state.dockEdge = .right
+            // Scheme A: Dual-sided smart magnetic snap (iOS AssistiveTouch behavior)
+            let toLeft = frame.midX < visible.midX
+            if toLeft {
+                targetOrigin.x = visible.minX
+                windowController?.state.dockEdge = .left
+            } else {
+                targetOrigin.x = visible.maxX - frame.width
+                windowController?.state.dockEdge = .right
+            }
+            windowController?.state.isDocked = false
 
             if distTop < snapThreshold {
-                targetOrigin.y = visible.maxY - frame.height - snapMargin
+                targetOrigin.y = visible.maxY - frame.height - 24
             } else if distBottom < snapThreshold {
-                targetOrigin.y = visible.minY + snapMargin
+                targetOrigin.y = visible.minY + 24
             } else {
-                targetOrigin.y = max(visible.minY + snapMargin, min(targetOrigin.y, visible.maxY - frame.height - snapMargin))
+                targetOrigin.y = max(visible.minY + 24, min(targetOrigin.y, visible.maxY - frame.height - 24))
             }
         }
 
@@ -535,6 +550,7 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
     private var hoverDwellTimer: Timer?
     private var collapseTimer: Timer?
     private var tuckTimer: Timer?
+    private let edgeTuckIdleInterval: TimeInterval = 30.0
     // Programmatic window moves can synthesize tracking-area enter/exit events.
     // Remember the pointer position before a collapse/tuck and require genuine
     // pointer movement before hover behavior is re-armed. This breaks the
@@ -553,10 +569,6 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
     }
 
     private func setupWindow() {
-        // Older releases persisted a left-edge bubble. Collapsed restoration is
-        // intentionally normalized to the right edge; expanded cards still use
-        // their own current-frame positioning below.
-        state.dockEdge = .right
         let restored = loadSavedPosition() ?? defaultPosition(for: bubbleSize)
         let initialRect = normalizedCollapsedFrame(restored)
 
@@ -572,6 +584,7 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
         window.isOpaque = false
         window.backgroundColor = .clear
         window.hasShadow = false
+        window.appearance = NSAppearance(named: .darkAqua)
         window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
         window.isMovableByWindowBackground = false
         window.delegate = self
@@ -583,8 +596,22 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
 
         window.orderFront(nil)
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) { [weak self] in
+        // Automatically collapse expanded panel on outside clicks
+        NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { [weak self] _ in
+            guard let self = self else { return }
+            if self.state.isExpanded && !self.state.isPinned && !self.isInteractingOrDragging {
+                self.state.collapse()
+            }
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + edgeTuckIdleInterval) { [weak self] in
             self?.scheduleTuck()
+        }
+    }
+
+    public func windowDidResignKey(_ notification: Notification) {
+        if state.isExpanded && !state.isPinned && !isInteractingOrDragging {
+            state.collapse()
         }
     }
 
@@ -597,8 +624,7 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
     public func scheduleTuck() {
         cancelTuckTimer()
         guard !state.isExpanded, !state.isPinned, !isInteractingOrDragging, !state.isDocked else { return }
-        state.dockEdge = .right
-        tuckTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false) { [weak self] _ in
+        tuckTimer = Timer.scheduledTimer(withTimeInterval: edgeTuckIdleInterval, repeats: false) { [weak self] _ in
             self?.tuckBubble(animated: true)
         }
     }
@@ -625,10 +651,11 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
         guard let screen = window.screen ?? NSScreen.main else { return }
         let visible = screen.visibleFrame
 
-        state.dockEdge = .right
-        let targetX = visible.maxX - bubbleSize.width
+        let isLeft = (state.dockEdge == .left)
+        let targetX = isLeft ? visible.minX : (visible.maxX - bubbleSize.width)
+        let targetY = max(visible.minY + 24, min(window.frame.origin.y, visible.maxY - bubbleSize.height - 24))
 
-        let targetFrame = NSRect(origin: NSPoint(x: targetX, y: window.frame.origin.y), size: bubbleSize)
+        let targetFrame = NSRect(origin: NSPoint(x: targetX, y: targetY), size: bubbleSize)
         suppressHoverUntilPointerMoves()
         state.isDocked = true
 
@@ -646,30 +673,9 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
 
     public func unTuckBubble(animated: Bool = true) {
         cancelTuckTimer()
-        guard let window = self.window else { return }
+        guard self.window != nil else { return }
         guard state.isDocked else { return }
-        guard let screen = window.screen ?? NSScreen.main else { return }
-        let visible = screen.visibleFrame
-
-        state.dockEdge = .right
-        let targetX = visible.maxX - bubbleSize.width - 8.0
-
-        let targetFrame = NSRect(origin: NSPoint(x: targetX, y: window.frame.origin.y), size: bubbleSize)
         state.isDocked = false
-
-        if animated {
-            NSAnimationContext.runAnimationGroup({ context in
-                context.duration = 0.14
-                context.timingFunction = CAMediaTimingFunction(name: .easeOut)
-                context.allowsImplicitAnimation = true
-                window.animator().setFrame(targetFrame, display: true)
-            }, completionHandler: { [weak self] in
-                self?.saveWindowPosition(NSPoint(x: targetX, y: window.frame.origin.y))
-            })
-        } else {
-            window.setFrame(targetFrame, display: true)
-            saveWindowPosition(NSPoint(x: targetX, y: window.frame.origin.y))
-        }
     }
 
     // MARK: - Hover-Dwell 0.4s Detection
@@ -735,22 +741,18 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
         let targetSize = state.isExpanded ? summarySize : bubbleSize
         let currentFrame = window.frame
 
-        var newOrigin = NSPoint(
-            x: currentFrame.maxX - targetSize.width,
-            y: currentFrame.maxY - targetSize.height
-        )
-
+        var newOrigin: NSPoint
         if let screen = window.screen ?? NSScreen.main {
             let visible = screen.visibleFrame
-            if state.isExpanded {
-                // Expanded cards preserve the right/bottom anchor of the
-                // current frame and retain their existing edge behavior.
-                newOrigin.x = max(visible.minX, min(newOrigin.x, visible.maxX - targetSize.width))
-            } else {
-                state.dockEdge = .right
-                newOrigin.x = visible.maxX - targetSize.width - 8.0
-            }
-            newOrigin.y = max(visible.minY, min(newOrigin.y, visible.maxY - targetSize.height))
+            let isLeft = (state.dockEdge == .left)
+            let x: CGFloat = isLeft ? visible.minX : (visible.maxX - targetSize.width)
+            let y = max(visible.minY + 24, min(currentFrame.maxY - targetSize.height, visible.maxY - targetSize.height - 24))
+            newOrigin = NSPoint(x: x, y: y)
+        } else {
+            newOrigin = NSPoint(
+                x: currentFrame.maxX - targetSize.width,
+                y: currentFrame.maxY - targetSize.height
+            )
         }
 
         let newFrame = NSRect(origin: newOrigin, size: targetSize)
@@ -792,9 +794,12 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
 
     private func normalizedCollapsedFrame(_ frame: NSRect) -> NSRect {
         let visible = screen(forSavedFrame: frame)?.visibleFrame
+            ?? NSScreen.main?.visibleFrame
             ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
-        let x = visible.maxX - bubbleSize.width - 8.0
-        let y = max(visible.minY, min(frame.origin.y, visible.maxY - bubbleSize.height))
+        let isLeft = frame.midX < visible.midX
+        state.dockEdge = isLeft ? .left : .right
+        let x = isLeft ? visible.minX : (visible.maxX - bubbleSize.width)
+        let y = max(visible.minY + 24, min(frame.origin.y, visible.maxY - bubbleSize.height - 24))
         return NSRect(origin: NSPoint(x: x, y: y), size: bubbleSize)
     }
 
@@ -833,7 +838,7 @@ public class OverlayWindowController: NSObject, NSWindowDelegate {
 
     private func defaultPosition(for size: NSSize) -> NSRect {
         let screen = NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
-        let x = screen.maxX - size.width - 32
+        let x = screen.maxX - size.width
         let y = screen.maxY - size.height - 32
         return NSRect(x: x, y: y, width: size.width, height: size.height)
     }

--- a/apps/macos-overlay/Sources/Controllers/OverlayWindowController.swift
+++ b/apps/macos-overlay/Sources/Controllers/OverlayWindowController.swift
@@ -363,10 +363,11 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
         }
 
         if isDragging {
+            // Keep the interaction gate active only until the snap animation
+            // finishes. Its completion owns ending this drag and scheduling the
+            // subsequent idle tuck, so no detached delayed closure can clear a
+            // newer user interaction or lose the tuck while the guard is active.
             performMagneticSnap(for: window)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { [weak self] in
-                self?.windowController?.isInteractingOrDragging = false
-            }
         } else {
             windowController?.isInteractingOrDragging = false
             if let state = windowController?.state, !state.isExpanded {
@@ -378,7 +379,11 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
     }
 
     private func performMagneticSnap(for window: NSWindow) {
-        guard let screen = window.screen ?? NSScreen.main else { return }
+        guard let screen = window.screen ?? NSScreen.main else {
+            windowController?.isInteractingOrDragging = false
+            windowController?.scheduleTuck()
+            return
+        }
         let visible = screen.visibleFrame
         let frame = window.frame
         var targetOrigin = frame.origin
@@ -424,9 +429,10 @@ class TrackingHostingView<Content: View>: NSHostingView<Content> {
             context.allowsImplicitAnimation = true
             window.animator().setFrame(targetFrame, display: true)
         }, completionHandler: { [weak self] in
-            guard let self = self else { return }
-            self.windowController?.saveWindowPosition(targetOrigin)
-            self.windowController?.scheduleTuck()
+            guard let self = self, let controller = self.windowController else { return }
+            controller.isInteractingOrDragging = false
+            controller.saveWindowPosition(targetOrigin)
+            controller.scheduleTuck()
         })
     }
 

--- a/apps/macos-overlay/Sources/Models/TelemetryData.swift
+++ b/apps/macos-overlay/Sources/Models/TelemetryData.swift
@@ -248,6 +248,32 @@ public struct QuotaWindow: Codable, Identifiable {
     }
 }
 
+public struct DailyQuotaUsage: Identifiable {
+    public var id: String { dateString }
+    public let date: Date
+    public let dateString: String
+    public let displayDate: String
+    public let quotaDelta: Double
+    public let tokens: Int
+    public let runs: Int
+
+    public init(
+        date: Date,
+        dateString: String,
+        displayDate: String,
+        quotaDelta: Double,
+        tokens: Int,
+        runs: Int
+    ) {
+        self.date = date
+        self.dateString = dateString
+        self.displayDate = displayDate
+        self.quotaDelta = quotaDelta
+        self.tokens = tokens
+        self.runs = runs
+    }
+}
+
 public struct SkillUsage: Codable, Identifiable {
     public var id: String { name }
     public var name: String

--- a/apps/macos-overlay/Sources/Services/AccountSnapshotService.swift
+++ b/apps/macos-overlay/Sources/Services/AccountSnapshotService.swift
@@ -922,6 +922,14 @@ public enum AccountSnapshotService {
         return nil
     }
 
+    private static func isBooleanNumber(_ number: NSNumber) -> Bool {
+        #if canImport(Darwin)
+        return CFGetTypeID(number) == CFBooleanGetTypeID()
+        #else
+        return String(cString: number.objCType) == "c"
+        #endif
+    }
+
     private static func stringValue(_ value: Any?) -> String? {
         if let value = value as? String { return value }
         if let value = value as? NSNumber { return value.stringValue }
@@ -929,19 +937,22 @@ public enum AccountSnapshotService {
     }
 
     private static func intValue(_ value: Any?) -> Int? {
-        if let number = value as? NSNumber, !(value is Bool) { return number.intValue }
+        if let number = value as? NSNumber, !isBooleanNumber(number) { return number.intValue }
         if let value = value as? String { return Int(value.trimmingCharacters(in: .whitespacesAndNewlines)) }
         return nil
     }
 
     private static func doubleValue(_ value: Any?) -> Double? {
-        if let number = value as? NSNumber, !(value is Bool) { return number.doubleValue }
+        if let number = value as? NSNumber, !isBooleanNumber(number) { return number.doubleValue }
         if let value = value as? String { return Double(value.trimmingCharacters(in: .whitespacesAndNewlines)) }
         return nil
     }
 
     private static func boolValue(_ value: Any?) -> Bool? {
-        if let number = value as? NSNumber { return number.boolValue }
+        if let number = value as? NSNumber {
+            if isBooleanNumber(number) { return number.boolValue }
+            return nil
+        }
         if let value = value as? String {
             switch value.lowercased() {
             case "true", "1", "yes": return true

--- a/apps/macos-overlay/Sources/Services/TelemetryQueryEngine.swift
+++ b/apps/macos-overlay/Sources/Services/TelemetryQueryEngine.swift
@@ -677,4 +677,50 @@ public class TelemetryQueryEngine {
             projects: sortedProjects
         )
     }
+
+    // MARK: - Daily Quota Usage Aggregation
+    public func computeDailyQuotaUsage(days: Int = 7) -> [DailyQuotaUsage] {
+        let runs = loadAllRuns()
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        let cutoff = calendar.date(byAdding: .day, value: -(max(1, days) - 1), to: today) ?? today
+
+        var buckets: [Date: (quotaDelta: Double, tokens: Int, runs: Int)] = [:]
+        for run in runs {
+            guard let ms = run.finishedAtMs ?? run.startedAtMs else { continue }
+            let day = calendar.startOfDay(for: Date(timeIntervalSince1970: ms / 1000.0))
+            guard day >= cutoff && day <= today else { continue }
+            let existing = buckets[day] ?? (0.0, 0, 0)
+            let delta = run.primaryQuotaDelta ?? 0.0
+            let tokens = run.aggregatedUsage.totalTokens ?? 0
+            buckets[day] = (existing.quotaDelta + delta, existing.tokens + tokens, existing.runs + 1)
+        }
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+
+        let shortFormatter = DateFormatter()
+        shortFormatter.dateFormat = "MM-dd"
+
+        return (0..<days).compactMap { offset in
+            guard let day = calendar.date(byAdding: .day, value: -offset, to: today) else { return nil }
+            let value = buckets[day] ?? (0.0, 0, 0)
+            let displayDate: String
+            if calendar.isDateInToday(day) {
+                displayDate = L("Today", "今天")
+            } else if calendar.isDateInYesterday(day) {
+                displayDate = L("Yesterday", "昨天")
+            } else {
+                displayDate = shortFormatter.string(from: day)
+            }
+            return DailyQuotaUsage(
+                date: day,
+                dateString: dateFormatter.string(from: day),
+                displayDate: displayDate,
+                quotaDelta: value.quotaDelta,
+                tokens: value.tokens,
+                runs: value.runs
+            )
+        }
+    }
 }

--- a/apps/macos-overlay/Sources/Views/AccountView.swift
+++ b/apps/macos-overlay/Sources/Views/AccountView.swift
@@ -19,8 +19,6 @@ public struct AccountView: View {
     public var body: some View {
         let content = VStack(spacing: 9) {
             accountHeader
-            StrategyModeCard()
-            AutostartCard()
 
             if isLoading || !hasLoaded {
                 loadingState
@@ -34,6 +32,9 @@ public struct AccountView: View {
             } else {
                 emptyState
             }
+
+            StrategyModeCard()
+            AutostartCard()
         }
         .padding(.vertical, 2)
 
@@ -171,32 +172,161 @@ public struct AccountView: View {
         .background(cardBackground)
     }
 
+    enum QuotaTabMode: String, CaseIterable {
+        case window
+        case daily
+    }
+    @State private var quotaTabMode: QuotaTabMode = .window
+
     private func quotaCard(_ value: AccountSnapshot) -> some View {
         VStack(alignment: .leading, spacing: 7) {
             HStack {
-                Label(L("Current quota", "当前额度"), systemImage: "gauge.with.needle.fill")
-                    .font(.system(size: 9.5, weight: .bold, design: .rounded))
-                    .foregroundColor(.white.opacity(0.82))
+                Label(
+                    quotaTabMode == .window ? L("Current quota", "当前额度") : L("Daily quota usage", "每日额度消耗"),
+                    systemImage: quotaTabMode == .window ? "gauge.with.needle.fill" : "chart.bar.fill"
+                )
+                .font(.system(size: 9.5, weight: .bold, design: .rounded))
+                .foregroundColor(.white.opacity(0.82))
+
                 Spacer()
-                if value.quotaWindows.isEmpty {
-                    Text(L("Not reported", "未返回"))
-                        .font(.system(size: 8))
-                        .foregroundColor(.white.opacity(0.4))
+
+                HStack(spacing: 2) {
+                    quotaTabButton(mode: .window, title: L("Window", "额度窗口"))
+                    quotaTabButton(mode: .daily, title: L("Daily", "每日消耗"))
                 }
+                .padding(2)
+                .background(Capsule().fill(Color.white.opacity(0.06)))
             }
 
-            if value.quotaWindows.isEmpty {
-                Text(L("Codex did not return a rate-limit window for this account.", "Codex 当前没有返回该账户的额度窗口。"))
-                    .font(.system(size: 8.5))
-                    .foregroundColor(.white.opacity(0.45))
-            } else {
-                ForEach(value.orderedWindows) { window in
-                    quotaRow(window)
+            if quotaTabMode == .window {
+                if value.quotaWindows.isEmpty {
+                    Text(L("Codex did not return a rate-limit window for this account.", "Codex 当前没有返回该账户的额度窗口。"))
+                        .font(.system(size: 8.5))
+                        .foregroundColor(.white.opacity(0.45))
+                } else {
+                    ForEach(value.orderedWindows) { window in
+                        quotaRow(window)
+                    }
                 }
+            } else {
+                dailyQuotaView
             }
         }
         .padding(9)
         .background(cardBackground)
+    }
+
+    private func quotaTabButton(mode: QuotaTabMode, title: String) -> some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.15)) {
+                quotaTabMode = mode
+            }
+        } label: {
+            Text(title)
+                .font(.system(size: 7.8, weight: quotaTabMode == mode ? .bold : .medium, design: .rounded))
+                .foregroundColor(quotaTabMode == mode ? .white : .white.opacity(0.45))
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2.5)
+                .background(
+                    Capsule()
+                        .fill(quotaTabMode == mode ? Color.cyan.opacity(0.28) : Color.clear)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var dailyQuotaView: some View {
+        let dailyUsages = TelemetryQueryEngine.shared.computeDailyQuotaUsage(days: 7)
+        let maxDelta = max(1.0, dailyUsages.map(\.quotaDelta).max() ?? 1.0)
+        let totalRecentDelta = dailyUsages.map(\.quotaDelta).reduce(0, +)
+        let todayUsage = dailyUsages.first
+
+        return VStack(spacing: 6) {
+            HStack(spacing: 8) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(L("TODAY'S USAGE", "今日消耗"))
+                        .font(.system(size: 7.5, weight: .bold, design: .rounded))
+                        .foregroundColor(.white.opacity(0.4))
+                    HStack(alignment: .firstTextBaseline, spacing: 4) {
+                        Text(String(format: "+%.0f%%", todayUsage?.quotaDelta ?? 0))
+                            .font(.system(size: 13, weight: .heavy, design: .rounded))
+                            .foregroundColor((todayUsage?.quotaDelta ?? 0) > 0 ? .orange : .white.opacity(0.8))
+                        if let tokens = todayUsage?.tokens, tokens > 0 {
+                            Text("· \(TaskRun.formatTokenCount(tokens))")
+                                .font(.system(size: 7.8, weight: .semibold))
+                                .foregroundColor(.white.opacity(0.5))
+                        }
+                    }
+                }
+
+                Spacer()
+
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text(L("7-DAY TOTAL", "近 7 天消耗"))
+                        .font(.system(size: 7.5, weight: .bold, design: .rounded))
+                        .foregroundColor(.white.opacity(0.4))
+                    Text(String(format: "+%.0f%%", totalRecentDelta))
+                        .font(.system(size: 12, weight: .bold, design: .rounded))
+                        .foregroundColor(.cyan)
+                }
+            }
+            .padding(.horizontal, 4)
+            .padding(.bottom, 2)
+
+            VStack(spacing: 4) {
+                ForEach(dailyUsages) { item in
+                    dailyQuotaRow(item, maxDelta: maxDelta)
+                }
+            }
+        }
+    }
+
+    private func dailyQuotaRow(_ item: DailyQuotaUsage, maxDelta: Double) -> some View {
+        let fraction = max(0.0, min(1.0, item.quotaDelta / maxDelta))
+        let accent: Color = item.quotaDelta >= 10 ? .orange : (item.quotaDelta > 0 ? .cyan : .white.opacity(0.2))
+
+        return HStack(spacing: 6) {
+            Text(item.displayDate)
+                .font(.system(size: 8.2, weight: .semibold, design: .rounded))
+                .foregroundColor(.white.opacity(0.75))
+                .frame(width: 36, alignment: .leading)
+
+            GeometryReader { proxy in
+                ZStack(alignment: .leading) {
+                    Capsule().fill(Color.white.opacity(0.06))
+                    if item.quotaDelta > 0 {
+                        Capsule().fill(accent)
+                            .frame(width: max(4, proxy.size.width * CGFloat(fraction)))
+                    }
+                }
+            }
+            .frame(height: 4)
+
+            HStack(spacing: 3) {
+                if item.quotaDelta > 0 {
+                    Text(String(format: "+%.0f%%", item.quotaDelta))
+                        .font(.system(size: 8, weight: .bold, design: .rounded))
+                        .foregroundColor(accent)
+                } else {
+                    Text("0%")
+                        .font(.system(size: 7.8))
+                        .foregroundColor(.white.opacity(0.3))
+                }
+
+                if item.runs > 0 {
+                    Text("(\(item.runs)\(L(" runs", "次")))")
+                        .font(.system(size: 7.2))
+                        .foregroundColor(.white.opacity(0.32))
+                }
+            }
+            .frame(width: 58, alignment: .trailing)
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(Color.white.opacity(0.02))
+        )
     }
 
     private func quotaRow(_ window: AccountQuotaWindow) -> some View {
@@ -265,7 +395,7 @@ public struct AccountView: View {
 
     private func resetCard(_ value: AccountSnapshot) -> some View {
         HStack(spacing: 8) {
-            VStack(alignment: .leading, spacing: 3) {
+            VStack(alignment: .center, spacing: 3) {
                 Text(L("RESET CREDITS AVAILABLE", "可用重置次数"))
                     .font(.system(size: 8, weight: .bold, design: .rounded))
                     .foregroundColor(.white.opacity(0.42))

--- a/apps/macos-overlay/Sources/Views/SummaryView.swift
+++ b/apps/macos-overlay/Sources/Views/SummaryView.swift
@@ -135,45 +135,68 @@ public struct SummaryView: View {
     }
 
     private var tabBar: some View {
-        HStack(spacing: 3) {
+        HStack(spacing: 4) {
             ForEach(OverlayTab.allCases) { tab in
-                tabButton(tab.localizedTitle, tab.iconName, !showingAccount && state.activeTab == tab) {
+                TabButtonView(
+                    title: tab.localizedTitle,
+                    icon: tab.iconName,
+                    selected: !showingAccount && state.activeTab == tab
+                ) {
                     showingAccount = false
                     state.selectTab(tab)
                 }
             }
 
-            tabButton(L("Account", "账户"), "person.crop.circle.fill", showingAccount) {
+            TabButtonView(
+                title: L("Account", "账户"),
+                icon: "person.crop.circle.fill",
+                selected: showingAccount
+            ) {
                 showingAccount = true
             }
         }
-        .padding(4)
-        .background(Color.black.opacity(0.12))
+        .padding(.horizontal, 6)
+        .padding(.vertical, 4)
+        .background(Color.black.opacity(0.14))
     }
 
-    private func tabButton(_ title: String, _ icon: String, _ selected: Bool, action: @escaping () -> Void) -> some View {
+    private struct TabButtonView: View {
+    let title: String
+    let icon: String
+    let selected: Bool
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
         Button(action: action) {
-            HStack(spacing: 3) {
+            HStack(spacing: 4) {
                 Image(systemName: icon)
-                    .font(.system(size: 7.8, weight: .semibold))
+                    .font(.system(size: 8.8, weight: .semibold))
                 Text(title)
-                    .font(.system(size: 8.4, weight: selected ? .bold : .medium, design: .rounded))
+                    .font(.system(size: 9.2, weight: selected ? .bold : .medium, design: .rounded))
                     .lineLimit(1)
+                    .minimumScaleFactor(0.85)
             }
-            .foregroundColor(selected ? .white : .white.opacity(0.48))
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 4)
+            .foregroundColor(selected ? .white : (isHovered ? .white.opacity(0.85) : .white.opacity(0.52)))
+            .frame(maxWidth: .infinity, minHeight: 26)
+            .padding(.vertical, 5)
             .background(
                 RoundedRectangle(cornerRadius: 7)
-                    .fill(selected ? Color.cyan.opacity(0.22) : Color.clear)
+                    .fill(selected ? Color.cyan.opacity(0.22) : (isHovered ? Color.white.opacity(0.06) : Color.clear))
                     .overlay(
                         RoundedRectangle(cornerRadius: 7)
-                            .stroke(selected ? Color.cyan.opacity(0.32) : Color.clear, lineWidth: 0.6)
+                            .stroke(selected ? Color.cyan.opacity(0.32) : (isHovered ? Color.white.opacity(0.1) : Color.clear), lineWidth: 0.6)
                     )
             )
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .frame(maxWidth: .infinity)
+        .contentShape(Rectangle())
+        .onHover { isHovered = $0 }
     }
+}
 
     private var background: some View {
         RoundedRectangle(cornerRadius: 18, style: .continuous)
@@ -841,7 +864,7 @@ public struct QuotaWindowsView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack {
-                Label(L("Quota remaining", "额度剩余"), systemImage: "gauge.with.needle.fill")
+                Label(L("Quota remaining at task completion", "任务结束额度剩余"), systemImage: "gauge.with.needle.fill")
                     .font(.system(size: 8.8, weight: .bold, design: .rounded))
                     .foregroundColor(.white.opacity(0.7))
                 Spacer()

--- a/scripts/generate_showcase.swift
+++ b/scripts/generate_showcase.swift
@@ -4,32 +4,63 @@ import CoreGraphics
 
 @MainActor
 func renderViewToPNG<V: View>(view: V, targetWidth: CGFloat? = nil, targetHeight: CGFloat? = nil, scale: CGFloat = 2.0, outputPath: String) {
-    let configuredView: AnyView
+    let darkView = view.preferredColorScheme(.dark)
+    
+    let sizedView: AnyView
     if let w = targetWidth, let h = targetHeight {
-        configuredView = AnyView(view.frame(width: w, height: h))
+        sizedView = AnyView(darkView.frame(width: w, height: h))
     } else if let w = targetWidth {
-        configuredView = AnyView(view.frame(width: w))
+        sizedView = AnyView(darkView.frame(width: w))
     } else if let h = targetHeight {
-        configuredView = AnyView(view.frame(height: h))
+        sizedView = AnyView(darkView.frame(height: h))
     } else {
-        configuredView = AnyView(view)
+        sizedView = AnyView(darkView)
     }
     
-    let renderer = ImageRenderer(content: configuredView)
-    renderer.scale = scale
+    let hostingView = NSHostingView(rootView: sizedView)
+    let fitting = hostingView.fittingSize
+    let width = targetWidth ?? max(fitting.width, 10)
+    let height = targetHeight ?? max(fitting.height, 10)
+    let contentRect = NSRect(x: 0, y: 0, width: width, height: height)
+    hostingView.frame = contentRect
     
+    let window = NSWindow(
+        contentRect: contentRect,
+        styleMask: [.borderless],
+        backing: .buffered,
+        defer: false
+    )
+    window.contentView = hostingView
+    window.appearance = NSAppearance(named: .darkAqua)
+    window.backgroundColor = .clear
+    window.isOpaque = false
+    window.layoutIfNeeded()
+    
+    // Allow AppKit/SwiftUI to attach controls (Menu, TextField, ProgressView)
+    // and resolve background fetch tasks cleanly
+    RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.35))
+    
+    if let rep = hostingView.bitmapImageRepForCachingDisplay(in: contentRect) {
+        hostingView.cacheDisplay(in: contentRect, to: rep)
+        if let pngData = rep.representation(using: .png, properties: [:]) {
+            let url = URL(fileURLWithPath: outputPath)
+            try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try? pngData.write(to: url)
+            print("✅ Rendered [\(rep.pixelsWide)x\(rep.pixelsHigh)] -> \(outputPath)")
+            return
+        }
+    }
+    
+    let renderer = ImageRenderer(content: sizedView)
+    renderer.scale = scale
     if let cgImage = renderer.cgImage {
         let bitmapRep = NSBitmapImageRep(cgImage: cgImage)
         if let pngData = bitmapRep.representation(using: .png, properties: [:]) {
             let url = URL(fileURLWithPath: outputPath)
             try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
             try? pngData.write(to: url)
-            print("✅ Rendered [\(cgImage.width)x\(cgImage.height)] -> \(outputPath)")
-        } else {
-            print("❌ Failed to encode PNG for \(outputPath)")
+            print("✅ Rendered fallback [\(cgImage.width)x\(cgImage.height)] -> \(outputPath)")
         }
-    } else {
-        print("❌ ImageRenderer failed for \(outputPath)")
     }
 }
 
@@ -482,6 +513,7 @@ func runGenerator() {
     renderViewToPNG(
         view: SummaryView(state: stateInspector, isFullHeight: false),
         targetWidth: 384,
+        targetHeight: 490,
         scale: 2.0,
         outputPath: "docs/assets/screenshots/inspector_window.png"
     )
@@ -489,6 +521,7 @@ func runGenerator() {
     renderViewToPNG(
         view: SummaryView(state: stateHistoryFull, isFullHeight: false),
         targetWidth: 384,
+        targetHeight: 490,
         scale: 2.0,
         outputPath: "docs/assets/screenshots/history_window.png"
     )
@@ -496,6 +529,7 @@ func runGenerator() {
     renderViewToPNG(
         view: SummaryView(state: stateAnalytics, isFullHeight: false),
         targetWidth: 384,
+        targetHeight: 490,
         scale: 2.0,
         outputPath: "docs/assets/screenshots/analytics_window.png"
     )

--- a/tests/telemetry-core.sh
+++ b/tests/telemetry-core.sh
@@ -6,6 +6,7 @@ trap 'rm -rf "$TMP"' EXIT
 export CODEX_HOME="$TMP/.codex"
 export FAKE_COUNTER="$TMP/counter"
 export CODEX_FLOW_TELEMETRY_NOTIFICATIONS=false
+export CODEX_FLOW_LANGUAGE="${CODEX_FLOW_LANGUAGE:-en}"
 
 # A current Codex response may omit the legacy single-bucket field entirely;
 # the telemetry retry wrapper must treat the canonical codex bucket as usable.

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -315,7 +315,7 @@ class UpdaterTest(unittest.TestCase):
             run.return_value.returncode = 0
             result = updater._legacy_git_update()
         self.assertEqual(result, 0)
-        commands = [call.args[0] for call in run.call_args_list]
+        commands = [c[0][0] for c in run.call_args_list]
         self.assertFalse(any("pull" in command for command in commands))
         self.assertTrue(any(("install.ps1" in " ".join(command)) or ("install.sh" in " ".join(command)) for command in commands))
 


### PR DESCRIPTION
## Scope
This PR now combines the two concurrent emergency hotfix streams into one reviewed branch.

### Overlay state-machine fixes
- Preserve the right-edge-only collapsed destination to eliminate left/right ambiguity.
- Suppress synthetic AppKit hover events caused by programmatic NSPanel frame changes until the pointer genuinely moves.
- Complete drag interaction state in magnetic-snap completion before scheduling idle tuck; remove the detached 0.6s state mutation that could lose tuck or clear a newer interaction.
- Use stable global pointer/original-window coordinates during drag so frame movement does not feed back into drag deltas.
- Clear stale `isDocked` state on collapse.
- Keep the requested idle tuck interval at **30 seconds** (without stacking two 30-second delays at startup).

### Concurrent hotfix merged
Also includes the other hotfix branch's telemetry/account/UI/test changes, including daily quota usage aggregation, account number/bool decoding hardening, and related UI/test updates.

### Conflict resolution
The concurrent branch experimented with dual-sided collapsed snapping. That part is intentionally not retained because the reported production failure specifically requires a deterministic right-side destination. The 30-second tuck timing from that branch is retained.

## Validation
Fresh CI is running on the merged head across macOS overlay, general CI, and OTA CI.