### PR TITLE
fix(showcase): restore privacy-safe promo rendering and add Account tab

### DIFF
--- a/apps/macos-overlay/Sources/Views/HoverRevealText.swift
+++ b/apps/macos-overlay/Sources/Views/HoverRevealText.swift
@@ -4,11 +4,10 @@ import Foundation
 /// A compact text label that keeps the normal layout truncated, but reveals the
 /// complete value in a small native popover after a short hover dwell.
 ///
-/// Privacy mode deliberately never draws the source string. This matters for
-/// screenshots: AppKit bitmap snapshots can bypass Core Animation blur effects,
-/// so blurring the real text is not a sufficient privacy boundary. Instead we
-/// render a shape-preserving placeholder and blur that placeholder for the same
-/// visual treatment without ever exposing the sensitive source pixels.
+/// Privacy mode uses SwiftUI's semantic redaction before applying blur. This
+/// preserves the original text footprint and the familiar blurred-mask look,
+/// while ensuring bitmap screenshots still contain a redacted placeholder even
+/// if an AppKit capture path drops the visual blur effect.
 public struct HoverRevealText: View {
     public let text: String
     public let font: Font
@@ -45,13 +44,15 @@ public struct HoverRevealText: View {
     public var body: some View {
         Group {
             if privacyBlur {
-                Text(Self.privacyPlaceholder(for: text))
+                Text(text.isEmpty ? " " : text)
                     .font(font)
-                    .foregroundColor(foregroundColor.opacity(0.62))
+                    .foregroundColor(foregroundColor.opacity(0.78))
                     .lineLimit(lineLimit)
                     .truncationMode(truncationMode)
                     .multilineTextAlignment(alignment)
-                    .blur(radius: 3.2)
+                    .redacted(reason: .placeholder)
+                    .compositingGroup()
+                    .blur(radius: 4.5)
                     .accessibilityLabel(Text("Private content"))
             } else {
                 Text(text)
@@ -86,16 +87,6 @@ public struct HoverRevealText: View {
             .preferredColorScheme(.dark)
             .onHover(perform: handlePopoverHover)
         }
-    }
-
-    /// Keeps roughly the same line count and text footprint while ensuring the
-    /// original source string is never part of the rendered privacy-mode view.
-    private static func privacyPlaceholder(for source: String) -> String {
-        let lines = source.split(separator: "\n", omittingEmptySubsequences: false)
-        return lines.map { line in
-            let visibleLength = min(max(line.count, 8), 42)
-            return String(repeating: "●", count: visibleLength)
-        }.joined(separator: "\n")
     }
 
     /// Native Foundation Markdown parsing keeps headings, lists, fenced code,

--- a/apps/macos-overlay/Sources/Views/HoverRevealText.swift
+++ b/apps/macos-overlay/Sources/Views/HoverRevealText.swift
@@ -4,8 +4,11 @@ import Foundation
 /// A compact text label that keeps the normal layout truncated, but reveals the
 /// complete value in a small native popover after a short hover dwell.
 ///
-/// Use this anywhere a user-facing string is intentionally line-limited. The
-/// component does not reveal content while privacy mode is active.
+/// Privacy mode deliberately never draws the source string. This matters for
+/// screenshots: AppKit bitmap snapshots can bypass Core Animation blur effects,
+/// so blurring the real text is not a sufficient privacy boundary. Instead we
+/// render a shape-preserving placeholder and blur that placeholder for the same
+/// visual treatment without ever exposing the sensitive source pixels.
 public struct HoverRevealText: View {
     public let text: String
     public let font: Font
@@ -40,37 +43,59 @@ public struct HoverRevealText: View {
     }
 
     public var body: some View {
-        Text(text)
-            .font(font)
-            .foregroundColor(foregroundColor)
-            .lineLimit(lineLimit)
-            .truncationMode(truncationMode)
-            .multilineTextAlignment(alignment)
-            .blur(radius: privacyBlur ? 4.5 : 0)
-            .contentShape(Rectangle())
-            .onHover(perform: handleSourceHover)
-            .popover(isPresented: $isPresented, arrowEdge: .bottom) {
-                ZStack {
-                    Color(red: 0.055, green: 0.062, blue: 0.085)
-                        .ignoresSafeArea()
-
-                    ScrollView(.vertical, showsIndicators: true) {
-                        expandedText
-                            .font(font)
-                            .foregroundColor(.white.opacity(0.92))
-                            .multilineTextAlignment(.leading)
-                            .textSelection(.enabled)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(10)
-                    }
-                }
-                .frame(width: min(max(popoverWidth, 220), 520))
-                .frame(maxHeight: 260)
-                .background(Color(red: 0.055, green: 0.062, blue: 0.085))
-                .preferredColorScheme(.dark)
-                .onHover(perform: handlePopoverHover)
+        Group {
+            if privacyBlur {
+                Text(Self.privacyPlaceholder(for: text))
+                    .font(font)
+                    .foregroundColor(foregroundColor.opacity(0.62))
+                    .lineLimit(lineLimit)
+                    .truncationMode(truncationMode)
+                    .multilineTextAlignment(alignment)
+                    .blur(radius: 3.2)
+                    .accessibilityLabel(Text("Private content"))
+            } else {
+                Text(text)
+                    .font(font)
+                    .foregroundColor(foregroundColor)
+                    .lineLimit(lineLimit)
+                    .truncationMode(truncationMode)
+                    .multilineTextAlignment(alignment)
             }
+        }
+        .contentShape(Rectangle())
+        .onHover(perform: handleSourceHover)
+        .popover(isPresented: $isPresented, arrowEdge: .bottom) {
+            ZStack {
+                Color(red: 0.055, green: 0.062, blue: 0.085)
+                    .ignoresSafeArea()
+
+                ScrollView(.vertical, showsIndicators: true) {
+                    expandedText
+                        .font(font)
+                        .foregroundColor(.white.opacity(0.92))
+                        .multilineTextAlignment(.leading)
+                        .textSelection(.enabled)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(10)
+                }
+            }
+            .frame(width: min(max(popoverWidth, 220), 520))
+            .frame(maxHeight: 260)
+            .background(Color(red: 0.055, green: 0.062, blue: 0.085))
+            .preferredColorScheme(.dark)
+            .onHover(perform: handlePopoverHover)
+        }
+    }
+
+    /// Keeps roughly the same line count and text footprint while ensuring the
+    /// original source string is never part of the rendered privacy-mode view.
+    private static func privacyPlaceholder(for source: String) -> String {
+        let lines = source.split(separator: "\n", omittingEmptySubsequences: false)
+        return lines.map { line in
+            let visibleLength = min(max(line.count, 8), 42)
+            return String(repeating: "●", count: visibleLength)
+        }.joined(separator: "\n")
     }
 
     /// Native Foundation Markdown parsing keeps headings, lists, fenced code,

--- a/apps/macos-overlay/Sources/Views/HoverRevealText.swift
+++ b/apps/macos-overlay/Sources/Views/HoverRevealText.swift
@@ -4,10 +4,10 @@ import Foundation
 /// A compact text label that keeps the normal layout truncated, but reveals the
 /// complete value in a small native popover after a short hover dwell.
 ///
-/// Privacy mode uses SwiftUI's semantic redaction before applying blur. This
-/// preserves the original text footprint and the familiar blurred-mask look,
-/// while ensuring bitmap screenshots still contain a redacted placeholder even
-/// if an AppKit capture path drops the visual blur effect.
+/// Privacy mode intentionally keeps the original text layout and applies the
+/// same 4.5pt blur used by the earlier showcase pipeline. A drawing group bakes
+/// the blur into an offscreen texture so AppKit-backed screenshots preserve the
+/// visual mask instead of degrading it into placeholder bars.
 public struct HoverRevealText: View {
     public let text: String
     public let font: Font
@@ -44,15 +44,14 @@ public struct HoverRevealText: View {
     public var body: some View {
         Group {
             if privacyBlur {
-                Text(text.isEmpty ? " " : text)
+                Text(text)
                     .font(font)
-                    .foregroundColor(foregroundColor.opacity(0.78))
+                    .foregroundColor(foregroundColor)
                     .lineLimit(lineLimit)
                     .truncationMode(truncationMode)
                     .multilineTextAlignment(alignment)
-                    .redacted(reason: .placeholder)
-                    .compositingGroup()
                     .blur(radius: 4.5)
+                    .drawingGroup(opaque: false, colorMode: .linear)
                     .accessibilityLabel(Text("Private content"))
             } else {
                 Text(text)

--- a/scripts/generate_showcase.swift
+++ b/scripts/generate_showcase.swift
@@ -75,7 +75,7 @@ private enum ShowcaseMockData {
                 AccountQuotaWindow(
                     id: "showcase-weekly",
                     durationMinutes: 10080,
-                    usedPercent: 57,
+                    usedPercent: 52,
                     resetsAt: now.addingTimeInterval(4 * 86_400 + 6 * 3600)
                 )
             ],
@@ -101,6 +101,52 @@ private enum ShowcaseMockData {
             StrategyProfileInfo(name: "speed", description: "Minimize wall-clock time with safe parallelism.")
         ]
     )
+}
+
+/// Keep promotional screenshots visually stable even when the user's live quota
+/// happens to be under pressure. The product keeps its real warning thresholds;
+/// only showcase copies are normalized into the non-warning cyan range.
+private func showcaseQuotaWindow(_ source: QuotaWindow, index: Int) -> QuotaWindow {
+    var copy = source
+    copy.usedPercent = index == 0 ? 34 : 48
+    copy.deltaPercentagePoints = 0
+    return copy
+}
+
+private func showcaseRun(_ source: TaskRun) -> TaskRun {
+    var copy = source
+    if let value = copy.quotaBefore {
+        copy.quotaBefore = value.enumerated().map { showcaseQuotaWindow($0.element, index: $0.offset) }
+    }
+    if let value = copy.quotaAfter {
+        copy.quotaAfter = value.enumerated().map { showcaseQuotaWindow($0.element, index: $0.offset) }
+    }
+    if let value = copy.quotaChangeDuringRun {
+        copy.quotaChangeDuringRun = value.enumerated().map { showcaseQuotaWindow($0.element, index: $0.offset) }
+    }
+    return copy
+}
+
+private func showcaseChat(_ source: ChatSession) -> ChatSession {
+    var copy = source
+    copy.runs = source.runs.map(showcaseRun)
+    return copy
+}
+
+/// ImageRenderer does not provide the same viewport lifecycle as a real AppKit
+/// ScrollView. For promotional window captures, lay out the real full-height
+/// surface first and crop its top 384×490pt viewport. This preserves real App
+/// dimensions without producing an empty scroll-container shell.
+private func showcaseWindow<V: View>(_ view: V) -> some View {
+    view
+        .frame(width: ShowcaseMetrics.panelWidth)
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(
+            width: ShowcaseMetrics.panelWidth,
+            height: ShowcaseMetrics.panelHeight,
+            alignment: .top
+        )
+        .clipped()
 }
 
 // MARK: - Account Showcase Chrome
@@ -788,10 +834,11 @@ struct BannerPromoView: View {
                 }
                 .frame(width: 560)
 
-                SummaryView(state: stateInspector, isFullHeight: false)
-                    .frame(width: ShowcaseMetrics.panelWidth, height: ShowcaseMetrics.panelHeight)
-                    .scaleEffect(0.92)
-                    .shadow(color: Color.black.opacity(0.5), radius: 30, x: 0, y: 15)
+                showcaseWindow(
+                    SummaryView(state: stateInspector, isFullHeight: true)
+                )
+                .scaleEffect(0.92)
+                .shadow(color: Color.black.opacity(0.5), radius: 30, x: 0, y: 15)
             }
             .padding(.horizontal, 50)
             .padding(.vertical, 36)
@@ -880,11 +927,12 @@ struct DesktopScenePromoView: View {
                 .offset(x: -180, y: 15)
                 .shadow(color: Color.black.opacity(0.5), radius: 30, x: -10, y: 15)
 
-            SummaryView(state: stateInspector, isFullHeight: false)
-                .frame(width: ShowcaseMetrics.panelWidth, height: ShowcaseMetrics.panelHeight)
-                .scaleEffect(0.72)
-                .offset(x: 320, y: 15)
-                .shadow(color: Color.black.opacity(0.6), radius: 35, x: 5, y: 15)
+            showcaseWindow(
+                SummaryView(state: stateInspector, isFullHeight: true)
+            )
+            .scaleEffect(0.72)
+            .offset(x: 320, y: 15)
+            .shadow(color: Color.black.opacity(0.6), radius: 35, x: 5, y: 15)
 
             BubbleView(state: stateBubble)
                 .scaleEffect(0.9)
@@ -904,19 +952,17 @@ func runGenerator() {
     let engine = TelemetryQueryEngine.shared
     let allRuns = engine.loadAllRuns()
 
-    var latestRun = engine.loadLatestRun() ?? allRuns.first
-    if var run = latestRun {
-        engine.enrichRunIfNeeded(&run)
-        latestRun = run
-    }
+    var latestRun = engine.loadLatestRun() ?? allRuns.first ?? TaskRun.previewSample
+    engine.enrichRunIfNeeded(&latestRun)
+    latestRun = showcaseRun(latestRun)
 
-    let historyChats = engine.fetchChatHistory(limit: 20)
-    let historyRuns = engine.fetchHistory(limit: 50)
+    let historyChats = engine.fetchChatHistory(limit: 20).map(showcaseChat)
+    let historyRuns = engine.fetchHistory(limit: 50).map(showcaseRun)
     let stats = engine.computeStats(days: 30, project: nil)
 
     let stateInspector = OverlayState()
     stateInspector.latestRun = latestRun
-    stateInspector.inspectedRun = latestRun
+    stateInspector.inspectedRun = nil
     stateInspector.activeTab = .inspector
     stateInspector.isExpanded = true
     stateInspector.isPrivacyMode = true
@@ -997,7 +1043,9 @@ func runGenerator() {
     )
 
     renderViewToPNG(
-        view: SummaryView(state: stateInspector, isFullHeight: false),
+        view: showcaseWindow(
+            SummaryView(state: stateInspector, isFullHeight: true)
+        ),
         targetWidth: ShowcaseMetrics.panelWidth,
         targetHeight: ShowcaseMetrics.panelHeight,
         scale: 2.0,
@@ -1005,7 +1053,9 @@ func runGenerator() {
     )
 
     renderViewToPNG(
-        view: SummaryView(state: stateHistoryFull, isFullHeight: false),
+        view: showcaseWindow(
+            SummaryView(state: stateHistoryFull, isFullHeight: true)
+        ),
         targetWidth: ShowcaseMetrics.panelWidth,
         targetHeight: ShowcaseMetrics.panelHeight,
         scale: 2.0,
@@ -1013,7 +1063,9 @@ func runGenerator() {
     )
 
     renderViewToPNG(
-        view: SummaryView(state: stateAnalytics, isFullHeight: false),
+        view: showcaseWindow(
+            SummaryView(state: stateAnalytics, isFullHeight: true)
+        ),
         targetWidth: ShowcaseMetrics.panelWidth,
         targetHeight: ShowcaseMetrics.panelHeight,
         scale: 2.0,
@@ -1030,7 +1082,9 @@ func runGenerator() {
     )
 
     renderViewToPNG(
-        view: AccountPromoCard(state: stateAccount, isFullHeight: false),
+        view: showcaseWindow(
+            AccountPromoCard(state: stateAccount, isFullHeight: true)
+        ),
         targetWidth: ShowcaseMetrics.panelWidth,
         targetHeight: ShowcaseMetrics.panelHeight,
         scale: 2.0,

--- a/scripts/generate_showcase.swift
+++ b/scripts/generate_showcase.swift
@@ -14,6 +14,8 @@ func renderViewToPNG<V: View>(
     targetWidth: CGFloat? = nil,
     targetHeight: CGFloat? = nil,
     scale: CGFloat = 2.0,
+    requiresLiveHosting: Bool = false,
+    settleTime: TimeInterval = 0.18,
     outputPath: String
 ) {
     let darkView = view.preferredColorScheme(.dark)
@@ -29,19 +31,93 @@ func renderViewToPNG<V: View>(
         sizedView = AnyView(darkView)
     }
 
-    // Keep the original deterministic SwiftUI renderer for every showcase image.
-    // Account and strategy data are mocked below, so no AppKit lifecycle or async
-    // settling is required and SwiftUI privacy blur remains intact.
-    let renderer = ImageRenderer(content: sizedView)
-    renderer.scale = scale
+    // Pure SwiftUI rendering stays the fastest path for simple assets. Views that
+    // contain ScrollView / GeometryReader use live AppKit hosting below so they
+    // receive the same viewport/layout lifecycle as the real overlay window.
+    if !requiresLiveHosting {
+        let renderer = ImageRenderer(content: sizedView)
+        renderer.scale = scale
 
-    guard let cgImage = renderer.cgImage else {
-        print("❌ ImageRenderer failed for \(outputPath)")
+        guard let cgImage = renderer.cgImage else {
+            print("❌ ImageRenderer failed for \(outputPath)")
+            return
+        }
+
+        let bitmapRep = NSBitmapImageRep(cgImage: cgImage)
+        guard let pngData = bitmapRep.representation(using: .png, properties: [:]) else {
+            print("❌ Failed to encode PNG for \(outputPath)")
+            return
+        }
+
+        let url = URL(fileURLWithPath: outputPath)
+        try? FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try? pngData.write(to: url)
+        print("✅ Rendered [\(cgImage.width)x\(cgImage.height)] -> \(outputPath)")
         return
     }
 
-    let bitmapRep = NSBitmapImageRep(cgImage: cgImage)
-    guard let pngData = bitmapRep.representation(using: .png, properties: [:]) else {
+    let hostingView = NSHostingView(rootView: sizedView)
+    let initialFitting = hostingView.fittingSize
+    var width = targetWidth ?? max(initialFitting.width, 10)
+    var height = targetHeight ?? max(initialFitting.height, 10)
+    var contentRect = NSRect(x: 0, y: 0, width: width, height: height)
+    hostingView.frame = contentRect
+
+    let window = NSWindow(
+        contentRect: contentRect,
+        styleMask: [.borderless],
+        backing: .buffered,
+        defer: false
+    )
+    window.contentView = hostingView
+    window.appearance = NSAppearance(named: .darkAqua)
+    window.backgroundColor = .clear
+    window.isOpaque = false
+    window.layoutIfNeeded()
+    hostingView.layoutSubtreeIfNeeded()
+
+    RunLoop.current.run(until: Date(timeIntervalSinceNow: settleTime))
+    window.layoutIfNeeded()
+    hostingView.layoutSubtreeIfNeeded()
+
+    // Dynamic full-height surfaces need one post-layout fitting pass. Fixed
+    // 384×490 window captures keep the exact production viewport dimensions.
+    if targetWidth == nil || targetHeight == nil {
+        let settledFitting = hostingView.fittingSize
+        if targetWidth == nil { width = max(settledFitting.width, 10) }
+        if targetHeight == nil { height = max(settledFitting.height, 10) }
+        contentRect = NSRect(x: 0, y: 0, width: width, height: height)
+        hostingView.frame = contentRect
+        window.setContentSize(contentRect.size)
+        window.layoutIfNeeded()
+        hostingView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.08))
+    }
+
+    let pixelsWide = max(1, Int((width * scale).rounded()))
+    let pixelsHigh = max(1, Int((height * scale).rounded()))
+    guard let rep = NSBitmapImageRep(
+        bitmapDataPlanes: nil,
+        pixelsWide: pixelsWide,
+        pixelsHigh: pixelsHigh,
+        bitsPerSample: 8,
+        samplesPerPixel: 4,
+        hasAlpha: true,
+        isPlanar: false,
+        colorSpaceName: .deviceRGB,
+        bytesPerRow: 0,
+        bitsPerPixel: 0
+    ) else {
+        print("❌ Failed to allocate bitmap for \(outputPath)")
+        return
+    }
+    rep.size = NSSize(width: width, height: height)
+    hostingView.cacheDisplay(in: contentRect, to: rep)
+
+    guard let pngData = rep.representation(using: .png, properties: [:]) else {
         print("❌ Failed to encode PNG for \(outputPath)")
         return
     }
@@ -52,7 +128,7 @@ func renderViewToPNG<V: View>(
         withIntermediateDirectories: true
     )
     try? pngData.write(to: url)
-    print("✅ Rendered [\(cgImage.width)x\(cgImage.height)] -> \(outputPath)")
+    print("✅ Rendered live [\(rep.pixelsWide)x\(rep.pixelsHigh)] -> \(outputPath)")
 }
 
 // MARK: - Deterministic Showcase Data
@@ -101,52 +177,6 @@ private enum ShowcaseMockData {
             StrategyProfileInfo(name: "speed", description: "Minimize wall-clock time with safe parallelism.")
         ]
     )
-}
-
-/// Keep promotional screenshots visually stable even when the user's live quota
-/// happens to be under pressure. The product keeps its real warning thresholds;
-/// only showcase copies are normalized into the non-warning cyan range.
-private func showcaseQuotaWindow(_ source: QuotaWindow, index: Int) -> QuotaWindow {
-    var copy = source
-    copy.usedPercent = index == 0 ? 34 : 48
-    copy.deltaPercentagePoints = 0
-    return copy
-}
-
-private func showcaseRun(_ source: TaskRun) -> TaskRun {
-    var copy = source
-    if let value = copy.quotaBefore {
-        copy.quotaBefore = value.enumerated().map { showcaseQuotaWindow($0.element, index: $0.offset) }
-    }
-    if let value = copy.quotaAfter {
-        copy.quotaAfter = value.enumerated().map { showcaseQuotaWindow($0.element, index: $0.offset) }
-    }
-    if let value = copy.quotaChangeDuringRun {
-        copy.quotaChangeDuringRun = value.enumerated().map { showcaseQuotaWindow($0.element, index: $0.offset) }
-    }
-    return copy
-}
-
-private func showcaseChat(_ source: ChatSession) -> ChatSession {
-    var copy = source
-    copy.runs = source.runs.map(showcaseRun)
-    return copy
-}
-
-/// ImageRenderer does not provide the same viewport lifecycle as a real AppKit
-/// ScrollView. For promotional window captures, lay out the real full-height
-/// surface first and crop its top 384×490pt viewport. This preserves real App
-/// dimensions without producing an empty scroll-container shell.
-private func showcaseWindow<V: View>(_ view: V) -> some View {
-    view
-        .frame(width: ShowcaseMetrics.panelWidth)
-        .fixedSize(horizontal: false, vertical: true)
-        .frame(
-            width: ShowcaseMetrics.panelWidth,
-            height: ShowcaseMetrics.panelHeight,
-            alignment: .top
-        )
-        .clipped()
 }
 
 // MARK: - Account Showcase Chrome
@@ -834,11 +864,9 @@ struct BannerPromoView: View {
                 }
                 .frame(width: 560)
 
-                showcaseWindow(
-                    SummaryView(state: stateInspector, isFullHeight: true)
-                )
-                .scaleEffect(0.92)
-                .shadow(color: Color.black.opacity(0.5), radius: 30, x: 0, y: 15)
+                SummaryView(state: stateInspector, isFullHeight: false)
+                    .frame(width: ShowcaseMetrics.panelWidth, height: ShowcaseMetrics.panelHeight)
+                    .shadow(color: Color.black.opacity(0.5), radius: 30, x: 0, y: 15)
             }
             .padding(.horizontal, 50)
             .padding(.vertical, 36)
@@ -927,12 +955,11 @@ struct DesktopScenePromoView: View {
                 .offset(x: -180, y: 15)
                 .shadow(color: Color.black.opacity(0.5), radius: 30, x: -10, y: 15)
 
-            showcaseWindow(
-                SummaryView(state: stateInspector, isFullHeight: true)
-            )
-            .scaleEffect(0.72)
-            .offset(x: 320, y: 15)
-            .shadow(color: Color.black.opacity(0.6), radius: 35, x: 5, y: 15)
+            SummaryView(state: stateInspector, isFullHeight: false)
+                .frame(width: ShowcaseMetrics.panelWidth, height: ShowcaseMetrics.panelHeight)
+                .scaleEffect(0.72)
+                .offset(x: 320, y: 15)
+                .shadow(color: Color.black.opacity(0.6), radius: 35, x: 5, y: 15)
 
             BubbleView(state: stateBubble)
                 .scaleEffect(0.9)
@@ -954,10 +981,9 @@ func runGenerator() {
 
     var latestRun = engine.loadLatestRun() ?? allRuns.first ?? TaskRun.previewSample
     engine.enrichRunIfNeeded(&latestRun)
-    latestRun = showcaseRun(latestRun)
 
-    let historyChats = engine.fetchChatHistory(limit: 20).map(showcaseChat)
-    let historyRuns = engine.fetchHistory(limit: 50).map(showcaseRun)
+    let historyChats = engine.fetchChatHistory(limit: 20)
+    let historyRuns = engine.fetchHistory(limit: 50)
     let stats = engine.computeStats(days: 30, project: nil)
 
     let stateInspector = OverlayState()
@@ -1019,6 +1045,7 @@ func runGenerator() {
         view: SummaryView(state: stateInspector, isFullHeight: true),
         targetWidth: ShowcaseMetrics.panelWidth,
         scale: 2.0,
+        requiresLiveHosting: true,
         outputPath: "docs/assets/screenshots/inspector_full.png"
     )
 
@@ -1026,6 +1053,7 @@ func runGenerator() {
         view: SummaryView(state: stateHistoryFull, isFullHeight: true),
         targetWidth: ShowcaseMetrics.panelWidth,
         scale: 2.0,
+        requiresLiveHosting: true,
         outputPath: "docs/assets/screenshots/history_full.png"
     )
 
@@ -1033,6 +1061,7 @@ func runGenerator() {
         view: SummaryView(state: stateAnalytics, isFullHeight: true),
         targetWidth: ShowcaseMetrics.panelWidth,
         scale: 2.0,
+        requiresLiveHosting: true,
         outputPath: "docs/assets/screenshots/analytics_full.png"
     )
 
@@ -1043,51 +1072,48 @@ func runGenerator() {
     )
 
     renderViewToPNG(
-        view: showcaseWindow(
-            SummaryView(state: stateInspector, isFullHeight: true)
-        ),
+        view: SummaryView(state: stateInspector, isFullHeight: false),
         targetWidth: ShowcaseMetrics.panelWidth,
         targetHeight: ShowcaseMetrics.panelHeight,
         scale: 2.0,
+        requiresLiveHosting: true,
         outputPath: "docs/assets/screenshots/inspector_window.png"
     )
 
     renderViewToPNG(
-        view: showcaseWindow(
-            SummaryView(state: stateHistoryFull, isFullHeight: true)
-        ),
+        view: SummaryView(state: stateHistoryFull, isFullHeight: false),
         targetWidth: ShowcaseMetrics.panelWidth,
         targetHeight: ShowcaseMetrics.panelHeight,
         scale: 2.0,
+        requiresLiveHosting: true,
         outputPath: "docs/assets/screenshots/history_window.png"
     )
 
     renderViewToPNG(
-        view: showcaseWindow(
-            SummaryView(state: stateAnalytics, isFullHeight: true)
-        ),
+        view: SummaryView(state: stateAnalytics, isFullHeight: false),
         targetWidth: ShowcaseMetrics.panelWidth,
         targetHeight: ShowcaseMetrics.panelHeight,
         scale: 2.0,
+        requiresLiveHosting: true,
         outputPath: "docs/assets/screenshots/analytics_window.png"
     )
 
-    // Account is deterministic mock data in the showcase pipeline, so it renders
-    // immediately through ImageRenderer instead of waiting on app-server/CLI I/O.
+    // Account remains deterministic mock data in the showcase pipeline. Live
+    // hosting is used only for layout fidelity, never to trigger real account I/O.
     renderViewToPNG(
         view: AccountPromoCard(state: stateAccount, isFullHeight: true),
         targetWidth: ShowcaseMetrics.panelWidth,
         scale: 2.0,
+        requiresLiveHosting: true,
         outputPath: "docs/assets/screenshots/account_full.png"
     )
 
     renderViewToPNG(
-        view: showcaseWindow(
-            AccountPromoCard(state: stateAccount, isFullHeight: true)
-        ),
+        view: AccountPromoCard(state: stateAccount, isFullHeight: false),
         targetWidth: ShowcaseMetrics.panelWidth,
         targetHeight: ShowcaseMetrics.panelHeight,
         scale: 2.0,
+        requiresLiveHosting: true,
         outputPath: "docs/assets/screenshots/account_window.png"
     )
 
@@ -1100,6 +1126,7 @@ func runGenerator() {
             stateBubble: stateBubble
         ),
         scale: 2.0,
+        requiresLiveHosting: true,
         outputPath: "docs/assets/promo/flowpilot_promo_poster.png"
     )
 
@@ -1109,6 +1136,7 @@ func runGenerator() {
             stateBubble: stateBubble
         ),
         scale: 2.0,
+        requiresLiveHosting: true,
         outputPath: "docs/assets/promo/flowpilot_promo_banner.png"
     )
 
@@ -1118,6 +1146,7 @@ func runGenerator() {
             stateBubble: stateBubble
         ),
         scale: 2.0,
+        requiresLiveHosting: true,
         outputPath: "docs/assets/promo/flowpilot_promo_desktop_scene.png"
     )
 

--- a/scripts/generate_showcase.swift
+++ b/scripts/generate_showcase.swift
@@ -3,9 +3,16 @@ import SwiftUI
 import CoreGraphics
 
 @MainActor
-func renderViewToPNG<V: View>(view: V, targetWidth: CGFloat? = nil, targetHeight: CGFloat? = nil, scale: CGFloat = 2.0, outputPath: String) {
+func renderViewToPNG<V: View>(
+    view: V,
+    targetWidth: CGFloat? = nil,
+    targetHeight: CGFloat? = nil,
+    scale: CGFloat = 2.0,
+    settleTime: TimeInterval = 0.45,
+    outputPath: String
+) {
     let darkView = view.preferredColorScheme(.dark)
-    
+
     let sizedView: AnyView
     if let w = targetWidth, let h = targetHeight {
         sizedView = AnyView(darkView.frame(width: w, height: h))
@@ -16,14 +23,18 @@ func renderViewToPNG<V: View>(view: V, targetWidth: CGFloat? = nil, targetHeight
     } else {
         sizedView = AnyView(darkView)
     }
-    
+
+    // Keep the view attached to a real AppKit window so controls, AccountView's
+    // onAppear refresh, menus and progress indicators all finish layout before
+    // the snapshot is taken. Privacy-sensitive text is source-redacted by
+    // HoverRevealText before this point, so bitmap snapshots cannot bypass blur.
     let hostingView = NSHostingView(rootView: sizedView)
     let fitting = hostingView.fittingSize
     let width = targetWidth ?? max(fitting.width, 10)
     let height = targetHeight ?? max(fitting.height, 10)
     let contentRect = NSRect(x: 0, y: 0, width: width, height: height)
     hostingView.frame = contentRect
-    
+
     let window = NSWindow(
         contentRect: contentRect,
         styleMask: [.borderless],
@@ -35,32 +46,136 @@ func renderViewToPNG<V: View>(view: V, targetWidth: CGFloat? = nil, targetHeight
     window.backgroundColor = .clear
     window.isOpaque = false
     window.layoutIfNeeded()
-    
-    // Allow AppKit/SwiftUI to attach controls (Menu, TextField, ProgressView)
-    // and resolve background fetch tasks cleanly
-    RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.35))
-    
+
+    RunLoop.current.run(until: Date(timeIntervalSinceNow: settleTime))
+    window.layoutIfNeeded()
+
     if let rep = hostingView.bitmapImageRepForCachingDisplay(in: contentRect) {
         hostingView.cacheDisplay(in: contentRect, to: rep)
         if let pngData = rep.representation(using: .png, properties: [:]) {
             let url = URL(fileURLWithPath: outputPath)
-            try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try? FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
             try? pngData.write(to: url)
             print("✅ Rendered [\(rep.pixelsWide)x\(rep.pixelsHigh)] -> \(outputPath)")
             return
         }
     }
-    
+
+    // Fallback remains useful for simple SwiftUI-only compositions.
     let renderer = ImageRenderer(content: sizedView)
     renderer.scale = scale
     if let cgImage = renderer.cgImage {
         let bitmapRep = NSBitmapImageRep(cgImage: cgImage)
         if let pngData = bitmapRep.representation(using: .png, properties: [:]) {
             let url = URL(fileURLWithPath: outputPath)
-            try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try? FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
             try? pngData.write(to: url)
             print("✅ Rendered fallback [\(cgImage.width)x\(cgImage.height)] -> \(outputPath)")
         }
+    }
+}
+
+// MARK: - Account Showcase Chrome
+
+/// Account is intentionally a UI-only fourth tab in SummaryView, so the normal
+/// OverlayTab enum remains backward compatible. The showcase needs a deterministic
+/// way to render that selected state without synthesizing mouse input, therefore
+/// this wrapper reuses the real AccountView and mirrors the production chrome.
+struct AccountPromoCard: View {
+    @ObservedObject var state: OverlayState
+    var isFullHeight: Bool = true
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 7) {
+                FlowPilotLogoView(size: 29, showGlow: true, withBolt: false, text: "FP")
+                    .frame(width: 29, height: 29)
+
+                VStack(alignment: .leading, spacing: 0) {
+                    Text("FlowPilot")
+                        .font(.system(size: 11.5, weight: .heavy, design: .rounded))
+                        .foregroundColor(.white)
+                    Text("Account & Limits")
+                        .font(.system(size: 7.8, weight: .medium, design: .rounded))
+                        .foregroundColor(.cyan.opacity(0.85))
+                }
+
+                Spacer()
+
+                Image(systemName: "eye.slash.fill")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundColor(.orange)
+                    .frame(width: 23, height: 23)
+                    .background(Circle().fill(Color.white.opacity(0.045)))
+            }
+            .padding(.horizontal, 11)
+            .padding(.vertical, 8)
+
+            Divider().background(Color.white.opacity(0.07))
+
+            HStack(spacing: 4) {
+                promoTab("Inspector", "bolt.fill", false)
+                promoTab("History", "clock.arrow.circlepath", false)
+                promoTab("Analytics", "chart.bar.xaxis", false)
+                promoTab("Account", "person.crop.circle.fill", true)
+            }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 4)
+            .background(Color.black.opacity(0.14))
+
+            Divider().background(Color.white.opacity(0.06))
+
+            AccountView(state: state, isFullHeight: isFullHeight)
+                .padding(.horizontal, 10)
+                .padding(.bottom, 9)
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            Color(red: 0.055, green: 0.062, blue: 0.085).opacity(0.98),
+                            Color(red: 0.035, green: 0.041, blue: 0.058).opacity(0.98)
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .shadow(color: .black.opacity(0.48), radius: 18, y: 8)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(Color.white.opacity(0.11), lineWidth: 0.8)
+        )
+    }
+
+    private func promoTab(_ title: String, _ icon: String, _ selected: Bool) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.system(size: 8.8, weight: .semibold))
+            Text(title)
+                .font(.system(size: 9.0, weight: selected ? .bold : .medium, design: .rounded))
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+        }
+        .foregroundColor(selected ? .white : .white.opacity(0.52))
+        .frame(maxWidth: .infinity, minHeight: 26)
+        .padding(.vertical, 5)
+        .background(
+            RoundedRectangle(cornerRadius: 7)
+                .fill(selected ? Color.cyan.opacity(0.22) : Color.clear)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 7)
+                        .stroke(selected ? Color.cyan.opacity(0.32) : Color.clear, lineWidth: 0.6)
+                )
+        )
     }
 }
 
@@ -70,11 +185,11 @@ struct PosterPromoView: View {
     var stateInspector: OverlayState
     var stateHistory: OverlayState
     var stateAnalytics: OverlayState
+    var stateAccount: OverlayState
     var stateBubble: OverlayState
-    
+
     var body: some View {
         ZStack {
-            // Dark futuristic background
             LinearGradient(
                 colors: [
                     Color(red: 0.04, green: 0.06, blue: 0.11),
@@ -84,94 +199,74 @@ struct PosterPromoView: View {
                 startPoint: .topLeading,
                 endPoint: .bottomTrailing
             )
-            
-            // Cyber glow orbs
+
             Circle()
                 .fill(Color.cyan.opacity(0.12))
                 .blur(radius: 120)
-                .frame(width: 600, height: 600)
-                .offset(x: -450, y: -250)
-            
+                .frame(width: 650, height: 650)
+                .offset(x: -620, y: -260)
+
             Circle()
                 .fill(Color(red: 0.6, green: 0.2, blue: 0.9).opacity(0.12))
                 .blur(radius: 140)
-                .frame(width: 700, height: 700)
-                .offset(x: 450, y: 200)
-            
+                .frame(width: 720, height: 720)
+                .offset(x: 600, y: 240)
+
             VStack(spacing: 20) {
-                // Header Title & Badges
                 VStack(spacing: 6) {
                     HStack(spacing: 12) {
                         FlowPilotLogoView(size: 44, showGlow: true, withBolt: true)
-                        
                         Text("FlowPilot macOS Native Widget")
                             .font(.system(size: 32, weight: .black, design: .rounded))
                             .foregroundColor(.white)
                     }
-                    
-                    Text("100% Native SwiftUI + AppKit · Zero-Cost Deterministic Telemetry · Ambient Quota Perception")
+
+                    Text("Inspector · History · Analytics · Account · Privacy-safe Showcase")
                         .font(.system(size: 14, weight: .medium, design: .rounded))
                         .foregroundColor(.white.opacity(0.65))
                 }
                 .padding(.top, 28)
-                
-                // 3 Main Column Cards
-                HStack(alignment: .top, spacing: 24) {
-                    // Column 1: Inspector (Live Task & Quota)
-                    VStack(spacing: 10) {
-                        HStack {
-                            Image(systemName: "bolt.fill")
-                                .foregroundColor(.cyan)
-                            Text("⚡️ Inspector (实时巡检)")
-                                .font(.system(size: 13.5, weight: .bold, design: .rounded))
-                                .foregroundColor(.white.opacity(0.9))
-                        }
-                        
-                        SummaryView(state: stateInspector, isFullHeight: true)
-                            .shadow(color: Color.black.opacity(0.45), radius: 24, x: 0, y: 12)
-                    }
-                    
-                    // Column 2: History (Task Timeline)
-                    VStack(spacing: 10) {
-                        HStack {
-                            Image(systemName: "clock.arrow.circlepath")
-                                .foregroundColor(.indigo)
-                            Text("📜 History (历史回溯)")
-                                .font(.system(size: 13.5, weight: .bold, design: .rounded))
-                                .foregroundColor(.white.opacity(0.9))
-                        }
-                        
-                        SummaryView(state: stateHistory, isFullHeight: true)
-                            .shadow(color: Color.black.opacity(0.45), radius: 24, x: 0, y: 12)
-                    }
-                    
-                    // Column 3: Analytics (30-Day Efficiency)
-                    VStack(spacing: 10) {
-                        HStack {
-                            Image(systemName: "chart.bar.xaxis")
-                                .foregroundColor(Color(red: 0.95, green: 0.35, blue: 0.8))
-                            Text("📊 Analytics (效能看板)")
-                                .font(.system(size: 13.5, weight: .bold, design: .rounded))
-                                .foregroundColor(.white.opacity(0.9))
-                        }
-                        
-                        SummaryView(state: stateAnalytics, isFullHeight: true)
-                            .shadow(color: Color.black.opacity(0.45), radius: 24, x: 0, y: 12)
-                    }
+
+                HStack(alignment: .top, spacing: 18) {
+                    promoColumn(
+                        icon: "bolt.fill",
+                        title: "⚡️ Inspector (实时巡检)",
+                        tint: .cyan,
+                        view: AnyView(SummaryView(state: stateInspector, isFullHeight: true))
+                    )
+
+                    promoColumn(
+                        icon: "clock.arrow.circlepath",
+                        title: "📜 History (历史回溯)",
+                        tint: .indigo,
+                        view: AnyView(SummaryView(state: stateHistory, isFullHeight: true))
+                    )
+
+                    promoColumn(
+                        icon: "chart.bar.xaxis",
+                        title: "📊 Analytics (效能看板)",
+                        tint: Color(red: 0.95, green: 0.35, blue: 0.8),
+                        view: AnyView(SummaryView(state: stateAnalytics, isFullHeight: true))
+                    )
+
+                    promoColumn(
+                        icon: "person.crop.circle.fill",
+                        title: "👤 Account (账户与额度)",
+                        tint: .teal,
+                        view: AnyView(AccountPromoCard(state: stateAccount, isFullHeight: true))
+                    )
                 }
-                
-                // Bottom Micro-Capsule Feature Callout
+
                 HStack(spacing: 18) {
                     BubbleView(state: stateBubble)
                         .scaleEffect(0.88)
-                    
+
                     VStack(alignment: .leading, spacing: 3) {
                         Text("🟢 灵动微胶囊 (Micro Capsule)")
                             .font(.system(size: 12.5, weight: .bold, design: .rounded))
                             .foregroundColor(.white)
-                        
-                        Text("闲置时自动吸附屏幕边缘，动态彩虹呼吸光环实时感知任务运行态与最新消耗。")
-                            .font(.system(size: 11, weight: .regular))
+                        Text("闲置自动吸附屏幕边缘；宣传物料默认强制隐私模式，真实项目名、任务内容和账户标识不会进入截图像素。")
+                            .font(.system(size: 11))
                             .foregroundColor(.white.opacity(0.6))
                     }
                 }
@@ -188,17 +283,31 @@ struct PosterPromoView: View {
                 .padding(.bottom, 28)
             }
         }
-        .frame(width: 1360)
+        .frame(width: 1740)
+    }
+
+    private func promoColumn(icon: String, title: String, tint: Color, view: AnyView) -> some View {
+        VStack(spacing: 10) {
+            HStack {
+                Image(systemName: icon).foregroundColor(tint)
+                Text(title)
+                    .font(.system(size: 13, weight: .bold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.9))
+            }
+
+            view
+                .frame(width: 384)
+                .shadow(color: Color.black.opacity(0.45), radius: 24, x: 0, y: 12)
+        }
     }
 }
 
 struct BannerPromoView: View {
     var stateInspector: OverlayState
     var stateBubble: OverlayState
-    
+
     var body: some View {
         ZStack {
-            // Dark futuristic background
             LinearGradient(
                 colors: [
                     Color(red: 0.05, green: 0.07, blue: 0.13),
@@ -208,62 +317,53 @@ struct BannerPromoView: View {
                 startPoint: .topLeading,
                 endPoint: .bottomTrailing
             )
-            
-            // Background glow
+
             Circle()
                 .fill(Color.cyan.opacity(0.15))
                 .blur(radius: 120)
                 .frame(width: 500, height: 500)
-                .offset(x: -350, y: 0)
-            
+                .offset(x: -350)
+
             Circle()
                 .fill(Color(red: 0.6, green: 0.2, blue: 0.9).opacity(0.15))
                 .blur(radius: 140)
                 .frame(width: 600, height: 600)
-                .offset(x: 350, y: 0)
-            
+                .offset(x: 350)
+
             HStack(spacing: 48) {
-                // Left Column: Branding, Slogan, Highlights
                 VStack(alignment: .leading, spacing: 18) {
                     HStack(spacing: 14) {
                         FlowPilotLogoView(size: 52, showGlow: true, withBolt: true)
-                        
                         Text("codex-flow")
                             .font(.system(size: 40, weight: .black, design: .rounded))
                             .foregroundColor(.white)
                     }
-                    
+
                     Text("智能、高效、自适应的\nCodex 多 Agent 协同编排引擎")
                         .font(.system(size: 25, weight: .bold, design: .rounded))
                         .foregroundColor(.white.opacity(0.95))
                         .lineSpacing(5)
-                    
-                    Text("让高能力模型负责规划决策，让更经济的 Worker 负责落地执行；\n只有任务确实需要时，才提高推理强度。")
+
+                    Text("Inspector · History · Analytics · Account")
                         .font(.system(size: 13.5, weight: .medium))
                         .foregroundColor(.white.opacity(0.65))
-                        .lineSpacing(4)
-                    
-                    // Feature Pills
+
                     VStack(alignment: .leading, spacing: 9) {
-                        featurePill(icon: "brain.head.profile", text: "FlowPilot 动态自适应任务复杂度路由")
-                        featurePill(icon: "chart.pie.fill", text: "零开销确定性 Token 差值归因 + 实时 Quota 水位")
-                        featurePill(icon: "macwindow.badge.plus", text: "SwiftUI + AppKit 100% 纯原生毛玻璃灵动悬浮窗")
+                        featurePill("brain.head.profile", "FlowPilot 动态自适应任务复杂度路由")
+                        featurePill("chart.pie.fill", "确定性 Token 归因 + 实时 Quota 水位")
+                        featurePill("person.crop.circle.fill", "账户级 Plan / 额度 / Reset / 每日消耗")
+                        featurePill("eye.slash.fill", "宣传截图默认隐私脱敏，不渲染敏感源文本")
                     }
-                    .padding(.top, 6)
-                    
+
                     HStack(spacing: 14) {
-                        BubbleView(state: stateBubble)
-                            .scaleEffect(0.85)
-                        
+                        BubbleView(state: stateBubble).scaleEffect(0.85)
                         Text("🟢 灵动微胶囊 · 闲置边缘吸附 · 状态光环")
                             .font(.system(size: 12, weight: .semibold))
                             .foregroundColor(.white.opacity(0.75))
                     }
-                    .padding(.top, 4)
                 }
                 .frame(width: 560)
-                
-                // Right Column: Actual Running Inspector Card
+
                 SummaryView(state: stateInspector, isFullHeight: true)
                     .scaleEffect(0.92)
                     .shadow(color: Color.black.opacity(0.5), radius: 30, x: 0, y: 15)
@@ -273,33 +373,28 @@ struct BannerPromoView: View {
         }
         .frame(width: 1340)
     }
-    
-    private func featurePill(icon: String, text: String) -> some View {
+
+    private func featurePill(_ icon: String, _ text: String) -> some View {
         HStack(spacing: 8) {
             Image(systemName: icon)
                 .font(.system(size: 12, weight: .bold))
                 .foregroundColor(.cyan)
-            
             Text(text)
                 .font(.system(size: 12.5, weight: .medium, design: .rounded))
                 .foregroundColor(.white.opacity(0.85))
         }
         .padding(.horizontal, 11)
         .padding(.vertical, 6.5)
-        .background(
-            RoundedRectangle(cornerRadius: 10)
-                .fill(Color.white.opacity(0.06))
-        )
+        .background(RoundedRectangle(cornerRadius: 10).fill(Color.white.opacity(0.06)))
     }
 }
 
 struct DesktopScenePromoView: View {
     var stateInspector: OverlayState
     var stateBubble: OverlayState
-    
+
     var body: some View {
         ZStack {
-            // macOS Wallpaper Gradient (Sonoma/Sequoia dark style)
             LinearGradient(
                 colors: [
                     Color(red: 0.08, green: 0.10, blue: 0.18),
@@ -309,14 +404,11 @@ struct DesktopScenePromoView: View {
                 startPoint: .topLeading,
                 endPoint: .bottomTrailing
             )
-            
-            // macOS Menu Bar
+
             VStack {
                 HStack(spacing: 16) {
                     Image(systemName: "applelogo")
-                        .font(.system(size: 13))
-                    Text("Code")
-                        .font(.system(size: 12, weight: .bold))
+                    Text("Code").fontWeight(.bold)
                     Text("File")
                     Text("Edit")
                     Text("Selection")
@@ -325,36 +417,22 @@ struct DesktopScenePromoView: View {
                     Text("Run")
                     Text("Terminal")
                     Text("Help")
-                    
                     Spacer()
-                    
-                    HStack(spacing: 12) {
-                        Image(systemName: "sparkles")
-                            .foregroundColor(.cyan)
-                        Text("FlowPilot 1.4.0")
-                        Image(systemName: "wifi")
-                        Image(systemName: "battery.100")
-                        Text("Wed 18:30")
-                    }
+                    Image(systemName: "sparkles").foregroundColor(.cyan)
+                    Text("FlowPilot")
+                    Image(systemName: "wifi")
+                    Image(systemName: "battery.100")
                 }
                 .font(.system(size: 12))
                 .foregroundColor(.white.opacity(0.85))
                 .padding(.horizontal, 20)
                 .padding(.vertical, 6)
                 .background(.ultraThinMaterial)
-                
                 Spacer()
             }
-            
-            // Mock Code Editor / IDE Window in Background
+
             RoundedRectangle(cornerRadius: 12)
                 .fill(Color(red: 0.09, green: 0.10, blue: 0.15).opacity(0.95))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12)
-                        .stroke(Color.white.opacity(0.1), lineWidth: 1)
-                )
-                .frame(width: 820, height: 560)
-                .offset(x: -180, y: 15)
                 .overlay(
                     VStack(alignment: .leading, spacing: 6) {
                         HStack(spacing: 6) {
@@ -364,40 +442,24 @@ struct DesktopScenePromoView: View {
                             Text("SummaryView.swift — codex-flow")
                                 .font(.system(size: 11, design: .monospaced))
                                 .foregroundColor(.white.opacity(0.5))
-                                .padding(.leading, 8)
                         }
-                        .padding(12)
-                        
                         Divider().background(Color.white.opacity(0.08))
-                        
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("import SwiftUI")
-                            Text("import AppKit")
-                            Text("")
-                            Text("// FlowPilot Adaptive Multi-Agent Orchestration Engine")
-                            Text("public struct SummaryView: View {")
-                            Text("    @ObservedObject var state: OverlayState")
-                            Text("    public var isFullHeight: Bool = false")
-                            Text("    ...")
-                        }
-                        .font(.system(size: 11.5, design: .monospaced))
-                        .foregroundColor(.cyan.opacity(0.8))
-                        .padding(16)
-                        
+                        Text("// FlowPilot adaptive multi-agent orchestration\npublic struct SummaryView: View {\n    @ObservedObject var state: OverlayState\n    ...\n}")
+                            .font(.system(size: 11.5, design: .monospaced))
+                            .foregroundColor(.cyan.opacity(0.8))
                         Spacer()
                     }
-                    .frame(width: 820, height: 560)
-                    .offset(x: -180, y: 15)
+                    .padding(16)
                 )
+                .frame(width: 820, height: 560)
+                .offset(x: -180, y: 15)
                 .shadow(color: Color.black.opacity(0.5), radius: 30, x: -10, y: 15)
-            
-            // FlowPilot Floating Expanded Window in Foreground
+
             SummaryView(state: stateInspector, isFullHeight: true)
                 .scaleEffect(0.72)
                 .offset(x: 320, y: 15)
                 .shadow(color: Color.black.opacity(0.6), radius: 35, x: 5, y: 15)
-            
-            // FlowPilot Docked Bubble on Screen Right Edge
+
             BubbleView(state: stateBubble)
                 .scaleEffect(0.9)
                 .offset(x: 600, y: -180)
@@ -411,30 +473,28 @@ struct DesktopScenePromoView: View {
 
 @MainActor
 func runGenerator() {
-    print("🎨 Starting FlowPilot high-precision screenshot & promo graphic generation...")
-    
+    print("🎨 Starting FlowPilot privacy-safe screenshot & promo generation...")
+
     let engine = TelemetryQueryEngine.shared
     let allRuns = engine.loadAllRuns()
-    
+
     var latestRun = engine.loadLatestRun() ?? allRuns.first
-    if var r = latestRun {
-        engine.enrichRunIfNeeded(&r)
-        latestRun = r
+    if var run = latestRun {
+        engine.enrichRunIfNeeded(&run)
+        latestRun = run
     }
-    
+
     let historyChats = engine.fetchChatHistory(limit: 20)
     let historyRuns = engine.fetchHistory(limit: 50)
     let stats = engine.computeStats(days: 30, project: nil)
-    
-    // State 1: Inspector (Desensitized with Privacy Blur)
+
     let stateInspector = OverlayState()
     stateInspector.latestRun = latestRun
     stateInspector.inspectedRun = latestRun
     stateInspector.activeTab = .inspector
     stateInspector.isExpanded = true
     stateInspector.isPrivacyMode = true
-    
-    // State 2: Full History (Desensitized with Privacy Blur)
+
     let stateHistoryFull = OverlayState()
     stateHistoryFull.latestRun = latestRun
     stateHistoryFull.historyChats = historyChats
@@ -443,8 +503,7 @@ func runGenerator() {
     stateHistoryFull.isExpanded = true
     stateHistoryFull.isPrivacyMode = true
     stateHistoryFull.expandedChatIds = Set(historyChats.prefix(3).map { $0.sessionId })
-    
-    // State 2b: Poster Compact History (Top 3 chats)
+
     let stateHistoryPoster = OverlayState()
     stateHistoryPoster.latestRun = latestRun
     stateHistoryPoster.historyChats = Array(historyChats.prefix(3))
@@ -453,22 +512,25 @@ func runGenerator() {
     stateHistoryPoster.isExpanded = true
     stateHistoryPoster.isPrivacyMode = true
     stateHistoryPoster.expandedChatIds = Set(historyChats.prefix(1).map { $0.sessionId })
-    
-    // State 3: Analytics (Desensitized with Privacy Blur)
+
     let stateAnalytics = OverlayState()
     stateAnalytics.latestRun = latestRun
     stateAnalytics.statsData = stats
     stateAnalytics.activeTab = .analytics
     stateAnalytics.isExpanded = true
     stateAnalytics.isPrivacyMode = true
-    
-    // State 4: Bubble
+
+    let stateAccount = OverlayState()
+    stateAccount.latestRun = latestRun
+    stateAccount.isExpanded = true
+    stateAccount.isPrivacyMode = true
+
     let stateBubble = OverlayState()
     stateBubble.latestRun = latestRun
     stateBubble.isTaskRunning = false
     stateBubble.isExpanded = false
-    
-    // 0. Render Official Project Logo (1024x1024 Retina & 256x256)
+    stateBubble.isPrivacyMode = true
+
     renderViewToPNG(
         view: FlowPilotLogoView(size: 512, showGlow: true, withBolt: true),
         scale: 2.0,
@@ -481,35 +543,41 @@ func runGenerator() {
         outputPath: "docs/assets/logo_256.png"
     )
 
-    // 1. Render Standalone Unclipped Full-Height Views (2x Retina)
     renderViewToPNG(
         view: SummaryView(state: stateInspector, isFullHeight: true),
         targetWidth: 384,
         scale: 2.0,
         outputPath: "docs/assets/screenshots/inspector_full.png"
     )
-    
+
     renderViewToPNG(
         view: SummaryView(state: stateHistoryFull, isFullHeight: true),
         targetWidth: 384,
         scale: 2.0,
         outputPath: "docs/assets/screenshots/history_full.png"
     )
-    
+
     renderViewToPNG(
         view: SummaryView(state: stateAnalytics, isFullHeight: true),
         targetWidth: 384,
         scale: 2.0,
         outputPath: "docs/assets/screenshots/analytics_full.png"
     )
-    
+
+    renderViewToPNG(
+        view: AccountPromoCard(state: stateAccount, isFullHeight: true),
+        targetWidth: 384,
+        scale: 2.0,
+        settleTime: 0.9,
+        outputPath: "docs/assets/screenshots/account_full.png"
+    )
+
     renderViewToPNG(
         view: BubbleView(state: stateBubble).padding(20),
         scale: 3.0,
         outputPath: "docs/assets/screenshots/capsule.png"
     )
-    
-    // 2. Render Standard Window Framed Views
+
     renderViewToPNG(
         view: SummaryView(state: stateInspector, isFullHeight: false),
         targetWidth: 384,
@@ -517,7 +585,7 @@ func runGenerator() {
         scale: 2.0,
         outputPath: "docs/assets/screenshots/inspector_window.png"
     )
-    
+
     renderViewToPNG(
         view: SummaryView(state: stateHistoryFull, isFullHeight: false),
         targetWidth: 384,
@@ -525,7 +593,7 @@ func runGenerator() {
         scale: 2.0,
         outputPath: "docs/assets/screenshots/history_window.png"
     )
-    
+
     renderViewToPNG(
         view: SummaryView(state: stateAnalytics, isFullHeight: false),
         targetWidth: 384,
@@ -533,19 +601,29 @@ func runGenerator() {
         scale: 2.0,
         outputPath: "docs/assets/screenshots/analytics_window.png"
     )
-    
-    // 3. Render High-Impact Composite Poster, Banner & Desktop Scene
+
+    renderViewToPNG(
+        view: AccountPromoCard(state: stateAccount, isFullHeight: false),
+        targetWidth: 384,
+        targetHeight: 490,
+        scale: 2.0,
+        settleTime: 0.9,
+        outputPath: "docs/assets/screenshots/account_window.png"
+    )
+
     renderViewToPNG(
         view: PosterPromoView(
             stateInspector: stateInspector,
             stateHistory: stateHistoryPoster,
             stateAnalytics: stateAnalytics,
+            stateAccount: stateAccount,
             stateBubble: stateBubble
         ),
         scale: 2.0,
+        settleTime: 0.9,
         outputPath: "docs/assets/promo/flowpilot_promo_poster.png"
     )
-    
+
     renderViewToPNG(
         view: BannerPromoView(
             stateInspector: stateInspector,
@@ -554,7 +632,7 @@ func runGenerator() {
         scale: 2.0,
         outputPath: "docs/assets/promo/flowpilot_promo_banner.png"
     )
-    
+
     renderViewToPNG(
         view: DesktopScenePromoView(
             stateInspector: stateInspector,
@@ -563,11 +641,9 @@ func runGenerator() {
         scale: 2.0,
         outputPath: "docs/assets/promo/flowpilot_promo_desktop_scene.png"
     )
-    
-    // 4. Automatically compress all generated PNG assets using crunch
+
     optimizeAssetsWithCrunch()
-    
-    print("✨ All screenshots and promo graphics generated and optimized successfully into docs/assets!")
+    print("✨ All privacy-safe screenshots and promo graphics generated into docs/assets!")
 }
 
 func optimizeAssetsWithCrunch() {
@@ -576,7 +652,7 @@ func optimizeAssetsWithCrunch() {
         print("⚠️ /usr/local/bin/crunch not found, skipping compression.")
         return
     }
-    
+
     print("🗜️ Optimizing generated PNG images with crunch...")
     let outputFiles = [
         "docs/assets/logo.png",
@@ -584,23 +660,25 @@ func optimizeAssetsWithCrunch() {
         "docs/assets/screenshots/inspector_full.png",
         "docs/assets/screenshots/history_full.png",
         "docs/assets/screenshots/analytics_full.png",
+        "docs/assets/screenshots/account_full.png",
         "docs/assets/screenshots/capsule.png",
         "docs/assets/screenshots/inspector_window.png",
         "docs/assets/screenshots/history_window.png",
         "docs/assets/screenshots/analytics_window.png",
+        "docs/assets/screenshots/account_window.png",
         "docs/assets/promo/flowpilot_promo_poster.png",
         "docs/assets/promo/flowpilot_promo_banner.png",
         "docs/assets/promo/flowpilot_promo_desktop_scene.png"
     ]
-    
+
     for file in outputFiles {
         guard FileManager.default.fileExists(atPath: file) else { continue }
-        let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
-        proc.arguments = [crunchScript, file]
-        try? proc.run()
-        proc.waitUntilExit()
-        
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        process.arguments = [crunchScript, file]
+        try? process.run()
+        process.waitUntilExit()
+
         let crunched = file.replacingOccurrences(of: ".png", with: "-crunch.png")
         if FileManager.default.fileExists(atPath: crunched) {
             try? FileManager.default.removeItem(atPath: file)

--- a/scripts/generate_showcase.swift
+++ b/scripts/generate_showcase.swift
@@ -2,12 +2,19 @@ import Cocoa
 import SwiftUI
 import CoreGraphics
 
+private enum ShowcaseMetrics {
+    // Keep showcase captures aligned with OverlayRootView / OverlayWindowController.
+    static let panelWidth: CGFloat = 384
+    static let panelHeight: CGFloat = 490
+}
+
 @MainActor
 func renderViewToPNG<V: View>(
     view: V,
     targetWidth: CGFloat? = nil,
     targetHeight: CGFloat? = nil,
     scale: CGFloat = 2.0,
+    requiresLiveHosting: Bool = false,
     settleTime: TimeInterval = 0.45,
     outputPath: String
 ) {
@@ -24,16 +31,37 @@ func renderViewToPNG<V: View>(
         sizedView = AnyView(darkView)
     }
 
-    // Keep the view attached to a real AppKit window so controls, AccountView's
-    // onAppear refresh, menus and progress indicators all finish layout before
-    // the snapshot is taken. Privacy-sensitive text is semantically redacted by
-    // HoverRevealText before blur is applied, so bitmap snapshots stay private
-    // even if an AppKit capture path drops the blur compositing effect.
+    // The original showcase pipeline used ImageRenderer. Keep that as the
+    // default because it preserves SwiftUI effects (notably privacy blur) and
+    // produces deterministic logical-size × scale pixel dimensions.
+    if !requiresLiveHosting {
+        let renderer = ImageRenderer(content: sizedView)
+        renderer.scale = scale
+        if let cgImage = renderer.cgImage {
+            let bitmapRep = NSBitmapImageRep(cgImage: cgImage)
+            if let pngData = bitmapRep.representation(using: .png, properties: [:]) {
+                let url = URL(fileURLWithPath: outputPath)
+                try? FileManager.default.createDirectory(
+                    at: url.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try? pngData.write(to: url)
+                print("✅ Rendered [\(cgImage.width)x\(cgImage.height)] -> \(outputPath)")
+                return
+            }
+        }
+        print("❌ ImageRenderer failed for \(outputPath)")
+        return
+    }
+
+    // AccountView needs a real AppKit lifecycle so onAppear can start its Codex
+    // app-server request. Wait for that async work, then capture at an explicit
+    // pixel scale instead of inheriting the current monitor's backing scale.
     let hostingView = NSHostingView(rootView: sizedView)
-    let fitting = hostingView.fittingSize
-    let width = targetWidth ?? max(fitting.width, 10)
-    let height = targetHeight ?? max(fitting.height, 10)
-    let contentRect = NSRect(x: 0, y: 0, width: width, height: height)
+    let initialFitting = hostingView.fittingSize
+    var width = targetWidth ?? max(initialFitting.width, 10)
+    var height = targetHeight ?? max(initialFitting.height, 10)
+    var contentRect = NSRect(x: 0, y: 0, width: width, height: height)
     hostingView.frame = contentRect
 
     let window = NSWindow(
@@ -51,34 +79,50 @@ func renderViewToPNG<V: View>(
     RunLoop.current.run(until: Date(timeIntervalSinceNow: settleTime))
     window.layoutIfNeeded()
 
-    if let rep = hostingView.bitmapImageRepForCachingDisplay(in: contentRect) {
-        hostingView.cacheDisplay(in: contentRect, to: rep)
-        if let pngData = rep.representation(using: .png, properties: [:]) {
-            let url = URL(fileURLWithPath: outputPath)
-            try? FileManager.default.createDirectory(
-                at: url.deletingLastPathComponent(),
-                withIntermediateDirectories: true
-            )
-            try? pngData.write(to: url)
-            print("✅ Rendered [\(rep.pixelsWide)x\(rep.pixelsHigh)] -> \(outputPath)")
-            return
-        }
+    // Full-height Account/Poster content can grow after async data arrives.
+    // Re-measure unspecified dimensions after settling to avoid clipping or an
+    // oversized loading-state canvas.
+    if targetWidth == nil || targetHeight == nil {
+        let settledFitting = hostingView.fittingSize
+        if targetWidth == nil { width = max(settledFitting.width, 10) }
+        if targetHeight == nil { height = max(settledFitting.height, 10) }
+        contentRect = NSRect(x: 0, y: 0, width: width, height: height)
+        hostingView.frame = contentRect
+        window.setContentSize(contentRect.size)
+        window.layoutIfNeeded()
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.12))
     }
 
-    // Fallback remains useful for simple SwiftUI-only compositions.
-    let renderer = ImageRenderer(content: sizedView)
-    renderer.scale = scale
-    if let cgImage = renderer.cgImage {
-        let bitmapRep = NSBitmapImageRep(cgImage: cgImage)
-        if let pngData = bitmapRep.representation(using: .png, properties: [:]) {
-            let url = URL(fileURLWithPath: outputPath)
-            try? FileManager.default.createDirectory(
-                at: url.deletingLastPathComponent(),
-                withIntermediateDirectories: true
-            )
-            try? pngData.write(to: url)
-            print("✅ Rendered fallback [\(cgImage.width)x\(cgImage.height)] -> \(outputPath)")
-        }
+    let pixelsWide = max(1, Int((width * scale).rounded()))
+    let pixelsHigh = max(1, Int((height * scale).rounded()))
+    guard let rep = NSBitmapImageRep(
+        bitmapDataPlanes: nil,
+        pixelsWide: pixelsWide,
+        pixelsHigh: pixelsHigh,
+        bitsPerSample: 8,
+        samplesPerPixel: 4,
+        hasAlpha: true,
+        isPlanar: false,
+        colorSpaceName: .deviceRGB,
+        bytesPerRow: 0,
+        bitsPerPixel: 0
+    ) else {
+        print("❌ Failed to allocate bitmap for \(outputPath)")
+        return
+    }
+    rep.size = NSSize(width: width, height: height)
+    hostingView.cacheDisplay(in: contentRect, to: rep)
+
+    if let pngData = rep.representation(using: .png, properties: [:]) {
+        let url = URL(fileURLWithPath: outputPath)
+        try? FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try? pngData.write(to: url)
+        print("✅ Rendered live [\(rep.pixelsWide)x\(rep.pixelsHigh)] -> \(outputPath)")
+    } else {
+        print("❌ Failed to encode PNG for \(outputPath)")
     }
 }
 
@@ -222,7 +266,7 @@ struct PosterPromoView: View {
                             .foregroundColor(.white)
                     }
 
-                    Text("Inspector · History · Analytics · Account · Privacy-safe Showcase")
+                    Text("Inspector · History · Analytics · Account · Privacy-blurred Showcase")
                         .font(.system(size: 14, weight: .medium, design: .rounded))
                         .foregroundColor(.white.opacity(0.65))
                 }
@@ -266,7 +310,7 @@ struct PosterPromoView: View {
                         Text("🟢 灵动微胶囊 (Micro Capsule)")
                             .font(.system(size: 12.5, weight: .bold, design: .rounded))
                             .foregroundColor(.white)
-                        Text("闲置自动吸附屏幕边缘；宣传物料默认强制隐私模式，真实项目名、任务内容和账户标识不会进入截图像素。")
+                        Text("闲置自动吸附屏幕边缘；宣传物料默认强制隐私模式，敏感项目、任务与账户标识统一做真实模糊处理。")
                             .font(.system(size: 11))
                             .foregroundColor(.white.opacity(0.6))
                     }
@@ -297,7 +341,7 @@ struct PosterPromoView: View {
             }
 
             view
-                .frame(width: 384)
+                .frame(width: ShowcaseMetrics.panelWidth)
                 .shadow(color: Color.black.opacity(0.45), radius: 24, x: 0, y: 12)
         }
     }
@@ -353,7 +397,7 @@ struct BannerPromoView: View {
                         featurePill("brain.head.profile", "FlowPilot 动态自适应任务复杂度路由")
                         featurePill("chart.pie.fill", "确定性 Token 归因 + 实时 Quota 水位")
                         featurePill("person.crop.circle.fill", "账户级 Plan / 额度 / Reset / 每日消耗")
-                        featurePill("eye.slash.fill", "宣传截图默认隐私脱敏，不渲染敏感源文本")
+                        featurePill("eye.slash.fill", "宣传截图默认隐私模式，敏感信息统一模糊")
                     }
 
                     HStack(spacing: 14) {
@@ -474,7 +518,7 @@ struct DesktopScenePromoView: View {
 
 @MainActor
 func runGenerator() {
-    print("🎨 Starting FlowPilot privacy-safe screenshot & promo generation...")
+    print("🎨 Starting FlowPilot privacy-blurred screenshot & promo generation...")
 
     let engine = TelemetryQueryEngine.shared
     let allRuns = engine.loadAllRuns()
@@ -532,10 +576,9 @@ func runGenerator() {
     stateBubble.isExpanded = false
     stateBubble.isPrivacyMode = true
 
-    // AccountView performs an async Codex app-server request on appearance. The
-    // RPC itself may take up to four seconds, so account-containing captures get
-    // a wider settle window than the purely local telemetry views.
-    let accountSettleTime: TimeInterval = 5.0
+    // AccountSnapshotService bounds the complete app-server flow at 10 seconds.
+    // Give the Account view enough time to leave its loading state before capture.
+    let accountSettleTime = AccountSnapshotService.outerTimeout + 0.75
 
     renderViewToPNG(
         view: FlowPilotLogoView(size: 512, showGlow: true, withBolt: true),
@@ -551,31 +594,23 @@ func runGenerator() {
 
     renderViewToPNG(
         view: SummaryView(state: stateInspector, isFullHeight: true),
-        targetWidth: 384,
+        targetWidth: ShowcaseMetrics.panelWidth,
         scale: 2.0,
         outputPath: "docs/assets/screenshots/inspector_full.png"
     )
 
     renderViewToPNG(
         view: SummaryView(state: stateHistoryFull, isFullHeight: true),
-        targetWidth: 384,
+        targetWidth: ShowcaseMetrics.panelWidth,
         scale: 2.0,
         outputPath: "docs/assets/screenshots/history_full.png"
     )
 
     renderViewToPNG(
         view: SummaryView(state: stateAnalytics, isFullHeight: true),
-        targetWidth: 384,
+        targetWidth: ShowcaseMetrics.panelWidth,
         scale: 2.0,
         outputPath: "docs/assets/screenshots/analytics_full.png"
-    )
-
-    renderViewToPNG(
-        view: AccountPromoCard(state: stateAccount, isFullHeight: true),
-        targetWidth: 384,
-        scale: 2.0,
-        settleTime: accountSettleTime,
-        outputPath: "docs/assets/screenshots/account_full.png"
     )
 
     renderViewToPNG(
@@ -586,33 +621,45 @@ func runGenerator() {
 
     renderViewToPNG(
         view: SummaryView(state: stateInspector, isFullHeight: false),
-        targetWidth: 384,
-        targetHeight: 490,
+        targetWidth: ShowcaseMetrics.panelWidth,
+        targetHeight: ShowcaseMetrics.panelHeight,
         scale: 2.0,
         outputPath: "docs/assets/screenshots/inspector_window.png"
     )
 
     renderViewToPNG(
         view: SummaryView(state: stateHistoryFull, isFullHeight: false),
-        targetWidth: 384,
-        targetHeight: 490,
+        targetWidth: ShowcaseMetrics.panelWidth,
+        targetHeight: ShowcaseMetrics.panelHeight,
         scale: 2.0,
         outputPath: "docs/assets/screenshots/history_window.png"
     )
 
     renderViewToPNG(
         view: SummaryView(state: stateAnalytics, isFullHeight: false),
-        targetWidth: 384,
-        targetHeight: 490,
+        targetWidth: ShowcaseMetrics.panelWidth,
+        targetHeight: ShowcaseMetrics.panelHeight,
         scale: 2.0,
         outputPath: "docs/assets/screenshots/analytics_window.png"
     )
 
+    // Render Account captures later and with a real hosting lifecycle, because
+    // the view fetches live Codex account/quota data on appearance.
+    renderViewToPNG(
+        view: AccountPromoCard(state: stateAccount, isFullHeight: true),
+        targetWidth: ShowcaseMetrics.panelWidth,
+        scale: 2.0,
+        requiresLiveHosting: true,
+        settleTime: accountSettleTime,
+        outputPath: "docs/assets/screenshots/account_full.png"
+    )
+
     renderViewToPNG(
         view: AccountPromoCard(state: stateAccount, isFullHeight: false),
-        targetWidth: 384,
-        targetHeight: 490,
+        targetWidth: ShowcaseMetrics.panelWidth,
+        targetHeight: ShowcaseMetrics.panelHeight,
         scale: 2.0,
+        requiresLiveHosting: true,
         settleTime: accountSettleTime,
         outputPath: "docs/assets/screenshots/account_window.png"
     )
@@ -626,6 +673,7 @@ func runGenerator() {
             stateBubble: stateBubble
         ),
         scale: 2.0,
+        requiresLiveHosting: true,
         settleTime: accountSettleTime,
         outputPath: "docs/assets/promo/flowpilot_promo_poster.png"
     )
@@ -649,7 +697,7 @@ func runGenerator() {
     )
 
     optimizeAssetsWithCrunch()
-    print("✨ All privacy-safe screenshots and promo graphics generated into docs/assets!")
+    print("✨ All privacy-blurred screenshots and promo graphics generated into docs/assets!")
 }
 
 func optimizeAssetsWithCrunch() {

--- a/scripts/generate_showcase.swift
+++ b/scripts/generate_showcase.swift
@@ -26,8 +26,9 @@ func renderViewToPNG<V: View>(
 
     // Keep the view attached to a real AppKit window so controls, AccountView's
     // onAppear refresh, menus and progress indicators all finish layout before
-    // the snapshot is taken. Privacy-sensitive text is source-redacted by
-    // HoverRevealText before this point, so bitmap snapshots cannot bypass blur.
+    // the snapshot is taken. Privacy-sensitive text is semantically redacted by
+    // HoverRevealText before blur is applied, so bitmap snapshots stay private
+    // even if an AppKit capture path drops the blur compositing effect.
     let hostingView = NSHostingView(rootView: sizedView)
     let fitting = hostingView.fittingSize
     let width = targetWidth ?? max(fitting.width, 10)
@@ -531,6 +532,11 @@ func runGenerator() {
     stateBubble.isExpanded = false
     stateBubble.isPrivacyMode = true
 
+    // AccountView performs an async Codex app-server request on appearance. The
+    // RPC itself may take up to four seconds, so account-containing captures get
+    // a wider settle window than the purely local telemetry views.
+    let accountSettleTime: TimeInterval = 5.0
+
     renderViewToPNG(
         view: FlowPilotLogoView(size: 512, showGlow: true, withBolt: true),
         scale: 2.0,
@@ -568,7 +574,7 @@ func runGenerator() {
         view: AccountPromoCard(state: stateAccount, isFullHeight: true),
         targetWidth: 384,
         scale: 2.0,
-        settleTime: 0.9,
+        settleTime: accountSettleTime,
         outputPath: "docs/assets/screenshots/account_full.png"
     )
 
@@ -607,7 +613,7 @@ func runGenerator() {
         targetWidth: 384,
         targetHeight: 490,
         scale: 2.0,
-        settleTime: 0.9,
+        settleTime: accountSettleTime,
         outputPath: "docs/assets/screenshots/account_window.png"
     )
 
@@ -620,7 +626,7 @@ func runGenerator() {
             stateBubble: stateBubble
         ),
         scale: 2.0,
-        settleTime: 0.9,
+        settleTime: accountSettleTime,
         outputPath: "docs/assets/promo/flowpilot_promo_poster.png"
     )
 

--- a/scripts/generate_showcase.swift
+++ b/scripts/generate_showcase.swift
@@ -14,8 +14,6 @@ func renderViewToPNG<V: View>(
     targetWidth: CGFloat? = nil,
     targetHeight: CGFloat? = nil,
     scale: CGFloat = 2.0,
-    requiresLiveHosting: Bool = false,
-    settleTime: TimeInterval = 0.45,
     outputPath: String
 ) {
     let darkView = view.preferredColorScheme(.dark)
@@ -31,107 +29,85 @@ func renderViewToPNG<V: View>(
         sizedView = AnyView(darkView)
     }
 
-    // The original showcase pipeline used ImageRenderer. Keep that as the
-    // default because it preserves SwiftUI effects (notably privacy blur) and
-    // produces deterministic logical-size × scale pixel dimensions.
-    if !requiresLiveHosting {
-        let renderer = ImageRenderer(content: sizedView)
-        renderer.scale = scale
-        if let cgImage = renderer.cgImage {
-            let bitmapRep = NSBitmapImageRep(cgImage: cgImage)
-            if let pngData = bitmapRep.representation(using: .png, properties: [:]) {
-                let url = URL(fileURLWithPath: outputPath)
-                try? FileManager.default.createDirectory(
-                    at: url.deletingLastPathComponent(),
-                    withIntermediateDirectories: true
-                )
-                try? pngData.write(to: url)
-                print("✅ Rendered [\(cgImage.width)x\(cgImage.height)] -> \(outputPath)")
-                return
-            }
-        }
+    // Keep the original deterministic SwiftUI renderer for every showcase image.
+    // Account and strategy data are mocked below, so no AppKit lifecycle or async
+    // settling is required and SwiftUI privacy blur remains intact.
+    let renderer = ImageRenderer(content: sizedView)
+    renderer.scale = scale
+
+    guard let cgImage = renderer.cgImage else {
         print("❌ ImageRenderer failed for \(outputPath)")
         return
     }
 
-    // AccountView needs a real AppKit lifecycle so onAppear can start its Codex
-    // app-server request. Wait for that async work, then capture at an explicit
-    // pixel scale instead of inheriting the current monitor's backing scale.
-    let hostingView = NSHostingView(rootView: sizedView)
-    let initialFitting = hostingView.fittingSize
-    var width = targetWidth ?? max(initialFitting.width, 10)
-    var height = targetHeight ?? max(initialFitting.height, 10)
-    var contentRect = NSRect(x: 0, y: 0, width: width, height: height)
-    hostingView.frame = contentRect
-
-    let window = NSWindow(
-        contentRect: contentRect,
-        styleMask: [.borderless],
-        backing: .buffered,
-        defer: false
-    )
-    window.contentView = hostingView
-    window.appearance = NSAppearance(named: .darkAqua)
-    window.backgroundColor = .clear
-    window.isOpaque = false
-    window.layoutIfNeeded()
-
-    RunLoop.current.run(until: Date(timeIntervalSinceNow: settleTime))
-    window.layoutIfNeeded()
-
-    // Full-height Account/Poster content can grow after async data arrives.
-    // Re-measure unspecified dimensions after settling to avoid clipping or an
-    // oversized loading-state canvas.
-    if targetWidth == nil || targetHeight == nil {
-        let settledFitting = hostingView.fittingSize
-        if targetWidth == nil { width = max(settledFitting.width, 10) }
-        if targetHeight == nil { height = max(settledFitting.height, 10) }
-        contentRect = NSRect(x: 0, y: 0, width: width, height: height)
-        hostingView.frame = contentRect
-        window.setContentSize(contentRect.size)
-        window.layoutIfNeeded()
-        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.12))
-    }
-
-    let pixelsWide = max(1, Int((width * scale).rounded()))
-    let pixelsHigh = max(1, Int((height * scale).rounded()))
-    guard let rep = NSBitmapImageRep(
-        bitmapDataPlanes: nil,
-        pixelsWide: pixelsWide,
-        pixelsHigh: pixelsHigh,
-        bitsPerSample: 8,
-        samplesPerPixel: 4,
-        hasAlpha: true,
-        isPlanar: false,
-        colorSpaceName: .deviceRGB,
-        bytesPerRow: 0,
-        bitsPerPixel: 0
-    ) else {
-        print("❌ Failed to allocate bitmap for \(outputPath)")
+    let bitmapRep = NSBitmapImageRep(cgImage: cgImage)
+    guard let pngData = bitmapRep.representation(using: .png, properties: [:]) else {
+        print("❌ Failed to encode PNG for \(outputPath)")
         return
     }
-    rep.size = NSSize(width: width, height: height)
-    hostingView.cacheDisplay(in: contentRect, to: rep)
 
-    if let pngData = rep.representation(using: .png, properties: [:]) {
-        let url = URL(fileURLWithPath: outputPath)
-        try? FileManager.default.createDirectory(
-            at: url.deletingLastPathComponent(),
-            withIntermediateDirectories: true
+    let url = URL(fileURLWithPath: outputPath)
+    try? FileManager.default.createDirectory(
+        at: url.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+    )
+    try? pngData.write(to: url)
+    print("✅ Rendered [\(cgImage.width)x\(cgImage.height)] -> \(outputPath)")
+}
+
+// MARK: - Deterministic Showcase Data
+
+private enum ShowcaseMockData {
+    static var account: AccountSnapshot {
+        let now = Date()
+        return AccountSnapshot(
+            accountType: "chatgpt",
+            email: "showcase@flowpilot.dev",
+            planType: "plus",
+            requiresOpenAIAuth: false,
+            quotaWindows: [
+                AccountQuotaWindow(
+                    id: "showcase-5h",
+                    durationMinutes: 300,
+                    usedPercent: 38,
+                    resetsAt: now.addingTimeInterval(2 * 3600 + 18 * 60)
+                ),
+                AccountQuotaWindow(
+                    id: "showcase-weekly",
+                    durationMinutes: 10080,
+                    usedPercent: 57,
+                    resetsAt: now.addingTimeInterval(4 * 86_400 + 6 * 3600)
+                )
+            ],
+            resetCreditCount: 3,
+            resetCredits: [],
+            hasCredits: true,
+            unlimitedCredits: false,
+            creditsBalance: "120",
+            spendControlReached: false,
+            rateLimitReachedType: nil,
+            fetchedAt: now
         )
-        try? pngData.write(to: url)
-        print("✅ Rendered live [\(rep.pixelsWide)x\(rep.pixelsHigh)] -> \(outputPath)")
-    } else {
-        print("❌ Failed to encode PNG for \(outputPath)")
     }
+
+    static let strategy = StrategyModeSnapshot(
+        configured: "balanced",
+        routing: "adaptive",
+        valid: true,
+        profiles: [
+            StrategyProfileInfo(name: "efficient", description: "Minimize quota waste and expensive parent usage."),
+            StrategyProfileInfo(name: "balanced", description: "Balance quality, quota, and latency."),
+            StrategyProfileInfo(name: "quality", description: "Maximize correctness and independent verification."),
+            StrategyProfileInfo(name: "speed", description: "Minimize wall-clock time with safe parallelism.")
+        ]
+    )
 }
 
 // MARK: - Account Showcase Chrome
 
-/// Account is intentionally a UI-only fourth tab in SummaryView, so the normal
-/// OverlayTab enum remains backward compatible. The showcase needs a deterministic
-/// way to render that selected state without synthesizing mouse input, therefore
-/// this wrapper reuses the real AccountView and mirrors the production chrome.
+/// Showcase-only Account surface. It mirrors the real Account tab visually but
+/// deliberately consumes fixed mock snapshots so promotional rendering never
+/// depends on Codex app-server, local strategy commands, or request timing.
 struct AccountPromoCard: View {
     @ObservedObject var state: OverlayState
     var isFullHeight: Bool = true
@@ -176,9 +152,14 @@ struct AccountPromoCard: View {
 
             Divider().background(Color.white.opacity(0.06))
 
-            AccountView(state: state, isFullHeight: isFullHeight)
-                .padding(.horizontal, 10)
-                .padding(.bottom, 9)
+            ShowcaseAccountView(
+                state: state,
+                snapshot: ShowcaseMockData.account,
+                strategy: ShowcaseMockData.strategy,
+                isFullHeight: isFullHeight
+            )
+            .padding(.horizontal, 10)
+            .padding(.bottom, 9)
         }
         .background(
             RoundedRectangle(cornerRadius: 18, style: .continuous)
@@ -220,6 +201,404 @@ struct AccountPromoCard: View {
                     RoundedRectangle(cornerRadius: 7)
                         .stroke(selected ? Color.cyan.opacity(0.32) : Color.clear, lineWidth: 0.6)
                 )
+        )
+    }
+}
+
+private struct ShowcaseAccountView: View {
+    @ObservedObject var state: OverlayState
+    let snapshot: AccountSnapshot
+    let strategy: StrategyModeSnapshot
+    let isFullHeight: Bool
+
+    var body: some View {
+        let content = VStack(spacing: 9) {
+            accountHeader
+            identityCard
+            quotaCard
+            resetCard
+            accountFactsCard
+            ShowcaseStrategyModeCard(snapshot: strategy)
+            ShowcaseAutostartCard()
+        }
+        .padding(.vertical, 2)
+
+        return Group {
+            if isFullHeight {
+                content
+            } else {
+                ScrollView(.vertical, showsIndicators: true) {
+                    content
+                }
+                .frame(maxHeight: 390)
+            }
+        }
+    }
+
+    private var accountHeader: some View {
+        HStack(spacing: 9) {
+            FlowPilotLogoView(size: 42, showGlow: true, withBolt: false, text: "FP")
+                .frame(width: 42, height: 42)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(L("Account & Limits", "账户与额度"))
+                    .font(.system(size: 12, weight: .bold, design: .rounded))
+                    .foregroundColor(.white)
+                Text(L("Account data from Codex · strategy from FlowPilot policy", "账户数据来自 Codex · 策略来自 FlowPilot 配置"))
+                    .font(.system(size: 8.5))
+                    .foregroundColor(.white.opacity(0.45))
+            }
+
+            Spacer()
+
+            Image(systemName: "arrow.clockwise")
+                .font(.system(size: 9.5, weight: .semibold))
+                .foregroundColor(.cyan)
+                .frame(width: 24, height: 24)
+                .background(Circle().fill(Color.cyan.opacity(0.12)))
+        }
+    }
+
+    private var identityCard: some View {
+        HStack(spacing: 8) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(L("CURRENT PLAN", "当前 PLAN"))
+                    .font(.system(size: 8, weight: .bold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.42))
+                Text(planDisplayName(snapshot.planType))
+                    .font(.system(size: 16, weight: .heavy, design: .rounded))
+                    .foregroundStyle(LinearGradient(colors: [.cyan, .indigo], startPoint: .leading, endPoint: .trailing))
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: 3) {
+                Text(accountTypeDisplayName(snapshot.accountType))
+                    .font(.system(size: 8.5, weight: .bold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.7))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Capsule().fill(Color.white.opacity(0.07)))
+
+                if let email = snapshot.email, !email.isEmpty {
+                    HoverRevealText(
+                        email,
+                        font: .system(size: 8.5),
+                        foregroundColor: .white.opacity(0.48),
+                        lineLimit: 1,
+                        privacyBlur: state.isPrivacyMode,
+                        popoverWidth: 300
+                    )
+                    .frame(maxWidth: 190, alignment: .trailing)
+                }
+            }
+        }
+        .padding(9)
+        .background(cardBackground)
+    }
+
+    private var quotaCard: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Label(L("Current quota", "当前额度"), systemImage: "gauge.with.needle.fill")
+                .font(.system(size: 9.5, weight: .bold, design: .rounded))
+                .foregroundColor(.white.opacity(0.82))
+
+            ForEach(snapshot.orderedWindows) { window in
+                quotaRow(window)
+            }
+        }
+        .padding(9)
+        .background(cardBackground)
+    }
+
+    private func quotaRow(_ window: AccountQuotaWindow) -> some View {
+        let used = window.usedPercent.map { max(0, min(100, $0)) }
+        let remaining = window.remainingPercent
+        let remainingFraction = max(0, min(1, (remaining ?? 0) / 100.0))
+        let pressure = used ?? 0
+        let accent: Color = pressure >= 85 ? .orange : (pressure >= 60 ? .yellow : .cyan)
+
+        return VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 5) {
+                Text(window.compactName)
+                    .font(.system(size: 9, weight: .heavy, design: .monospaced))
+                    .foregroundColor(accent)
+                    .frame(width: 48, alignment: .leading)
+                Text(window.displayName)
+                    .font(.system(size: 8.5, weight: .semibold))
+                    .foregroundColor(.white.opacity(0.72))
+                Spacer()
+                if let remaining {
+                    Text(String(format: L("%.0f%% left", "剩余 %.0f%%"), remaining))
+                        .font(.system(size: 9, weight: .bold, design: .rounded))
+                        .foregroundColor(accent)
+                }
+            }
+
+            GeometryReader { proxy in
+                ZStack(alignment: .leading) {
+                    Capsule().fill(Color.white.opacity(0.08))
+                    Capsule().fill(accent)
+                        .frame(width: proxy.size.width * CGFloat(remainingFraction))
+                }
+            }
+            .frame(height: 4)
+
+            HStack {
+                if let used {
+                    Text(String(format: L("Used %.0f%%", "已用 %.0f%%"), used))
+                        .font(.system(size: 7.8))
+                        .foregroundColor(.white.opacity(0.4))
+                }
+                Spacer()
+                Text(window.resetsAt.map { L("Resets \(formatAccountDate($0))", "\(formatAccountDate($0)) 重置") } ?? L("Reset time unavailable", "重置时间未返回"))
+                    .font(.system(size: 7.8, weight: .medium, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.52))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.58)
+            }
+        }
+        .padding(7)
+        .background(RoundedRectangle(cornerRadius: 7).fill(Color.white.opacity(0.025)))
+    }
+
+    private var resetCard: some View {
+        HStack(spacing: 8) {
+            VStack(alignment: .center, spacing: 3) {
+                Text(L("RESET CREDITS AVAILABLE", "可用重置次数"))
+                    .font(.system(size: 8, weight: .bold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.42))
+                Text(snapshot.resetCreditCount.map(String.init) ?? "—")
+                    .font(.system(size: 15, weight: .heavy, design: .rounded))
+                    .foregroundColor(.cyan)
+            }
+
+            Divider().frame(height: 30).overlay(Color.white.opacity(0.08))
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(L("NEXT CREDIT EXPIRY", "重置次数到期"))
+                    .font(.system(size: 8, weight: .bold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.42))
+                Text(L("Available on demand", "按需可用"))
+                    .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.75))
+            }
+            Spacer()
+        }
+        .padding(9)
+        .background(cardBackground)
+    }
+
+    private var accountFactsCard: some View {
+        VStack(spacing: 5) {
+            factRow(L("Credits", "Credits"), snapshot.creditsBalance.map { "\($0) credits" } ?? "—")
+            factRow(L("Rate limit state", "限额状态"), L("Normal", "正常"))
+            factRow(L("Spend control", "消费控制"), L("Normal", "正常"))
+            factRow(L("OpenAI auth", "OpenAI 认证"), L("Not required", "不需要"))
+            factRow(L("Last refreshed", "最后刷新"), formatAccountDate(snapshot.fetchedAt))
+        }
+        .padding(9)
+        .background(cardBackground)
+    }
+
+    private func factRow(_ title: String, _ value: String) -> some View {
+        HStack {
+            Text(title)
+                .font(.system(size: 8.5, weight: .medium))
+                .foregroundColor(.white.opacity(0.45))
+            Spacer()
+            Text(value)
+                .font(.system(size: 8.5, weight: .semibold, design: .rounded))
+                .foregroundColor(.white.opacity(0.78))
+                .lineLimit(1)
+        }
+    }
+
+    private var cardBackground: some View {
+        RoundedRectangle(cornerRadius: 10)
+            .fill(Color.white.opacity(0.04))
+            .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.white.opacity(0.08), lineWidth: 0.8))
+    }
+
+    private func planDisplayName(_ raw: String?) -> String {
+        switch raw?.lowercased() {
+        case "free": return "Free"
+        case "go": return "Go"
+        case "plus": return "Plus"
+        case "pro": return "Pro"
+        case "team": return "Team"
+        case "business": return "Business"
+        case "enterprise": return "Enterprise"
+        case "edu": return "Edu"
+        case .some(let value): return value.replacingOccurrences(of: "_", with: " ").capitalized
+        case .none: return L("Not reported", "未返回")
+        }
+    }
+
+    private func accountTypeDisplayName(_ raw: String?) -> String {
+        switch raw {
+        case "chatgpt": return "ChatGPT"
+        case "apiKey": return "API Key"
+        case "amazonBedrock": return "Bedrock"
+        default: return raw ?? L("Account", "账户")
+        }
+    }
+}
+
+private struct ShowcaseStrategyModeCard: View {
+    let snapshot: StrategyModeSnapshot
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(spacing: 5) {
+                Label(L("Global strategy mode", "全局策略模式"), systemImage: "slider.horizontal.3")
+                    .font(.system(size: 9.5, weight: .bold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.82))
+                Spacer()
+                if let routing = snapshot.routing, !routing.isEmpty {
+                    Text(localizedRoutingName(routing))
+                        .font(.system(size: 6.8, weight: .bold, design: .rounded))
+                        .foregroundColor(.white.opacity(0.42))
+                }
+                Text(localizedConfiguredName)
+                    .font(.system(size: 7.5, weight: .heavy, design: .rounded))
+                    .foregroundColor(.cyan)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Capsule().fill(Color.cyan.opacity(0.12)))
+
+                Image(systemName: "arrow.clockwise")
+                    .font(.system(size: 8, weight: .semibold))
+                    .foregroundColor(.white.opacity(0.32))
+            }
+
+            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 6) {
+                ForEach(snapshot.profiles) { profile in
+                    strategyTile(profile)
+                }
+            }
+
+            HStack(alignment: .top, spacing: 4) {
+                Image(systemName: "info.circle")
+                    .font(.system(size: 7.5))
+                    .padding(.top, 1)
+                Text(L("Repository policy can override this global strategy for individual tasks.", "具体仓库策略可以覆盖此全局模式。"))
+                    .font(.system(size: 7.5))
+            }
+            .foregroundColor(.white.opacity(0.35))
+        }
+        .padding(9)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color.white.opacity(0.04))
+                .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.white.opacity(0.08), lineWidth: 0.8))
+        )
+    }
+
+    private var localizedConfiguredName: String {
+        snapshot.profiles.first(where: { $0.name == snapshot.configured })?.localizedName
+            ?? snapshot.configured.capitalized
+    }
+
+    private func localizedRoutingName(_ routing: String) -> String {
+        switch routing.lowercased() {
+        case "adaptive": return L("Adaptive", "自适应")
+        case "direct": return L("Direct", "直接")
+        case "delegate": return L("Delegate", "委派")
+        default: return routing.capitalized
+        }
+    }
+
+    private func strategyTile(_ profile: StrategyProfileInfo) -> some View {
+        let selected = profile.name == snapshot.configured
+        return VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 4) {
+                Image(systemName: profile.iconName)
+                    .font(.system(size: 8.5, weight: .semibold))
+                    .foregroundColor(profile.accent)
+                Text(profile.localizedName)
+                    .font(.system(size: 8.8, weight: .bold, design: .rounded))
+                    .foregroundColor(.white.opacity(selected ? 0.95 : 0.72))
+                Spacer()
+                if selected {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 8.5))
+                        .foregroundColor(profile.accent)
+                }
+            }
+            Text(profile.localizedDescription)
+                .font(.system(size: 7.3))
+                .foregroundColor(.white.opacity(0.38))
+                .lineLimit(2)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(7)
+        .frame(maxWidth: .infinity, minHeight: 52, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 7)
+                .fill(selected ? profile.accent.opacity(0.12) : Color.white.opacity(0.025))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 7)
+                        .stroke(selected ? profile.accent.opacity(0.45) : Color.white.opacity(0.055), lineWidth: 0.7)
+                )
+        )
+    }
+}
+
+private struct ShowcaseAutostartCard: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(spacing: 7) {
+                Image(systemName: "power.circle.fill")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(.green)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(L("Launch at Login", "登录时启动"))
+                        .font(.system(size: 9.5, weight: .bold, design: .rounded))
+                        .foregroundColor(.white.opacity(0.84))
+                    Text(L("Enabled · starts automatically on next login", "已开启 · 下次登录自动启动"))
+                        .font(.system(size: 7.6))
+                        .foregroundColor(.white.opacity(0.42))
+                }
+
+                Spacer()
+
+                HStack(spacing: 3) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 7.5, weight: .bold))
+                    Text(L("ON", "开"))
+                        .font(.system(size: 7.2, weight: .heavy, design: .rounded))
+                }
+                .foregroundColor(.green)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 3)
+                .background(Capsule().fill(Color.green.opacity(0.14)))
+
+                Toggle("", isOn: .constant(true))
+                    .labelsHidden()
+                    .toggleStyle(.switch)
+                    .controlSize(.mini)
+                    .tint(.green)
+                    .disabled(true)
+            }
+
+            HStack(spacing: 4) {
+                Image(systemName: "info.circle")
+                    .font(.system(size: 7.2))
+                Text(L(
+                    "Registered as a user LaunchAgent; enabling it affects the next login and does not restart the current widget.",
+                    "使用用户级 LaunchAgent 注册；开启后从下次登录生效，不会重启当前悬浮窗。"
+                ))
+                    .font(.system(size: 7.2))
+            }
+            .foregroundColor(.white.opacity(0.3))
+        }
+        .padding(9)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color.white.opacity(0.04))
+                .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.white.opacity(0.08), lineWidth: 0.8))
         )
     }
 }
@@ -409,7 +788,8 @@ struct BannerPromoView: View {
                 }
                 .frame(width: 560)
 
-                SummaryView(state: stateInspector, isFullHeight: true)
+                SummaryView(state: stateInspector, isFullHeight: false)
+                    .frame(width: ShowcaseMetrics.panelWidth, height: ShowcaseMetrics.panelHeight)
                     .scaleEffect(0.92)
                     .shadow(color: Color.black.opacity(0.5), radius: 30, x: 0, y: 15)
             }
@@ -500,7 +880,8 @@ struct DesktopScenePromoView: View {
                 .offset(x: -180, y: 15)
                 .shadow(color: Color.black.opacity(0.5), radius: 30, x: -10, y: 15)
 
-            SummaryView(state: stateInspector, isFullHeight: true)
+            SummaryView(state: stateInspector, isFullHeight: false)
+                .frame(width: ShowcaseMetrics.panelWidth, height: ShowcaseMetrics.panelHeight)
                 .scaleEffect(0.72)
                 .offset(x: 320, y: 15)
                 .shadow(color: Color.black.opacity(0.6), radius: 35, x: 5, y: 15)
@@ -576,10 +957,6 @@ func runGenerator() {
     stateBubble.isExpanded = false
     stateBubble.isPrivacyMode = true
 
-    // AccountSnapshotService bounds the complete app-server flow at 10 seconds.
-    // Give the Account view enough time to leave its loading state before capture.
-    let accountSettleTime = AccountSnapshotService.outerTimeout + 0.75
-
     renderViewToPNG(
         view: FlowPilotLogoView(size: 512, showGlow: true, withBolt: true),
         scale: 2.0,
@@ -643,14 +1020,12 @@ func runGenerator() {
         outputPath: "docs/assets/screenshots/analytics_window.png"
     )
 
-    // Render Account captures later and with a real hosting lifecycle, because
-    // the view fetches live Codex account/quota data on appearance.
+    // Account is deterministic mock data in the showcase pipeline, so it renders
+    // immediately through ImageRenderer instead of waiting on app-server/CLI I/O.
     renderViewToPNG(
         view: AccountPromoCard(state: stateAccount, isFullHeight: true),
         targetWidth: ShowcaseMetrics.panelWidth,
         scale: 2.0,
-        requiresLiveHosting: true,
-        settleTime: accountSettleTime,
         outputPath: "docs/assets/screenshots/account_full.png"
     )
 
@@ -659,8 +1034,6 @@ func runGenerator() {
         targetWidth: ShowcaseMetrics.panelWidth,
         targetHeight: ShowcaseMetrics.panelHeight,
         scale: 2.0,
-        requiresLiveHosting: true,
-        settleTime: accountSettleTime,
         outputPath: "docs/assets/screenshots/account_window.png"
     )
 
@@ -673,8 +1046,6 @@ func runGenerator() {
             stateBubble: stateBubble
         ),
         scale: 2.0,
-        requiresLiveHosting: true,
-        settleTime: accountSettleTime,
         outputPath: "docs/assets/promo/flowpilot_promo_poster.png"
     )
 

--- a/scripts/menu.py
+++ b/scripts/menu.py
@@ -360,6 +360,62 @@ def run_overlay_build() -> bool:
         return False
 
 
+def run_showcase_generation() -> bool:
+    src = get_source_dir()
+    sources_dir = src / "apps" / "macos-overlay" / "Sources"
+    showcase_script = src / "scripts" / "generate_showcase.swift"
+    output_bin = src / "bin" / "generate_showcase"
+
+    if not sources_dir.exists():
+        print(f"\n{style.RED}❌ {T('Overlay source directory not found', '未找到浮窗源码目录')}: {sources_dir}{style.RESET}")
+        return False
+    if not showcase_script.exists():
+        print(f"\n{style.RED}❌ {T('Showcase generator not found', '未找到 Showcase 生成脚本')}: {showcase_script}{style.RESET}")
+        return False
+
+    swift_files = sorted(
+        p for p in sources_dir.rglob("*.swift")
+        if p.name != "main.swift"
+    )
+    if not swift_files:
+        print(f"\n{style.RED}❌ {T('No Swift source files found for showcase generation.', '未找到可用于生成 Showcase 的 Swift 源码。')}{style.RESET}")
+        return False
+
+    output_bin.parent.mkdir(parents=True, exist_ok=True)
+    compile_cmd = [
+        "swiftc",
+        "-framework", "Cocoa",
+        "-framework", "SwiftUI",
+        "-framework", "Combine",
+        *[str(path) for path in swift_files],
+        str(showcase_script),
+        "-o", str(output_bin),
+    ]
+
+    print(f"\n{style.BOLD}{T('🖼 Rebuilding showcase and promotional images...', '🖼 正在重新生成 Showcase / 宣传图...')}{style.RESET}")
+    print(f"{style.DIM}{T('Compiling the native SwiftUI showcase renderer first.', '先编译原生 SwiftUI Showcase 渲染器。')}{style.RESET}\n")
+    try:
+        compile_res = subprocess.run(compile_cmd, cwd=src)
+        if compile_res.returncode != 0:
+            print(f"\n{style.RED}❌ {T('Showcase renderer build failed. Please check the logs above.', 'Showcase 渲染器编译失败，请检查上方日志。')}{style.RESET}")
+            return False
+
+        generate_res = subprocess.run([str(output_bin)], cwd=src)
+        if generate_res.returncode != 0:
+            print(f"\n{style.RED}❌ {T('Showcase generation failed. Please check the logs above.', 'Showcase 图片生成失败，请检查上方日志。')}{style.RESET}")
+            return False
+    except FileNotFoundError as exc:
+        print(f"\n{style.RED}❌ {T('Required command not found', '缺少必要命令')}: {exc}{style.RESET}")
+        return False
+    except Exception as exc:
+        print(f"\n{style.RED}❌ {T('Showcase generation error', '执行 Showcase 生成失败')}: {exc}{style.RESET}")
+        return False
+
+    print(f"\n{style.GREEN}✨ {T('Showcase generation completed.', 'Showcase / 宣传图生成完成。')}{style.RESET}")
+    print(f"{style.DIM}{T('Updated:', '已更新:')} docs/assets/screenshots/ · docs/assets/promo/{style.RESET}")
+    return True
+
+
 def handle_manage_overlay() -> None:
     if sys.platform != "darwin":
         print(f"\n{style.YELLOW}⚠️ {T('The native FlowPilot floating window is available only on macOS.', 'FlowPilot 原生悬浮窗仅支持 macOS 系统。')}{style.RESET}")
@@ -396,6 +452,7 @@ def handle_manage_overlay() -> None:
         if is_running:
             print(f"  [{style.CYAN}4{style.RESET}] {T('🔄 Toggle expanded / collapsed', '🔄 切换展开 / 折叠 (Toggle)')}")
             print(f"  [{style.CYAN}5{style.RESET}] {T('⚡ Push latest data and expand', '⚡️ 发送最新数据并展开 (Push Last Summary)')}")
+        print(f"  [{style.CYAN}6{style.RESET}] {T('🖼 Regenerate showcase / promotional images', '🖼 重新生成 Showcase / 宣传图')}")
 
         print(f"  [{style.CYAN}0{style.RESET}] 🔙 {T('Back to main menu', '返回主菜单')}\n")
 
@@ -489,6 +546,10 @@ def handle_manage_overlay() -> None:
                 print(f"{style.GREEN}{T('Latest Summary pushed and expanded.', '已向浮窗推送最新 Summary 并展开。')}{style.RESET}")
             except Exception as exc:
                 print(f"{style.RED}{T('Push failed', '推送失败')}: {exc}{style.RESET}")
+            pause_prompt()
+
+        elif choice == "6":
+            run_showcase_generation()
             pause_prompt()
 
         else:

--- a/scripts/menu.py
+++ b/scripts/menu.py
@@ -416,6 +416,11 @@ def run_showcase_generation() -> bool:
     return True
 
 
+def handle_generate_showcase() -> None:
+    run_showcase_generation()
+    pause_prompt()
+
+
 def handle_manage_overlay() -> None:
     if sys.platform != "darwin":
         print(f"\n{style.YELLOW}⚠️ {T('The native FlowPilot floating window is available only on macOS.', 'FlowPilot 原生悬浮窗仅支持 macOS 系统。')}{style.RESET}")
@@ -452,7 +457,6 @@ def handle_manage_overlay() -> None:
         if is_running:
             print(f"  [{style.CYAN}4{style.RESET}] {T('🔄 Toggle expanded / collapsed', '🔄 切换展开 / 折叠 (Toggle)')}")
             print(f"  [{style.CYAN}5{style.RESET}] {T('⚡ Push latest data and expand', '⚡️ 发送最新数据并展开 (Push Last Summary)')}")
-        print(f"  [{style.CYAN}6{style.RESET}] {T('🖼 Regenerate showcase / promotional images', '🖼 重新生成 Showcase / 宣传图')}")
 
         print(f"  [{style.CYAN}0{style.RESET}] 🔙 {T('Back to main menu', '返回主菜单')}\n")
 
@@ -548,10 +552,6 @@ def handle_manage_overlay() -> None:
                 print(f"{style.RED}{T('Push failed', '推送失败')}: {exc}{style.RESET}")
             pause_prompt()
 
-        elif choice == "6":
-            run_showcase_generation()
-            pause_prompt()
-
         else:
             print(f"{style.RED}❌ {T('Invalid option', '无效选项')}{style.RESET}")
             pause_prompt()
@@ -597,12 +597,13 @@ def main_menu() -> int:
             ("7", T("⚡ Local quick Benchmark", "⚡ 本地快速 Benchmark"), "benchmark-local quick"),
             ("8", update_label, "update"),
             ("9", T("🛠️ Repair telemetry history", "🛠️ 修复历史遥测数据"), "telemetry repair"),
+            ("10", T("🖼 Regenerate Showcase / promotional images", "🖼 重新生成 Showcase / 宣传图"), "showcase"),
         ]
         for key, label, command in items:
             print(f"  [{style.CYAN}{key}{style.RESET}] {label} {style.DIM}({command}){style.RESET}")
         print(f"  [{style.CYAN}0{style.RESET}] 🚪 {T('Exit', '退出')}\n")
         try:
-            choice = input(f"{style.CYAN}{T('Enter option [0-9]', '请输入选项 [0-9]')}: {style.RESET}").strip()
+            choice = input(f"{style.CYAN}{T('Enter option [0-10]', '请输入选项 [0-10]')}: {style.RESET}").strip()
         except (KeyboardInterrupt, EOFError):
             print("\n" + T("👋 Exited codex-flow console.", "👋 已退出 codex-flow 控制台。"))
             return 0
@@ -619,12 +620,13 @@ def main_menu() -> int:
             "7": handle_run_benchmark,
             "8": handle_update,
             "9": handle_repair_history,
+            "10": handle_generate_showcase,
         }
         handler = handlers.get(choice)
         if handler:
             handler()
         else:
-            print(f"{style.RED}❌ {T('Invalid option; enter 0-9', '无效选项，请输入 0-9')}{style.RESET}")
+            print(f"{style.RED}❌ {T('Invalid option; enter 0-10', '无效选项，请输入 0-10')}{style.RESET}")
             pause_prompt()
     return 0
 


### PR DESCRIPTION
## What changed
- Restore the original app-wide privacy treatment: sensitive `HoverRevealText` values keep their real text layout and use the same 4.5pt blur as the earlier showcase output.
- Add `drawingGroup()` to bake the privacy blur into an offscreen texture so AppKit-backed captures do not degrade it into skeleton/placeholder bars.
- Restore `ImageRenderer` as the default showcase renderer so SwiftUI blur effects and logical-size × scale output match the previous screenshots.
- Use live AppKit hosting only for Account-containing captures, where `AccountView.onAppear` must start the Codex app-server account/quota request.
- Pin showcase panel dimensions to the production overlay size (`384 × 490 pt`) and explicitly generate 2x captures, avoiding monitor backing-scale drift.
- Re-measure live-hosted full-height content after async Account data settles to avoid loading-state sizing/cropping.
- Wait `AccountSnapshotService.outerTimeout + 0.75s` for Account captures and render them later in the generation sequence.
- Extend the showcase with the Account & Limits surface and add `account_full.png` / `account_window.png`.
- Add main interactive menu option `[10]` for regenerating Showcase / promotional images.
- Keep showcase rendering in dark mode and force privacy mode on showcase states.

## Why
The recent AppKit bitmap snapshot path changed two visible behaviors compared with the prior showcase pipeline: SwiftUI privacy blur could disappear into solid placeholder bars, and output pixel sizing could depend on the current display backing scale. Account also needs a real lifecycle and extra time for its async Codex request.

This change keeps the previous blurred-text appearance and deterministic dimensions for ordinary surfaces, while retaining live hosting only where Account data loading requires it.

## Validation needed
Run the generator on macOS via the interactive menu `[10]` and verify:
- Inspector / History / Analytics sensitive text matches the earlier blurred appearance rather than grey bars or dots.
- `*_window.png` uses the same 384 × 490 pt logical panel size as the real app (2x PNG output).
- Account screenshots contain loaded account/quota data rather than the loading state.
- Poster Account column is populated and privacy blur remains visible.