### PR TITLE
feat: add strategy dispatch master switch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,9 +138,9 @@ jobs:
           & (Join-Path $env:CODEX_FLOW_BIN_DIR 'codex-flow.cmd') status
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           $strategyOutput = (& (Join-Path $env:CODEX_FLOW_BIN_DIR 'codex-flow.cmd') strategy show | Out-String).Trim()
-          if ($strategyOutput -ne 'strategy=efficient routing=adaptive') { throw "unexpected strategy output: $strategyOutput" }
+          if ($strategyOutput -ne 'enabled=true strategy=efficient routing=adaptive') { throw "unexpected strategy output: $strategyOutput" }
           $bareStrategyOutput = (& (Join-Path $env:CODEX_FLOW_BIN_DIR 'codex-flow.cmd') strategy | Out-String).Trim()
-          if ($bareStrategyOutput -ne 'strategy=efficient routing=adaptive') { throw "unexpected bare strategy output: $bareStrategyOutput" }
+          if ($bareStrategyOutput -ne 'enabled=true strategy=efficient routing=adaptive') { throw "unexpected bare strategy output: $bareStrategyOutput" }
           $doctorOutput = (& (Join-Path $env:CODEX_FLOW_BIN_DIR 'codex-flow.cmd') doctor 2>&1 | Out-String)
           $doctorExit = $LASTEXITCODE
           if ($doctorExit -ne 0) { exit $doctorExit }

--- a/apps/macos-overlay/Sources/Views/StrategyModeView.swift
+++ b/apps/macos-overlay/Sources/Views/StrategyModeView.swift
@@ -49,6 +49,7 @@ public struct StrategyProfileInfo: Identifiable, Equatable {
 }
 
 public struct StrategyModeSnapshot {
+    public let enabled: Bool
     public let configured: String
     public let routing: String?
     public let valid: Bool
@@ -85,6 +86,7 @@ public enum StrategyModeService {
             throw serviceError(L("Unable to parse the current strategy.", "无法解析当前策略。"))
         }
 
+        let enabled = (json["enabled"] as? NSNumber)?.boolValue ?? true
         let routing = json["routing"] as? String
         let valid = (json["valid"] as? NSNumber)?.boolValue ?? false
         let profilesOutput = try run(["strategy", "profiles"])
@@ -94,6 +96,7 @@ public enum StrategyModeService {
         }
 
         return StrategyModeSnapshot(
+            enabled: enabled,
             configured: configured,
             routing: routing,
             valid: valid,
@@ -113,6 +116,30 @@ public enum StrategyModeService {
             throw serviceError(L("Strategy change could not be verified.", "策略切换后无法验证配置结果。"))
         }
         return verified
+    }
+
+    public static func setEnabled(_ enabled: Bool) throws -> StrategyModeSnapshot {
+        _ = try run(["strategy", enabled ? "enable" : "disable"])
+        let verified = try load()
+        guard verified.enabled == enabled else {
+            throw serviceError(L(
+                "Strategy master switch change could not be verified.",
+                "策略总开关修改后无法验证配置结果。"
+            ))
+        }
+        return verified
+    }
+
+    public static func armTemporaryBypass() throws {
+        _ = try run(["strategy", "bypass-once"])
+        let pending = try run(["strategy", "bypass-pending"]).stdout
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard pending == "true" else {
+            throw serviceError(L(
+                "Temporary strategy bypass could not be verified.",
+                "临时关闭策略分发后无法验证一次性状态。"
+            ))
+        }
     }
 
     private struct CommandResult {
@@ -225,6 +252,8 @@ public struct StrategyModeCard: View {
     @State private var snapshot: StrategyModeSnapshot?
     @State private var isLoading = false
     @State private var applyingProfile: String?
+    @State private var applyingEnabled = false
+    @State private var showDisableConfirmation = false
     @State private var message: String?
     @State private var isError = false
 
@@ -245,10 +274,10 @@ public struct StrategyModeCard: View {
                     }
                     Text(localizedConfiguredName(snapshot))
                         .font(.system(size: 7.5, weight: .heavy, design: .rounded))
-                        .foregroundColor(snapshot.valid ? .cyan : .orange)
+                        .foregroundColor(statusColor(snapshot))
                         .padding(.horizontal, 6)
                         .padding(.vertical, 2)
-                        .background(Capsule().fill((snapshot.valid ? Color.cyan : Color.orange).opacity(0.12)))
+                        .background(Capsule().fill(statusColor(snapshot).opacity(0.12)))
                 }
                 Button(action: refresh) {
                     Image(systemName: "arrow.clockwise")
@@ -256,7 +285,7 @@ public struct StrategyModeCard: View {
                         .foregroundColor(.white.opacity(0.48))
                 }
                 .buttonStyle(.plain)
-                .disabled(isLoading || applyingProfile != nil)
+                .disabled(isLoading || applyingProfile != nil || applyingEnabled)
             }
 
             if isLoading && snapshot == nil {
@@ -268,6 +297,31 @@ public struct StrategyModeCard: View {
                 }
                 .frame(maxWidth: .infinity, minHeight: 48)
             } else if let snapshot {
+                HStack(spacing: 8) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(L("Enable strategy dispatch", "启用策略分发"))
+                            .font(.system(size: 8.8, weight: .bold, design: .rounded))
+                            .foregroundColor(.white.opacity(0.84))
+                        Text(L(
+                            "Turn off FlowPilot automatic planning and Worker dispatch while keeping the selected profile.",
+                            "关闭 FlowPilot 自动策略规划和 Worker 分发，同时保留当前策略配置。"
+                        ))
+                        .font(.system(size: 7.2))
+                        .foregroundColor(.white.opacity(0.36))
+                    }
+                    Spacer()
+                    if applyingEnabled {
+                        ProgressView().controlSize(.mini)
+                    }
+                    Toggle("", isOn: strategyEnabledBinding)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .controlSize(.mini)
+                        .disabled(isLoading || applyingProfile != nil || applyingEnabled)
+                }
+                .padding(7)
+                .background(RoundedRectangle(cornerRadius: 7).fill(Color.white.opacity(0.025)))
+
                 if !snapshot.valid {
                     Text(L("The stored strategy is invalid. Choose a supported mode below to repair it.", "当前保存的策略无效，请在下方选择一个受支持模式进行修复。"))
                         .font(.system(size: 7.8, weight: .medium))
@@ -276,15 +330,16 @@ public struct StrategyModeCard: View {
 
                 LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 6) {
                     ForEach(snapshot.profiles) { profile in
-                        strategyButton(profile, current: snapshot.configured)
+                        strategyButton(profile, current: snapshot.configured, enabled: snapshot.enabled)
                     }
                 }
+                .opacity(snapshot.enabled ? 1 : 0.42)
 
                 HStack(alignment: .top, spacing: 4) {
                     Image(systemName: "info.circle")
                         .font(.system(size: 7.5))
                         .padding(.top, 1)
-                    Text(L("This changes the global policy through `codex-flow strategy set`. A repository `.codex-flow.toml` remains higher priority for tasks in that repository.", "这里通过 `codex-flow strategy set` 修改全局策略；具体仓库中的 `.codex-flow.toml` 对该仓库任务仍具有更高优先级。"))
+                    Text(L("The master switch has global priority. When enabled, repository `.codex-flow.toml` may still override profile/routing; when disabled, repository policy cannot re-enable automatic dispatch.", "总开关具有全局最高优先级。开启时，仓库 `.codex-flow.toml` 仍可覆盖 profile/routing；关闭时，仓库策略不能重新开启自动分发。"))
                         .font(.system(size: 7.5))
                 }
                 .foregroundColor(.white.opacity(0.35))
@@ -309,10 +364,47 @@ public struct StrategyModeCard: View {
                 .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.white.opacity(0.08), lineWidth: 0.8))
         )
         .onAppear(perform: refresh)
+        .confirmationDialog(
+            L("Keep strategy dispatch available?", "要关闭策略分发吗？"),
+            isPresented: $showDisableConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button(L("Temporary — next task only", "临时关闭 · 仅下一次任务")) {
+                armTemporaryBypass()
+            }
+            Button(L("Permanently disable", "永久关闭"), role: .destructive) {
+                applyEnabled(false)
+            }
+            Button(L("Cancel", "取消"), role: .cancel) {}
+        } message: {
+            Text(L(
+                "If you only want one task to run without FlowPilot distribution, use Temporary. Strategy dispatch will automatically return for the task after that.",
+                "如果只是想让下一次任务不经过 FlowPilot 分发，建议选择临时关闭；该任务消费后会自动恢复策略分发。"
+            ))
+        }
+    }
+
+    private var strategyEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { snapshot?.enabled ?? true },
+            set: { requested in
+                if requested {
+                    applyEnabled(true)
+                } else if snapshot?.enabled == true {
+                    showDisableConfirmation = true
+                }
+            }
+        )
+    }
+
+    private func statusColor(_ snapshot: StrategyModeSnapshot) -> Color {
+        guard snapshot.enabled else { return .white.opacity(0.45) }
+        return snapshot.valid ? .cyan : .orange
     }
 
     private func localizedConfiguredName(_ snapshot: StrategyModeSnapshot) -> String {
-        snapshot.profiles.first(where: { $0.name == snapshot.configured })?.localizedName
+        guard snapshot.enabled else { return L("Off", "已关闭") }
+        return snapshot.profiles.first(where: { $0.name == snapshot.configured })?.localizedName
             ?? snapshot.configured.capitalized
     }
 
@@ -325,7 +417,7 @@ public struct StrategyModeCard: View {
         }
     }
 
-    private func strategyButton(_ profile: StrategyProfileInfo, current: String) -> some View {
+    private func strategyButton(_ profile: StrategyProfileInfo, current: String, enabled: Bool) -> some View {
         let selected = profile.name == current
         let pending = applyingProfile == profile.name
         return Button {
@@ -369,11 +461,11 @@ public struct StrategyModeCard: View {
             )
         }
         .buttonStyle(.plain)
-        .disabled(applyingProfile != nil || selected)
+        .disabled(applyingProfile != nil || applyingEnabled || !enabled || selected)
     }
 
     private func refresh() {
-        guard !isLoading, applyingProfile == nil else { return }
+        guard !isLoading, applyingProfile == nil, !applyingEnabled else { return }
         isLoading = true
         DispatchQueue.global(qos: .userInitiated).async {
             do {
@@ -395,7 +487,7 @@ public struct StrategyModeCard: View {
     }
 
     private func apply(_ profile: String) {
-        guard applyingProfile == nil else { return }
+        guard applyingProfile == nil, !applyingEnabled else { return }
         applyingProfile = profile
         message = nil
         DispatchQueue.global(qos: .userInitiated).async {
@@ -411,6 +503,56 @@ public struct StrategyModeCard: View {
             } catch {
                 DispatchQueue.main.async {
                     applyingProfile = nil
+                    isError = true
+                    message = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func armTemporaryBypass() {
+        guard !applyingEnabled, applyingProfile == nil else { return }
+        applyingEnabled = true
+        message = nil
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                try StrategyModeService.armTemporaryBypass()
+                DispatchQueue.main.async {
+                    applyingEnabled = false
+                    isError = false
+                    message = L(
+                        "Strategy dispatch will be skipped for the next task only.",
+                        "已临时关闭：仅下一次任务跳过策略分发，之后自动恢复。"
+                    )
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    applyingEnabled = false
+                    isError = true
+                    message = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func applyEnabled(_ enabled: Bool) {
+        guard !applyingEnabled, applyingProfile == nil else { return }
+        applyingEnabled = true
+        message = nil
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                let verified = try StrategyModeService.setEnabled(enabled)
+                DispatchQueue.main.async {
+                    snapshot = verified
+                    applyingEnabled = false
+                    isError = false
+                    message = enabled
+                        ? L("Strategy dispatch enabled.", "策略分发已开启。")
+                        : L("Strategy dispatch disabled. FlowPilot will use ordinary Codex execution.", "策略分发已关闭，FlowPilot 将使用普通 Codex 执行。")
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    applyingEnabled = false
                     isError = true
                     message = error.localizedDescription
                 }

--- a/bin/codex-flow
+++ b/bin/codex-flow
@@ -116,6 +116,7 @@ case "$cmd" in
     command -v git >/dev/null 2>&1 || fail "$(cf_t 'git is required for update' '更新需要 git')"
     [[ -f "$POLICY" ]] || fail "$(cf_t 'missing policy; reinstall codex-flow' '策略文件缺失，请重新安装 codex-flow')"
 
+    strategy_enabled="$(read_policy_value strategy enabled "$POLICY")"; [[ -n "$strategy_enabled" ]] || strategy_enabled=true
     strategy_profile="$(read_policy_value strategy profile "$POLICY")"; [[ -n "$strategy_profile" ]] || strategy_profile=efficient
     routing_mode="$(read_policy_value routing mode "$POLICY")"; [[ -n "$routing_mode" ]] || routing_mode=adaptive
     review_modifier="$(read_policy_value modifiers review "$POLICY")"; [[ -n "$review_modifier" ]] || review_modifier=auto
@@ -142,7 +143,7 @@ case "$cmd" in
     fi
     after="$(cat "$src/VERSION" 2>/dev/null || echo unknown)"
 
-    CODEX_FLOW_STRATEGY="$strategy_profile" CODEX_FLOW_ROUTING_MODE="$routing_mode" \
+    CODEX_FLOW_STRATEGY_ENABLED="$strategy_enabled" CODEX_FLOW_STRATEGY="$strategy_profile" CODEX_FLOW_ROUTING_MODE="$routing_mode" \
     CODEX_FLOW_REVIEW_MODIFIER="$review_modifier" CODEX_FLOW_FANOUT_MODIFIER="$fanout_modifier" \
     CODEX_FLOW_PARENT_MODEL_POLICY="$parent_policy" CODEX_FLOW_PARENT_MIN_MODEL="$parent_model" CODEX_FLOW_PARENT_MIN_EFFORT="$parent_effort" \
     CODEX_FLOW_WORKER_MODEL_POLICY="$worker_policy" CODEX_FLOW_WORKER_MODEL="$worker_model" CODEX_FLOW_WORKER_MIN_EFFORT="$worker_effort" \

--- a/bin/codex-flow.ps1
+++ b/bin/codex-flow.ps1
@@ -120,6 +120,9 @@ switch ($cmd) {
         if (-not (Get-Command git -ErrorAction SilentlyContinue)) { throw (L 'git is required for update' '更新需要 git') }
         if (-not (Test-Path $Policy)) { throw (L 'missing policy; reinstall codex-flow' '策略文件缺失，请重新安装 codex-flow') }
 
+        $strategyEnabled = Get-PolicyValue strategy enabled
+        if (-not $strategyEnabled) { $strategyEnabled = 'true' }
+        $env:CODEX_FLOW_STRATEGY_ENABLED = $strategyEnabled
         $strategyProfile = Get-PolicyValue strategy profile
         if (-not $strategyProfile) { $strategyProfile = 'efficient' }
         $routingMode = Get-PolicyValue routing mode

--- a/completions/codex-flow.bash
+++ b/completions/codex-flow.bash
@@ -5,7 +5,7 @@ _codex_flow_completion() {
     if [[ "${COMP_CWORD}" -eq 1 ]]; then
         COMPREPLY=( $(compgen -W "$commands" -- "$cur") )
     elif [[ "${COMP_CWORD}" -eq 2 && "${COMP_WORDS[1]}" == "strategy" ]]; then
-        COMPREPLY=( $(compgen -W "show profiles set routing plan" -- "$cur") )
+        COMPREPLY=( $(compgen -W "show profiles enabled enable disable set routing plan" -- "$cur") )
     elif [[ "${COMP_CWORD}" -eq 3 && "${COMP_WORDS[1]}" == "strategy" && "${COMP_WORDS[2]}" == "set" ]]; then
         COMPREPLY=( $(compgen -W "efficient balanced quality speed" -- "$cur") )
     elif [[ "${COMP_CWORD}" -eq 3 && "${COMP_WORDS[1]}" == "strategy" && "${COMP_WORDS[2]}" == "routing" ]]; then

--- a/completions/codex-flow.zsh
+++ b/completions/codex-flow.zsh
@@ -21,7 +21,7 @@ _codex_flow() {
     if (( CURRENT == 2 )); then
         _describe 'command' commands
     elif (( CURRENT == 3 )) && [[ "${words[2]}" == strategy ]]; then
-        _describe 'strategy command' '(show profiles set routing plan)'
+        _describe 'strategy command' '(show profiles enabled enable disable set routing plan)'
     elif (( CURRENT == 4 )) && [[ "${words[2]}" == strategy && "${words[3]}" == set ]]; then
         _describe 'strategy profile' '(efficient balanced quality speed)'
     elif (( CURRENT == 4 )) && [[ "${words[2]}" == strategy && "${words[3]}" == routing ]]; then

--- a/docs/configuration.en.md
+++ b/docs/configuration.en.md
@@ -31,6 +31,7 @@ schema_version = 4
 language = "auto"
 
 [strategy]
+enabled = true
 profile = "efficient"
 
 [routing]
@@ -76,6 +77,7 @@ The asymmetric reasoning defaults are deliberate: the expensive high-capability 
 Schema-v3 policies remain semantically compatible. Missing strategy/routing/modifier sections resolve to:
 
 ```text
+strategy_enabled = true
 strategy = efficient
 routing = adaptive
 review = auto
@@ -90,6 +92,8 @@ Installer/update migrates to schema v4 while preserving supported existing value
 ---
 
 ## Policy precedence
+
+`[strategy].enabled` is a global master gate above normal strategy precedence. When `false`, FlowPilot does not build a TaskProfile, compile an ExecutionPlan, or automatically dispatch Workers. Repository policy and current-task overrides cannot re-enable it. Stored profile/routing/modifier values are retained and resume when the switch is enabled again.
 
 ```text
 hard runtime / safety ceilings
@@ -106,6 +110,18 @@ Task-level overrides can choose strategy/routing/modifiers but cannot raise a re
 ## Strategy, routing, and modifiers
 
 ### `[strategy]`
+
+`enabled` controls FlowPilot automatic strategy dispatch and defaults to `true`:
+
+```bash
+codex-flow strategy enabled
+codex-flow strategy disable
+codex-flow strategy enable
+```
+
+Disabling it turns off **codex-flow automatic planning and dispatch only**. It does not change Codex's native `[agents].enabled`, so explicit native-subagent use remains available.
+
+Repository `.codex-flow.toml` may override profile/routing/modifiers while the master switch is enabled, but it cannot override a global `enabled = false`. This prevents a repository from silently re-enabling distribution after the user turned it off globally.
 
 - `efficient` — minimize expensive Parent use and total waste while offloading deep execution to efficient Workers.
 - `balanced` — balance quality, quota, and wall-clock latency with moderate safe Worker fan-out.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,7 @@ schema_version = 4
 language = "auto"
 
 [strategy]
+enabled = true
 profile = "efficient"
 
 [routing]
@@ -76,6 +77,7 @@ source = "hooks+app-server"
 旧 schema v3 缺少策略/路由/Modifier 字段时，语义兼容为：
 
 ```text
+strategy_enabled = true
 strategy = efficient
 routing = adaptive
 review = auto
@@ -90,6 +92,8 @@ quality_intent = normal
 ---
 
 ## 配置优先级
+
+`[strategy].enabled` 是全局总开关。它位于下面的普通策略优先级之上：当值为 `false` 时，FlowPilot 不构造 TaskProfile、不编译 ExecutionPlan、也不做自动 Worker 分发；仓库策略和当前任务覆盖都不能重新开启它。关闭时 profile/routing/modifier 配置仍会保留，重新开启后继续生效。
 
 Planner 按以下优先级解析：
 
@@ -110,6 +114,18 @@ Planner 按以下优先级解析：
 三个维度彼此正交。
 
 ### `[strategy]`
+
+`enabled`：FlowPilot 自动策略分发总开关，默认 `true`。可通过 CLI 直接控制：
+
+```bash
+codex-flow strategy enabled
+codex-flow strategy disable
+codex-flow strategy enable
+```
+
+关闭只会停用 **codex-flow 自动规划与自动分发**，不会修改 Codex 原生 `[agents].enabled`，因此不会剥夺用户显式使用原生子 Agent 的能力。
+
+仓库 `.codex-flow.toml` 可以在总开关开启时覆盖 `profile` / routing / modifiers，但不能覆盖全局 `enabled = false`。这可以避免用户全局关闭后，进入某个仓库又被静默重新开启。
 
 `profile` 支持：
 

--- a/install.ps1
+++ b/install.ps1
@@ -45,6 +45,7 @@ $DefaultWorkerModel = Get-TomlValue $defaultsText 'models' 'worker_model'
 $DefaultWorkerPolicy = Get-TomlValue $defaultsText 'models' 'worker_policy'
 $DefaultParentPolicy = Get-TomlValue $defaultsText 'models' 'parent_policy'
 $DefaultParentMinModel = Get-TomlValue $defaultsText 'models' 'parent_min_model'
+$DefaultStrategyEnabled = Get-TomlValue $defaultsText 'strategy' 'enabled'
 $DefaultStrategy = Get-TomlValue $defaultsText 'strategy' 'profile'
 $DefaultRoutingMode = Get-TomlValue $defaultsText 'routing' 'mode'
 $DefaultReviewModifier = Get-TomlValue $defaultsText 'modifiers' 'review'
@@ -63,6 +64,7 @@ $DefaultTelemetryEnabled = Get-TomlValue $defaultsText 'telemetry' 'enabled'
 $DefaultTelemetryNotifications = Get-TomlValue $defaultsText 'telemetry' 'notifications'
 $DefaultTelemetryRetentionDays = Get-TomlValue $defaultsText 'telemetry' 'retention_days'
 
+$ExistingStrategyEnabled = Existing-OrDefault $existingText 'strategy' 'enabled' $DefaultStrategyEnabled
 $ExistingStrategy = Existing-OrDefault $existingText 'strategy' 'profile' $DefaultStrategy
 $ExistingRouting = Existing-OrDefault $existingText 'routing' 'mode' $DefaultRoutingMode
 $ExistingReview = Existing-OrDefault $existingText 'modifiers' 'review' $DefaultReviewModifier
@@ -91,6 +93,7 @@ $ExistingUpdateNotifyCli = Existing-OrDefault $existingText 'update' 'notify_cli
 $ExistingUpdateNotifyApp = Existing-OrDefault $existingText 'update' 'notify_app' 'true'
 $ExistingUpdateAutoInstall = Existing-OrDefault $existingText 'update' 'auto_install' 'false'
 
+$StrategyEnabled = if ($env:CODEX_FLOW_STRATEGY_ENABLED) { $env:CODEX_FLOW_STRATEGY_ENABLED } else { $ExistingStrategyEnabled }
 $StrategyProfile = if ($env:CODEX_FLOW_STRATEGY) { $env:CODEX_FLOW_STRATEGY } else { $ExistingStrategy }
 $RoutingMode = if ($env:CODEX_FLOW_ROUTING_MODE) { $env:CODEX_FLOW_ROUTING_MODE } else { $ExistingRouting }
 $ReviewModifier = if ($env:CODEX_FLOW_REVIEW_MODIFIER) { $env:CODEX_FLOW_REVIEW_MODIFIER } else { $ExistingReview }
@@ -125,6 +128,7 @@ if (Test-Path $Policy) {
 }
 $UiLanguage = (& python3 $Localization --normalize $UiLanguage | Out-String).Trim()
 
+if ($StrategyEnabled -notin @('true','false')) { throw 'CODEX_FLOW_STRATEGY_ENABLED must be true or false' }
 if ($StrategyProfile -notin @('efficient','balanced','quality','speed')) { throw 'CODEX_FLOW_STRATEGY must be efficient, balanced, quality, or speed' }
 if ($RoutingMode -notin @('adaptive','direct','delegate')) { throw 'CODEX_FLOW_ROUTING_MODE must be adaptive, direct, or delegate' }
 if ($ReviewModifier -notin @('auto','standard','strict')) { throw 'CODEX_FLOW_REVIEW_MODIFIER must be auto, standard, or strict' }
@@ -180,6 +184,7 @@ schema_version = 4
 language = "$UiLanguage"
 
 [strategy]
+enabled = $StrategyEnabled
 profile = "$StrategyProfile"
 
 [routing]
@@ -269,7 +274,7 @@ Write-Host (L '  +-- Summary ---------------------------------------------------
 Write-Host "  |  * Policy:     $dispPolicy"
 Write-Host "  |  * CLI:        $dispBin"
 Write-Host "  |  * Skill:      FlowPilot (flow-pilot)"
-Write-Host "  |  * Strategy:   $StrategyProfile / $RoutingMode"
+Write-Host "  |  * Strategy:   $StrategyProfile / $RoutingMode (enabled=$StrategyEnabled)"
 Write-Host "  |  * Modifiers:  review=$ReviewModifier / fanout=$FanoutModifier"
 Write-Host "  |  * Models:     parent ($ParentModelPolicy) -> worker ($WorkerModel)"
 Write-Host "  |  * Language:   $UiLanguage (effective: $UiLang)"

--- a/install.sh
+++ b/install.sh
@@ -51,6 +51,7 @@ DEFAULT_WORKER_MODEL="$(read_default models worker_model)"
 DEFAULT_WORKER_POLICY="$(read_default models worker_policy)"
 DEFAULT_PARENT_POLICY="$(read_default models parent_policy)"
 DEFAULT_PARENT_MIN_MODEL="$(read_default models parent_min_model)"
+DEFAULT_STRATEGY_ENABLED="$(read_default strategy enabled)"
 DEFAULT_STRATEGY="$(read_default strategy profile)"
 DEFAULT_ROUTING_MODE="$(read_default routing mode)"
 DEFAULT_REVIEW_MODIFIER="$(read_default modifiers review)"
@@ -69,6 +70,7 @@ DEFAULT_TELEMETRY_ENABLED="$(read_default telemetry enabled)"
 DEFAULT_TELEMETRY_NOTIFICATIONS="$(read_default telemetry notifications)"
 DEFAULT_TELEMETRY_RETENTION_DAYS="$(read_default telemetry retention_days)"
 
+EXISTING_STRATEGY_ENABLED="$(policy_or_default strategy enabled "$DEFAULT_STRATEGY_ENABLED")"
 EXISTING_STRATEGY="$(policy_or_default strategy profile "$DEFAULT_STRATEGY")"
 EXISTING_ROUTING="$(policy_or_default routing mode "$DEFAULT_ROUTING_MODE")"
 EXISTING_REVIEW="$(policy_or_default modifiers review "$DEFAULT_REVIEW_MODIFIER")"
@@ -97,6 +99,7 @@ EXISTING_UPDATE_NOTIFY_CLI="$(policy_or_default update notify_cli true)"
 EXISTING_UPDATE_NOTIFY_APP="$(policy_or_default update notify_app true)"
 EXISTING_UPDATE_AUTO_INSTALL="$(policy_or_default update auto_install false)"
 
+STRATEGY_ENABLED="${CODEX_FLOW_STRATEGY_ENABLED:-$EXISTING_STRATEGY_ENABLED}"
 STRATEGY_PROFILE="${CODEX_FLOW_STRATEGY:-$EXISTING_STRATEGY}"
 ROUTING_MODE="${CODEX_FLOW_ROUTING_MODE:-$EXISTING_ROUTING}"
 REVIEW_MODIFIER="${CODEX_FLOW_REVIEW_MODIFIER:-$EXISTING_REVIEW}"
@@ -129,6 +132,7 @@ UI_LANGUAGE="auto"
 if [[ -f "$POLICY" ]]; then UI_LANGUAGE="$(python3 "$LOCALIZATION" --policy "$POLICY" --configured 2>/dev/null || echo auto)"; fi
 UI_LANGUAGE="$(python3 "$LOCALIZATION" --normalize "$UI_LANGUAGE")"
 
+case "$STRATEGY_ENABLED" in true|false) ;; *) echo "CODEX_FLOW_STRATEGY_ENABLED must be true or false" >&2; exit 2 ;; esac
 case "$STRATEGY_PROFILE" in efficient|balanced|quality|speed) ;; *) echo "CODEX_FLOW_STRATEGY must be efficient, balanced, quality, or speed" >&2; exit 2 ;; esac
 case "$ROUTING_MODE" in adaptive|direct|delegate) ;; *) echo "CODEX_FLOW_ROUTING_MODE must be adaptive, direct, or delegate" >&2; exit 2 ;; esac
 case "$REVIEW_MODIFIER" in auto|standard|strict) ;; *) echo "CODEX_FLOW_REVIEW_MODIFIER must be auto, standard, or strict" >&2; exit 2 ;; esac
@@ -182,6 +186,7 @@ schema_version = 4
 language = "$UI_LANGUAGE"
 
 [strategy]
+enabled = $STRATEGY_ENABLED
 profile = "$STRATEGY_PROFILE"
 
 [routing]

--- a/policy/defaults.toml
+++ b/policy/defaults.toml
@@ -13,6 +13,7 @@ worker_model = "gpt-5.6-luna"
 # FlowPilot is the strategy runtime. The default profile preserves the historical
 # codex-flow objective while offloading more deep execution to cheap workers.
 [strategy]
+enabled = true
 profile = "efficient"
 
 # Routing is an execution constraint, not a strategy. Prompt-level explicit

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -147,10 +147,17 @@ def main() -> int:
         else:
             warn(T(f"policy schema is {schema or 'unknown'}; reinstall recommended", f"策略 schema 为 {schema or 'unknown'}；建议重新安装"))
 
+        strategy_enabled = policy_value("strategy", "enabled", "true")
         strategy = policy_value("strategy", "profile", "efficient")
         routing = policy_value("routing", "mode", "adaptive")
         review = policy_value("modifiers", "review", "auto")
         fanout = policy_value("modifiers", "fanout", "auto")
+        if strategy_enabled == "true":
+            ok(T("strategy dispatch: enabled", "策略分发：已启用"))
+        elif strategy_enabled == "false":
+            ok(T("strategy dispatch: disabled by policy", "策略分发：已由策略禁用"))
+        else:
+            fail(T(f"invalid strategy dispatch switch: {strategy_enabled or 'missing'}", f"无效策略分发开关：{strategy_enabled or 'missing'}"))
         if strategy in {"efficient", "balanced", "quality", "speed"}:
             ok(T(f"strategy profile: {strategy}", f"执行策略：{strategy}"))
         else:

--- a/scripts/strategy_runtime.py
+++ b/scripts/strategy_runtime.py
@@ -12,6 +12,7 @@ import argparse
 import json
 import os
 import re
+import sys
 from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
 from typing import Any, Iterable
@@ -29,6 +30,7 @@ except ImportError:  # pragma: no cover - standalone installs always bundle it
 CODEX_HOME = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
 DEFAULT_POLICY = CODEX_HOME / "codex-flow.toml"
 REPO_POLICY_NAME = ".codex-flow.toml"
+TEMPORARY_BYPASS_NAME = ".strategy-bypass-once"
 
 STRATEGIES = strategy_names()
 ROUTING_MODES = ("adaptive", "direct", "delegate")
@@ -145,6 +147,7 @@ class PolicySnapshot:
 
 @dataclass(frozen=True)
 class ResolvedPolicy:
+    enabled: bool
     strategy: str
     routing: str
     modifiers: Modifiers
@@ -258,6 +261,33 @@ def _policy_int(path: Path | None, section: str, key: str, default: int) -> int:
         return default
 
 
+def _policy_bool(path: Path | None, section: str, key: str, default: bool, *, strict: bool = False) -> bool:
+    if strict and path is not None:
+        try:
+            text = path.read_text(encoding="utf-8-sig")
+        except OSError:
+            return default
+        match = _section_body(text, section)
+        if not match:
+            return default
+        key_match = re.search(rf"(?m)^\s*{re.escape(key)}\s*=\s*(.*?)\s*$", match.group(1))
+        if not key_match:
+            return default
+        raw = re.sub(r"\s+#.*$", "", key_match.group(1)).strip()
+        if len(raw) >= 2 and raw[0] == raw[-1] == '"':
+            raw = raw[1:-1]
+    else:
+        raw = policy_value(path, section, key, "true" if default else "false")
+    raw = raw.strip().lower()
+    if raw in {"1", "true", "yes", "on"}:
+        return True
+    if raw in {"0", "false", "no", "off"}:
+        return False
+    if strict:
+        raise ValueError(f"invalid [{section}].{key}: {raw or '<empty>'}; expected true or false")
+    return default
+
+
 def _release_value(section: str, key: str, fallback: str = "") -> str:
     return policy_value(_release_defaults_path(), section, key, fallback)
 
@@ -266,16 +296,20 @@ def _release_int(section: str, key: str, fallback: int) -> int:
     return _policy_int(_release_defaults_path(), section, key, fallback)
 
 
+def _release_bool(section: str, key: str, fallback: bool) -> bool:
+    return _policy_bool(_release_defaults_path(), section, key, fallback)
+
+
 def _quoted(value: str) -> str:
     return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
 
 
-def set_policy_value(path: Path, section: str, key: str, value: str) -> None:
+def set_policy_value(path: Path, section: str, key: str, value: str, *, quote: bool = True) -> None:
     if not path.exists():
         raise FileNotFoundError(f"policy not found: {path}")
     text = path.read_text(encoding="utf-8-sig")
     match = _section_body(text, section)
-    line = f"{key} = {_quoted(value)}"
+    line = f"{key} = {_quoted(value) if quote else value}"
     if match:
         body = match.group(1)
         key_re = re.compile(rf"(?m)^\s*{re.escape(key)}\s*=.*$")
@@ -396,6 +430,13 @@ def _raise_capability_floors(base: PolicySnapshot, repo: Path | None) -> PolicyS
 def resolve_policy(user_policy: Path, repo_policy: Path | None = None) -> ResolvedPolicy:
     """Resolve release + user + already-selected repository policy."""
     repo = repo_policy
+    enabled = _policy_bool(
+        user_policy,
+        "strategy",
+        "enabled",
+        _release_bool("strategy", "enabled", True),
+        strict=True,
+    )
     strategy = policy_value(user_policy, "strategy", "profile", _release_value("strategy", "profile"))
     routing = policy_value(user_policy, "routing", "mode", _release_value("routing", "mode"))
     review = policy_value(user_policy, "modifiers", "review", _release_value("modifiers", "review"))
@@ -422,6 +463,7 @@ def resolve_policy(user_policy: Path, repo_policy: Path | None = None) -> Resolv
                 pass
 
     resolved = ResolvedPolicy(
+        enabled=enabled,
         strategy=strategy,
         routing=routing,
         modifiers=Modifiers(review=review, fanout=fanout),
@@ -801,6 +843,56 @@ def compile_plan(
     )
 
 
+
+def _temporary_bypass_path() -> Path:
+    return CODEX_HOME / "codex-flow" / TEMPORARY_BYPASS_NAME
+
+
+def arm_temporary_bypass() -> None:
+    """Arm a one-shot strategy bypass without mutating persistent policy."""
+    path = _temporary_bypass_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        temporary.write_text("1\n", encoding="utf-8")
+        os.replace(temporary, path)
+    finally:
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def temporary_bypass_pending() -> bool:
+    return _temporary_bypass_path().exists()
+
+
+def consume_temporary_bypass() -> bool:
+    """Atomically consume the token. At most one concurrent task can succeed."""
+    path = _temporary_bypass_path()
+    claim = path.with_name(f".{path.name}.{os.getpid()}.claim")
+    try:
+        os.replace(path, claim)
+    except FileNotFoundError:
+        return False
+    try:
+        return True
+    finally:
+        try:
+            claim.unlink()
+        except FileNotFoundError:
+            pass
+
+def configured_strategy_enabled(path: Path) -> bool:
+    return _policy_bool(
+        path,
+        "strategy",
+        "enabled",
+        _release_bool("strategy", "enabled", True),
+        strict=True,
+    )
+
+
 def configured_strategy(path: Path) -> str:
     return policy_value(path, "strategy", "profile", _release_value("strategy", "profile"))
 
@@ -849,6 +941,12 @@ def build_parser() -> argparse.ArgumentParser:
     show.add_argument("--effective", action="store_true")
     show.add_argument("--repo-policy", default="auto")
 
+    sub.add_parser("enabled")
+    sub.add_parser("enable")
+    sub.add_parser("disable")
+    sub.add_parser("bypass-once")
+    sub.add_parser("bypass-pending")
+    sub.add_parser("consume-bypass")
     set_cmd = sub.add_parser("set")
     set_cmd.add_argument("profile", choices=STRATEGIES)
 
@@ -893,8 +991,16 @@ def main(argv: Iterable[str] | None = None) -> int:
     if command == "show":
         if getattr(ns, "effective", False):
             repo, _disabled = _repo_arg(getattr(ns, "repo_policy", "auto"))
-            resolved = resolve_policy(ns.policy, repo)
+            try:
+                resolved = resolve_policy(ns.policy, repo)
+            except ValueError as exc:
+                if getattr(ns, "json", False):
+                    print(json.dumps({"enabled": False, "valid": False, "error": str(exc)}, ensure_ascii=False, indent=2))
+                else:
+                    print(str(exc), file=sys.stderr)
+                return 2
             result = {
+                "enabled": resolved.enabled,
                 "strategy": resolved.strategy,
                 "routing": resolved.routing,
                 "review": resolved.modifiers.review,
@@ -912,12 +1018,56 @@ def main(argv: Iterable[str] | None = None) -> int:
             return 0
         strategy = configured_strategy(ns.policy)
         routing_mode = configured_routing(ns.policy)
-        valid = strategy in STRATEGIES and routing_mode in ROUTING_MODES
+        try:
+            enabled = configured_strategy_enabled(ns.policy)
+            enabled_valid = True
+            enabled_error = None
+        except ValueError as exc:
+            enabled = False
+            enabled_valid = False
+            enabled_error = str(exc)
+        valid = enabled_valid and strategy in STRATEGIES and routing_mode in ROUTING_MODES
         if getattr(ns, "json", False):
-            print(json.dumps({"strategy": strategy, "routing": routing_mode, "valid": valid}, ensure_ascii=False, indent=2))
+            result = {"enabled": enabled, "strategy": strategy, "routing": routing_mode, "valid": valid}
+            if enabled_error is not None:
+                result["error"] = enabled_error
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+        elif enabled_error is not None:
+            print(enabled_error, file=sys.stderr)
         else:
-            print(f"strategy={strategy} routing={routing_mode}")
+            print(f"enabled={'true' if enabled else 'false'} strategy={strategy} routing={routing_mode}")
         return 0 if valid else 2
+    if command == "enabled":
+        try:
+            enabled = configured_strategy_enabled(ns.policy)
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 2
+        print("true" if enabled else "false")
+        return 0
+    if command == "bypass-once":
+        try:
+            enabled = configured_strategy_enabled(ns.policy)
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 2
+        if not enabled:
+            print("strategy dispatch is globally disabled; temporary bypass is unnecessary", file=sys.stderr)
+            return 3
+        arm_temporary_bypass()
+        print("armed=true")
+        return 0
+    if command == "bypass-pending":
+        print("true" if temporary_bypass_pending() else "false")
+        return 0
+    if command == "consume-bypass":
+        print("true" if consume_temporary_bypass() else "false")
+        return 0
+    if command in {"enable", "disable"}:
+        enabled = command == "enable"
+        set_policy_value(ns.policy, "strategy", "enabled", "true" if enabled else "false", quote=False)
+        print(f"enabled={'true' if enabled else 'false'}")
+        return 0
     if command == "set":
         set_policy_value(ns.policy, "strategy", "profile", ns.profile)
         print(f"strategy={ns.profile}")
@@ -931,7 +1081,17 @@ def main(argv: Iterable[str] | None = None) -> int:
         return 0
     if command == "plan":
         repo, _disabled = _repo_arg(ns.repo_policy)
-        resolved = resolve_policy(ns.policy, repo)
+        try:
+            resolved = resolve_policy(ns.policy, repo)
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 3
+        if not resolved.enabled:
+            print(
+                "codex-flow strategy dispatch is disabled; run `codex-flow strategy enable` to re-enable it.",
+                file=sys.stderr,
+            )
+            return 3
         strategy = ns.profile or resolved.strategy
         routing_mode = ns.routing or resolved.routing
         modifiers = Modifiers(

--- a/scripts/ui.py
+++ b/scripts/ui.py
@@ -91,6 +91,7 @@ def status(lang: str) -> int:
     print(box_line(f"• {T('Runtime', '运行时', lang)}:     FlowPilot (flow-pilot)"))
     if POLICY.exists():
         print("  ├─ " + T("Strategy & Model Routing", "策略与模型路由", lang) + " " + "─" * (40 if lang == "en" else 46) + "┤")
+        strategy_enabled = policy_value("strategy", "enabled", "true")
         strategy = policy_value("strategy", "profile", "efficient")
         routing = policy_value("routing", "mode", "adaptive")
         p_policy = policy_value("parent", "model_policy", "unknown")
@@ -102,7 +103,8 @@ def status(lang: str) -> int:
         retention = policy_value("telemetry", "retention_days", "30")
         configured = configured_language(POLICY)
         effective = resolve_language(POLICY)
-        print(box_line(f"• {T('Strategy', '执行策略', lang)}:    {strategy}"))
+        state = "● " + T("enabled", "已启用", lang) if strategy_enabled == "true" else "○ " + T("disabled", "已禁用", lang)
+        print(box_line(f"• {T('Strategy', '执行策略', lang)}:    {strategy} ({state})"))
         print(box_line(f"• {T('Routing', '路由模式', lang)}:     {routing}"))
         print(box_line(f"• {T('Parent', '父 Agent', lang)}:      {p_policy} ({T('min effort', '最低推理', lang)}: {p_effort})"))
         print(box_line(f"• {T('Worker', '子 Agent', lang)}:      {w_model} ({T('min effort', '最低推理', lang)}: {w_effort})"))
@@ -161,6 +163,9 @@ def help_text(lang: str) -> int:
     strategy show               查看持久化 strategy / routing
     strategy profiles           查看 efficient/balanced/quality/speed
     strategy set <profile>      设置默认执行策略
+    strategy enabled            查看策略分发总开关
+    strategy enable             开启 FlowPilot 自动策略分发
+    strategy disable            关闭 FlowPilot 自动策略分发
     strategy routing <mode>     设置 adaptive/direct/delegate 路由约束
     strategy plan [选项]        从结构化 TaskProfile 生成 ExecutionPlan(JSON)
     language [auto|zh|en]       查看或设置界面语言（默认 auto 跟随系统）
@@ -184,6 +189,7 @@ def help_text(lang: str) -> int:
 
   提示:
     默认策略为 efficient，路由为 adaptive；这与旧版 FlowPilot 行为兼容。
+    strategy disable 只关闭 codex-flow 自动分发，不关闭 Codex 原生 Agent 能力。
     对话中的明确策略/路由指令只覆盖当前任务，不修改持久化配置。
 """)
     else:
@@ -198,6 +204,9 @@ Usage: codex-flow <command> [options]
     strategy show               Show persistent strategy / routing
     strategy profiles           List efficient/balanced/quality/speed profiles
     strategy set <profile>      Set the default execution strategy
+    strategy enabled            Show the strategy dispatch master switch
+    strategy enable             Enable FlowPilot automatic strategy dispatch
+    strategy disable            Disable FlowPilot automatic strategy dispatch
     strategy routing <mode>     Set adaptive/direct/delegate routing constraint
     strategy plan [options]     Compile a structured TaskProfile to ExecutionPlan JSON
     language [auto|zh|en]       Show or set UI language (auto follows the system)
@@ -221,6 +230,7 @@ Usage: codex-flow <command> [options]
 
   Tip:
     The default is efficient + adaptive, preserving previous FlowPilot behavior.
+    strategy disable turns off codex-flow auto-dispatch, not Codex native Agent capability.
     Explicit strategy/routing instructions in a prompt override only the current task.
 """)
     return 0

--- a/templates/skills/flow-pilot/SKILL.md
+++ b/templates/skills/flow-pilot/SKILL.md
@@ -17,6 +17,42 @@ Default compatibility remains `strategy = efficient` plus `routing = adaptive`.
 
 ## 0. Policy precedence and current-task intent
 
+### Global strategy master switch
+
+Before TaskProfile construction or any automatic Worker delegation, read the installed global strategy state:
+
+```bash
+python3 ~/.codex/codex-flow/strategy_runtime.py \
+  --policy ~/.codex/codex-flow.toml \
+  show --json
+```
+
+If the returned `enabled` field is `true`, consume any armed one-shot bypass before TaskProfile construction:
+
+```bash
+python3 ~/.codex/codex-flow/strategy_runtime.py \
+  --policy ~/.codex/codex-flow.toml \
+  consume-bypass
+```
+
+If that command prints `true`, **stop FlowPilot strategy processing for this task only** and continue with ordinary Codex execution. The token is consumed atomically, so concurrent tasks cannot both claim the same temporary bypass. The persistent global master switch remains enabled and the following task returns to normal strategy processing.
+
+If the returned `enabled` field is `false`, **stop FlowPilot strategy processing for this task**:
+
+- do not build a FlowPilot TaskProfile;
+- do not compile an ExecutionPlan;
+- do not apply codex-flow strategy, routing, modifier, WorkerBudget, lifecycle, repair, or role-capability decisions;
+- do not automatically spawn/delegate Workers on behalf of FlowPilot;
+- continue with ordinary Codex execution using the active Codex runtime/configuration.
+
+The switch disables codex-flow automatic distribution, not Codex's native Agent capability. If the user explicitly asks to use native subagents outside FlowPilot, that explicit request may still be honored when appropriate.
+
+`[strategy].enabled` is a **global master gate**. Repository policy and current-task strategy/routing/modifier overrides cannot re-enable it. Existing profile/routing/modifier values remain stored while disabled and become effective again after the user re-enables the switch.
+
+Missing `enabled` in an older policy is backward-compatible and resolves to `true`.
+
+When the switch is enabled, normal planner precedence applies:
+
 The planner resolves policy in this order, from strongest to weakest:
 
 ```text

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -115,8 +115,9 @@ grep -Fxq "$(cat "$ROOT_DIR/VERSION")" "$CODEX_HOME/codex-flow/version"
 
 codex-flow status
 strategy_show="$(codex-flow strategy show)"
-[[ "$strategy_show" == "strategy=efficient routing=adaptive" ]]
-[[ "$(codex-flow strategy)" == "strategy=efficient routing=adaptive" ]]
+[[ "$strategy_show" == "enabled=true strategy=efficient routing=adaptive" ]]
+[[ "$(codex-flow strategy)" == "enabled=true strategy=efficient routing=adaptive" ]]
+[[ "$(codex-flow strategy enabled)" == "true" ]]
 codex-flow strategy plan --complexity complex --uncertainty high > "$TMP/installed-plan.json"
 python3 - "$TMP/installed-plan.json" <<'PY'
 import json, sys
@@ -176,6 +177,7 @@ from pathlib import Path
 import sys
 p=Path(sys.argv[1]); s=p.read_text()
 replacements = {
+    'enabled = true': 'enabled = false',
     'profile = "efficient"': 'profile = "balanced"',
     'mode = "adaptive"': 'mode = "delegate"',
     'review = "auto"': 'review = "strict"',
@@ -195,6 +197,7 @@ p.write_text(s)
 PY
 
 bash "$ROOT_DIR/install.sh"
+[[ "$(codex-flow strategy enabled)" == "false" ]]
 grep -Fq 'profile = "balanced"' "$CODEX_HOME/codex-flow.toml"
 grep -Fq 'mode = "delegate"' "$CODEX_HOME/codex-flow.toml"
 grep -Fq 'review = "strict"' "$CODEX_HOME/codex-flow.toml"
@@ -219,6 +222,7 @@ assert any(hook.get("command") == "user-stop-handler" for hook in stop_hooks), s
 PY
 
 roundtrip_doctor="$(codex-flow doctor 2>&1)"
+[[ "$roundtrip_doctor" == *"strategy dispatch: disabled by policy"* ]]
 [[ "$roundtrip_doctor" == *"strategy profile: balanced"* ]]
 [[ "$roundtrip_doctor" == *"routing mode: delegate"* ]]
 [[ "$roundtrip_doctor" == *"review modifier: strict"* ]]
@@ -248,7 +252,8 @@ else
   grep -Fq 'compdef _codex_flow codex-flow' "$CODEX_HOME/codex-flow/shell/codex-flow.zsh"
 fi
 
-CODEX_FLOW_STRATEGY=quality CODEX_FLOW_ROUTING_MODE=direct CODEX_FLOW_WORKER_MODEL=gpt-test-worker CODEX_FLOW_WORKER_MIN_EFFORT=xhigh CODEX_FLOW_PARENT_MIN_EFFORT=xhigh bash "$ROOT_DIR/install.sh"
+CODEX_FLOW_STRATEGY_ENABLED=true CODEX_FLOW_STRATEGY=quality CODEX_FLOW_ROUTING_MODE=direct CODEX_FLOW_WORKER_MODEL=gpt-test-worker CODEX_FLOW_WORKER_MIN_EFFORT=xhigh CODEX_FLOW_PARENT_MIN_EFFORT=xhigh bash "$ROOT_DIR/install.sh"
+[[ "$(codex-flow strategy enabled)" == "true" ]]
 grep -Fq 'profile = "quality"' "$CODEX_HOME/codex-flow.toml"
 grep -Fq 'mode = "direct"' "$CODEX_HOME/codex-flow.toml"
 grep -Fq 'review = "strict"' "$CODEX_HOME/codex-flow.toml"

--- a/tests/strategy-runtime.sh
+++ b/tests/strategy-runtime.sh
@@ -10,6 +10,7 @@ cat > "$POLICY" <<'EOF'
 schema_version = 4
 
 [strategy]
+enabled = true
 profile = "efficient"
 
 [routing]
@@ -49,9 +50,106 @@ python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" show --json > "$T
 python3 - "$TMP/show.json" <<'PY'
 import json, sys
 obj=json.load(open(sys.argv[1]))
-assert obj == {"strategy":"efficient","routing":"adaptive","valid":True}, obj
+assert obj == {"enabled":True,"strategy":"efficient","routing":"adaptive","valid":True}, obj
 PY
-[[ "$(python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY")" == "strategy=efficient routing=adaptive" ]]
+[[ "$(python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY")" == "enabled=true strategy=efficient routing=adaptive" ]]
+[[ "$(python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" enabled)" == "true" ]]
+
+# Missing master-switch state in older policies remains backward-compatible.
+cp "$POLICY" "$TMP/legacy-policy.toml"
+python3 - "$TMP/legacy-policy.toml" <<'PY'
+from pathlib import Path
+import sys
+p=Path(sys.argv[1]); p.write_text(p.read_text().replace("enabled = true\n", "", 1))
+PY
+[[ "$(python3 "$ROOT/scripts/strategy_runtime.py" --policy "$TMP/legacy-policy.toml" enabled)" == "true" ]]
+
+# A present-but-invalid master switch fails closed instead of silently enabling dispatch.
+for invalid_value in flase '""'; do
+  cp "$POLICY" "$TMP/invalid-enabled.toml"
+  python3 - "$TMP/invalid-enabled.toml" "$invalid_value" <<'PY'
+from pathlib import Path
+import sys
+p=Path(sys.argv[1]); value=sys.argv[2]
+p.write_text(p.read_text().replace("enabled = true\n", f"enabled = {value}\n", 1))
+PY
+  set +e
+  python3 "$ROOT/scripts/strategy_runtime.py" --policy "$TMP/invalid-enabled.toml" show --json > "$TMP/invalid-enabled.json" 2> "$TMP/invalid-enabled.err"
+  invalid_show_rc=$?
+  set -e
+  [[ "$invalid_show_rc" -eq 2 ]]
+  python3 - "$TMP/invalid-enabled.json" <<'PY'
+import json, sys
+p=json.load(open(sys.argv[1]))
+assert p["enabled"] is False and p["valid"] is False, p
+assert "invalid [strategy].enabled" in p["error"], p
+PY
+  if python3 "$ROOT/scripts/strategy_runtime.py" --policy "$TMP/invalid-enabled.toml" enabled >/dev/null 2>"$TMP/invalid-enabled-command.err"; then
+    echo "invalid strategy switch unexpectedly reported a usable state" >&2
+    exit 1
+  fi
+  grep -Fq "invalid [strategy].enabled" "$TMP/invalid-enabled-command.err"
+  if python3 "$ROOT/scripts/strategy_runtime.py" --policy "$TMP/invalid-enabled.toml" plan --repo-policy none --quota-pressure unknown >/dev/null 2>"$TMP/invalid-enabled-plan.err"; then
+    echo "invalid strategy switch unexpectedly compiled a plan" >&2
+    exit 1
+  fi
+  grep -Fq "invalid [strategy].enabled" "$TMP/invalid-enabled-plan.err"
+done
+
+# The global master switch bypasses FlowPilot planning and cannot be re-enabled by repository policy.
+python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" disable >/dev/null
+[[ "$(python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" enabled)" == "false" ]]
+[[ "$(python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY")" == "enabled=false strategy=efficient routing=adaptive" ]]
+python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" show --json > "$TMP/disabled-show.json"
+python3 - "$TMP/disabled-show.json" <<'PY'
+import json, sys
+p=json.load(open(sys.argv[1]))
+assert p["enabled"] is False and p["strategy"] == "efficient" and p["routing"] == "adaptive", p
+PY
+mkdir -p "$TMP/repo"
+cat > "$TMP/repo/.codex-flow.toml" <<'EOF'
+[strategy]
+enabled = true
+profile = "quality"
+[routing]
+mode = "delegate"
+EOF
+python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" show --effective --repo-policy "$TMP/repo/.codex-flow.toml" --json > "$TMP/disabled-effective.json"
+python3 - "$TMP/disabled-effective.json" <<'PY'
+import json, sys
+p=json.load(open(sys.argv[1]))
+assert p["enabled"] is False and p["strategy"] == "quality" and p["routing"] == "delegate", p
+PY
+if python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" plan --repo-policy "$TMP/repo/.codex-flow.toml" --quota-pressure unknown >"$TMP/disabled-plan.json" 2>"$TMP/disabled-plan.err"; then
+  echo "disabled strategy unexpectedly compiled a plan" >&2
+  exit 1
+fi
+grep -q "strategy dispatch is disabled" "$TMP/disabled-plan.err"
+if python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" plan --repo-policy none --profile quality --routing delegate --quota-pressure unknown >/dev/null 2>&1; then
+  echo "current-task overrides unexpectedly bypassed the disabled master switch" >&2
+  exit 1
+fi
+python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" enable >/dev/null
+[[ "$(python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" enabled)" == "true" ]]
+
+# Temporary bypass is one-shot, does not mutate the global switch, and is atomically consumed.
+BYPASS_HOME="$TMP/bypass-home"
+[[ "$(CODEX_HOME="$BYPASS_HOME" python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" bypass-pending)" == "false" ]]
+CODEX_HOME="$BYPASS_HOME" python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" bypass-once >/dev/null
+[[ "$(CODEX_HOME="$BYPASS_HOME" python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" bypass-pending)" == "true" ]]
+[[ "$(python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" enabled)" == "true" ]]
+[[ "$(CODEX_HOME="$BYPASS_HOME" python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" consume-bypass)" == "true" ]]
+[[ "$(CODEX_HOME="$BYPASS_HOME" python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" consume-bypass)" == "false" ]]
+
+CODEX_HOME="$BYPASS_HOME" python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" bypass-once >/dev/null
+CODEX_HOME="$BYPASS_HOME" python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" consume-bypass > "$TMP/consume-a" &
+pid_a=$!
+CODEX_HOME="$BYPASS_HOME" python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" consume-bypass > "$TMP/consume-b" &
+pid_b=$!
+wait "$pid_a" "$pid_b"
+[[ "$(cat "$TMP/consume-a") $(cat "$TMP/consume-b")" == "true false" || "$(cat "$TMP/consume-a") $(cat "$TMP/consume-b")" == "false true" ]]
+grep -Fq "consume-bypass" "$ROOT/templates/skills/flow-pilot/SKILL.md"
+grep -Fq "task only" "$ROOT/templates/skills/flow-pilot/SKILL.md"
 
 # Registry owns topology/resource/lifecycle preferences. Generic Runtime only normalizes them.
 python3 - "$ROOT" <<'PY'


### PR DESCRIPTION
## Summary

Adds a global strategy-dispatch master switch plus a one-shot temporary bypass flow.

- add persistent `[strategy].enabled` master gate, defaulting to enabled for backward compatibility
- prevent repository/current-task overrides from re-enabling strategy dispatch when globally disabled
- add CLI controls for enable/disable/status
- add macOS Strategy Mode toggle and Account-page entry behavior
- add disable confirmation with **Temporary — next task only** and **Permanently disable** choices
- implement one-shot runtime bypass via atomic token consumption so at most one concurrent task can consume it
- preserve selected strategy/routing/modifier values while disabled
- update FlowPilot policy, installer preservation, completions, docs, doctor/status output and regression coverage

## Validation

- Linux CI: passed
- Windows PowerShell smoke: passed
- Windows pwsh smoke: passed
- strategy runtime tests: passed
- installer/CLI smoke: passed
- FlowPilot telemetry + MCP tests: passed
- macOS overlay runtime/state tests: passed
- native macOS Swift compile: passed
- overlay lifecycle smoke: passed

Branch is a single clean commit on top of `main`.