### PR TITLE
fix(overlay): use weekly quota delta for analytics

### DIFF
--- a/.github/workflows/macos-overlay.yml
+++ b/.github/workflows/macos-overlay.yml
@@ -26,6 +26,13 @@ jobs:
             apps/macos-overlay/Tests/OverlayScreenGeometryTests.swift \
             -o "$RUNNER_TEMP/overlay-runtime-tests"
           "$RUNNER_TEMP/overlay-runtime-tests"
+      - name: Test weekly quota analytics semantics
+        run: |
+          swiftc \
+            apps/macos-overlay/Sources/Models/TelemetryData.swift \
+            apps/macos-overlay/Tests/TelemetryQuotaSelectionTests.swift \
+            -o "$RUNNER_TEMP/telemetry-quota-tests"
+          "$RUNNER_TEMP/telemetry-quota-tests"
       - name: Compile native overlay
         run: bash apps/macos-overlay/build.sh
       - name: Smoke test overlay lifecycle

--- a/apps/macos-overlay/Sources/Models/TelemetryData.swift
+++ b/apps/macos-overlay/Sources/Models/TelemetryData.swift
@@ -652,13 +652,45 @@ public struct TaskRun: Codable, Identifiable {
         }
         return quotaBefore ?? []
     }
+
+    public static let shortQuotaWindowMinutes = 300
+    public static let weeklyQuotaWindowMinutes = 10_080
+
+    private func quotaWindow(durationMinutes: Int) -> QuotaWindow? {
+        return effectiveQuotaWindows.first { $0.windowDurationMins == durationMinutes }
+    }
+
+    public var shortWindowQuotaDelta: Double? {
+        return quotaWindow(durationMinutes: Self.shortQuotaWindowMinutes)?.deltaPercentagePoints
+    }
+
+    public var weeklyQuotaDelta: Double? {
+        return quotaWindow(durationMinutes: Self.weeklyQuotaWindowMinutes)?.deltaPercentagePoints
+    }
+
+    /// Canonical quota movement used by task, project, model, chat and trend analytics.
+    /// Never fall back to the short window: a 5h percentage point is not comparable
+    /// with a weekly percentage point when account capacities differ.
+    public var canonicalQuotaDelta: Double? {
+        return weeklyQuotaDelta
+    }
     
+    /// Backward-compatible name used by existing analytics consumers. Its semantic
+    /// value is now the canonical weekly quota delta, not the first/shortest window.
     public var primaryQuotaDelta: Double? {
-        return effectiveQuotaWindows.first?.deltaPercentagePoints
+        return canonicalQuotaDelta
+    }
+
+    public var shortWindowQuotaRemaining: Double? {
+        return quotaWindow(durationMinutes: Self.shortQuotaWindowMinutes)?.remainingPercent
+    }
+
+    public var weeklyQuotaRemaining: Double? {
+        return quotaWindow(durationMinutes: Self.weeklyQuotaWindowMinutes)?.remainingPercent
     }
     
     public var primaryQuotaRemaining: Double? {
-        return effectiveQuotaWindows.first?.remainingPercent
+        return shortWindowQuotaRemaining
     }
     
     public var aggregatedUsage: TokenUsage {
@@ -793,12 +825,12 @@ public struct TaskRun: Codable, Identifiable {
                 )
             ],
             quotaBefore: [
-                QuotaWindow(slot: "primary", usedPercent: 12.0, windowDurationMins: 5, resetsAt: Date().addingTimeInterval(180).timeIntervalSince1970),
-                QuotaWindow(slot: "secondary", usedPercent: 34.0, windowDurationMins: 60, resetsAt: Date().addingTimeInterval(2400).timeIntervalSince1970)
+                QuotaWindow(slot: "primary", usedPercent: 12.0, windowDurationMins: 300, resetsAt: Date().addingTimeInterval(180).timeIntervalSince1970),
+                QuotaWindow(slot: "secondary", usedPercent: 34.0, windowDurationMins: 10_080, resetsAt: Date().addingTimeInterval(2400).timeIntervalSince1970)
             ],
             quotaChangeDuringRun: [
-                QuotaWindow(slot: "primary", usedPercent: 18.0, windowDurationMins: 5, resetsAt: Date().addingTimeInterval(180).timeIntervalSince1970, deltaPercentagePoints: 6.0),
-                QuotaWindow(slot: "secondary", usedPercent: 39.0, windowDurationMins: 60, resetsAt: Date().addingTimeInterval(2400).timeIntervalSince1970, deltaPercentagePoints: 5.0)
+                QuotaWindow(slot: "primary", usedPercent: 18.0, windowDurationMins: 300, resetsAt: Date().addingTimeInterval(180).timeIntervalSince1970, deltaPercentagePoints: 6.0),
+                QuotaWindow(slot: "secondary", usedPercent: 39.0, windowDurationMins: 10_080, resetsAt: Date().addingTimeInterval(2400).timeIntervalSince1970, deltaPercentagePoints: 5.0)
             ]
         )
     }
@@ -929,7 +961,7 @@ public struct ChatSession: Identifiable {
         var total: Double = 0
         var hasDelta = false
         for r in runs {
-            if let d = r.primaryQuotaDelta {
+            if let d = r.canonicalQuotaDelta {
                 total += d
                 hasDelta = true
             }

--- a/apps/macos-overlay/Tests/TelemetryQuotaSelectionTests.swift
+++ b/apps/macos-overlay/Tests/TelemetryQuotaSelectionTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+// TelemetryData.swift references the app localization helper in an unrelated
+// display-only property. Keep this regression test isolated from UI/Combine.
+func L(_ english: String, _ chinese: String) -> String { english }
+
+@main
+struct TelemetryQuotaSelectionTests {
+    static func main() {
+        testCanonicalDeltaUsesWeeklyWindow()
+        testWindowOrderDoesNotChangeSemantics()
+        testMissingWeeklyWindowDoesNotFallBackToFiveHour()
+        testRemainingMetricsStayExplicit()
+        print("Telemetry quota selection regression tests passed")
+    }
+
+    private static func makeRun(_ windows: [QuotaWindow]) -> TaskRun {
+        TaskRun(
+            sessionId: "quota-test",
+            turnId: UUID().uuidString,
+            status: "completed",
+            quotaChangeDuringRun: windows
+        )
+    }
+
+    private static func testCanonicalDeltaUsesWeeklyWindow() {
+        let run = makeRun([
+            QuotaWindow(
+                slot: "primary",
+                usedPercent: 24.0,
+                windowDurationMins: 300,
+                deltaPercentagePoints: 4.0
+            ),
+            QuotaWindow(
+                slot: "secondary",
+                usedPercent: 40.8,
+                windowDurationMins: 10_080,
+                deltaPercentagePoints: 0.8
+            ),
+        ])
+
+        precondition(run.shortWindowQuotaDelta == 4.0)
+        precondition(run.weeklyQuotaDelta == 0.8)
+        precondition(run.canonicalQuotaDelta == 0.8)
+        precondition(run.primaryQuotaDelta == 0.8)
+    }
+
+    private static func testWindowOrderDoesNotChangeSemantics() {
+        let run = makeRun([
+            QuotaWindow(
+                slot: "secondary",
+                usedPercent: 40.8,
+                windowDurationMins: 10_080,
+                deltaPercentagePoints: 0.8
+            ),
+            QuotaWindow(
+                slot: "primary",
+                usedPercent: 24.0,
+                windowDurationMins: 300,
+                deltaPercentagePoints: 4.0
+            ),
+        ])
+
+        precondition(run.shortWindowQuotaDelta == 4.0)
+        precondition(run.weeklyQuotaDelta == 0.8)
+        precondition(run.canonicalQuotaDelta == 0.8)
+    }
+
+    private static func testMissingWeeklyWindowDoesNotFallBackToFiveHour() {
+        let run = makeRun([
+            QuotaWindow(
+                slot: "primary",
+                usedPercent: 24.0,
+                windowDurationMins: 300,
+                deltaPercentagePoints: 4.0
+            ),
+        ])
+
+        precondition(run.shortWindowQuotaDelta == 4.0)
+        precondition(run.weeklyQuotaDelta == nil)
+        precondition(run.canonicalQuotaDelta == nil)
+        precondition(run.primaryQuotaDelta == nil)
+    }
+
+    private static func testRemainingMetricsStayExplicit() {
+        let run = makeRun([
+            QuotaWindow(
+                slot: "primary",
+                usedPercent: 24.0,
+                windowDurationMins: 300,
+                deltaPercentagePoints: 4.0
+            ),
+            QuotaWindow(
+                slot: "secondary",
+                usedPercent: 40.8,
+                windowDurationMins: 10_080,
+                deltaPercentagePoints: 0.8
+            ),
+        ])
+
+        precondition(run.shortWindowQuotaRemaining == 76.0)
+        precondition(run.weeklyQuotaRemaining == 59.2)
+        // Preserve the legacy UI meaning of primary remaining as the short window.
+        precondition(run.primaryQuotaRemaining == 76.0)
+    }
+}


### PR DESCRIPTION
## Problem
Quota delta analytics implicitly used the first quota window. Because quota windows are ordered shortest-first, this made task/model/project/daily quota movement use the 5h percentage-point delta. That metric is not comparable across different weekly capacities and can also move backward as a rolling 5h window expires.

## Fix
- Select the canonical analytics quota delta explicitly from the 7-day / 10080-minute window.
- Keep 5h delta available separately as `shortWindowQuotaDelta`.
- Add explicit `weeklyQuotaDelta`, `canonicalQuotaDelta`, `shortWindowQuotaRemaining`, and `weeklyQuotaRemaining` semantics.
- Preserve `primaryQuotaDelta` as a backward-compatible alias, but make it return the canonical weekly delta so existing analytics consumers are corrected immediately, including historical run JSON.
- Do not fall back to 5h when weekly data is missing.
- Keep `primaryQuotaRemaining` on its existing short-window meaning to avoid an unrelated UI behavior change.
- Correct preview quota durations to real 300m / 10080m values.

## Regression coverage
Adds a standalone Swift regression test that verifies:
- canonical delta uses weekly rather than 5h,
- input array ordering cannot change the selected metric,
- missing weekly data does not silently fall back to 5h,
- short/weekly remaining metrics stay explicit.

The macOS overlay workflow now compiles and runs this test before building the app.