### PR TITLE
Detect FlowPilot hook trust and re-authorization state

### DIFF
--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -2,6 +2,7 @@
 """Cross-platform localized diagnostics for codex-flow."""
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
@@ -19,6 +20,7 @@ STATE_DIR = CODEX_HOME / "codex-flow"
 LANG = resolve_language(POLICY)
 FAILED = False
 CODEX_AVAILABLE = True
+HOOKS_ACTION_REQUIRED = False
 
 
 def T(en: str, zh: str) -> str:
@@ -97,8 +99,20 @@ def _check_effort(label_en: str, label_zh: str, value: str) -> None:
         fail(T(f"invalid {label_en}: {value or 'missing'}", f"无效{label_zh}：{value or 'missing'}"))
 
 
+def _hook_action_hint() -> str:
+    if CODEX_AVAILABLE:
+        return T(
+            "Open the Codex CLI using the same CODEX_HOME, run /hooks, then review and trust/enable the FlowPilot hooks.",
+            "请使用同一 CODEX_HOME 打开 Codex CLI，运行 /hooks，然后 review 并信任/启用 FlowPilot hooks。",
+        )
+    return T(
+        "Hook review is required, but Codex CLI is not in PATH. Install/open Codex CLI once with the same CODEX_HOME, run /hooks, approve FlowPilot, then you may continue using ChatGPT Desktop without keeping the CLI running.",
+        "Hooks 需要 review，但当前 PATH 中没有 Codex CLI。请使用同一 CODEX_HOME 安装/打开一次 Codex CLI，运行 /hooks 批准 FlowPilot；完成授权后无需让 CLI 常驻，可继续使用 ChatGPT Desktop。",
+    )
+
+
 def main() -> int:
-    global CODEX_AVAILABLE
+    global CODEX_AVAILABLE, HOOKS_ACTION_REQUIRED
     print(f"\n🩺 {T('codex-flow doctor', 'codex-flow 系统诊断')}")
 
     section("Environment & Tools", "环境与工具")
@@ -169,11 +183,11 @@ def main() -> int:
         if review in {"auto", "standard", "strict"}:
             ok(T(f"review modifier: {review}", f"Review 修饰策略：{review}"))
         else:
-            fail(T(f"invalid review modifier: {review}", f"无效 Review 修饰策略：{review}"))
+            fail(T(f"invalid review modifier: {review or 'missing'}", f"无效 Review 修饰策略：{review or 'missing'}"))
         if fanout in {"auto", "conservative", "aggressive"}:
             ok(T(f"fanout modifier: {fanout}", f"Fan-out 修饰策略：{fanout}"))
         else:
-            fail(T(f"invalid fanout modifier: {fanout}", f"无效 Fan-out 修饰策略：{fanout}"))
+            fail(T(f"invalid fanout modifier: {fanout or 'missing'}", f"无效 Fan-out 修饰策略：{fanout or 'missing'}"))
 
         parent_effort = policy_value("parent", "min_reasoning_effort")
         worker_effort = policy_value("worker", "min_reasoning_effort")
@@ -254,7 +268,57 @@ def main() -> int:
                 code, _ = run_capture([sys.executable, str(manager), "check", "--hooks", str(HOOKS)])
                 if code == 0:
                     ok(T("FlowPilot lifecycle hooks installed", "FlowPilot 生命周期 hooks 已安装"))
-                    warn(T("command hooks may require one-time trust approval in Codex; use /hooks if Codex reports them pending", "命令 hooks 可能需要在 Codex 中进行一次信任授权；如果显示 pending，请使用 /hooks 批准"))
+                    _, trust_output = run_capture([
+                        sys.executable,
+                        str(manager),
+                        "status",
+                        "--hooks",
+                        str(HOOKS),
+                        "--config",
+                        str(CONFIG),
+                        "--json",
+                    ])
+                    try:
+                        trust = json.loads(trust_output)
+                    except (json.JSONDecodeError, TypeError):
+                        trust = {"status": "unknown", "error": trust_output or "no trust report"}
+                    status = str(trust.get("status") or "unknown")
+                    total = int(trust.get("total") or 0)
+                    trusted = int(trust.get("trusted") or 0)
+                    if status == "trusted":
+                        ok(T(
+                            f"FlowPilot hook authorization: trusted ({trusted}/{total})",
+                            f"FlowPilot hooks 授权：已信任（{trusted}/{total}）",
+                        ))
+                    elif status == "modified":
+                        HOOKS_ACTION_REQUIRED = True
+                        warn(T(
+                            "FlowPilot hook authorization: definitions changed since approval; re-authorization required",
+                            "FlowPilot hooks 授权：hook 定义在上次批准后已变化，需要重新授权",
+                        ))
+                        print("    " + _hook_action_hint())
+                    elif status == "untrusted":
+                        HOOKS_ACTION_REQUIRED = True
+                        warn(T(
+                            "FlowPilot hook authorization: approval required before hook-backed features can run",
+                            "FlowPilot hooks 授权：需要批准后，依赖 hooks 的功能才能运行",
+                        ))
+                        print("    " + _hook_action_hint())
+                    elif status == "disabled":
+                        HOOKS_ACTION_REQUIRED = True
+                        warn(T(
+                            "FlowPilot hook authorization: one or more lifecycle hooks are disabled",
+                            "FlowPilot hooks 授权：一个或多个生命周期 hook 已被禁用",
+                        ))
+                        print("    " + _hook_action_hint())
+                    else:
+                        HOOKS_ACTION_REQUIRED = True
+                        detail = str(trust.get("error") or "trust state unavailable")
+                        warn(T(
+                            f"FlowPilot hook authorization could not be verified: {detail}",
+                            f"无法验证 FlowPilot hooks 授权状态：{detail}",
+                        ))
+                        print("    " + _hook_action_hint())
                 else:
                     fail(T(f"FlowPilot lifecycle hooks missing from {HOOKS}", f"{HOOKS} 中缺少 FlowPilot 生命周期 hooks"))
         elif enabled == "false":
@@ -278,7 +342,12 @@ def main() -> int:
 
     print("\n  " + "─" * 69)
     if not FAILED:
-        if CODEX_AVAILABLE:
+        if HOOKS_ACTION_REQUIRED:
+            print("  ⚠ " + T(
+                "Installed with action required: FlowPilot hook-backed features are inactive until hook review is completed.",
+                "安装正常，但仍需操作：在完成 hook review 前，FlowPilot 依赖 hooks 的功能不会生效。",
+            ))
+        elif CODEX_AVAILABLE:
             print("  ✨ " + T("Ready. FlowPilot strategy runtime and deterministic telemetry are installed.", "就绪。FlowPilot 策略运行时与确定性遥测均已安装。"))
         else:
             print("  ✨ " + T("Ready. Core FlowPilot strategy runtime is installed and healthy; Codex CLI-dependent telemetry quota reads and benchmark execution are unavailable in this shell.", "就绪。FlowPilot 核心策略运行时安装正常；当前 shell 中依赖 Codex CLI 的遥测额度读取和 Benchmark 执行不可用。"))

--- a/scripts/manage-hooks.py
+++ b/scripts/manage-hooks.py
@@ -1,15 +1,50 @@
 #!/usr/bin/env python3
-"""Install/remove codex-flow lifecycle hooks without clobbering user hooks."""
+"""Install/remove FlowPilot lifecycle hooks and inspect Codex hook trust state.
+
+Trust detection intentionally mirrors Codex's current hook identity rules:
+- one persisted state key per event/group/handler
+- normalized command-hook config before hashing
+- canonical JSON + SHA-256 with the ``sha256:`` prefix
+
+The detector is read-only. It never grants trust on the user's behalf.
+"""
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
+import re
 from pathlib import Path
 from typing import Any
 
 EVENTS = ("UserPromptSubmit", "SubagentStart", "SubagentStop", "Stop")
 MARKER = "codex-flow/telemetry.py"
+DEFAULT_TIMEOUT_SEC = 600
+SESSION_END_DEFAULT_TIMEOUT_SEC = 1
+SESSION_END_MAX_TIMEOUT_SEC = 3
+DEFAULT_ADDITIONAL_CONTEXT_LIMIT = 2500
+ADDITIONAL_CONTEXT_EVENTS = {
+    "PreToolUse",
+    "PostToolUse",
+    "SessionStart",
+    "UserPromptSubmit",
+    "SubagentStart",
+}
+EVENT_KEY_LABELS = {
+    "PreToolUse": "pre_tool_use",
+    "PermissionRequest": "permission_request",
+    "PostToolUse": "post_tool_use",
+    "PreCompact": "pre_compact",
+    "PostCompact": "post_compact",
+    "SessionStart": "session_start",
+    "SessionEnd": "session_end",
+    "UserPromptSubmit": "user_prompt_submit",
+    "SubagentStart": "subagent_start",
+    "SubagentStop": "subagent_stop",
+    "Stop": "stop",
+    "Interrupt": "interrupt",
+}
 
 
 def load(path: Path) -> dict[str, Any]:
@@ -124,11 +159,266 @@ def check(path: Path) -> int:
     return 0
 
 
+def _absolute_display_path(path: Path) -> str:
+    # Codex builds hook keys from an absolute source path. Do not resolve
+    # symlinks here: the config-layer path is made absolute, not canonicalized.
+    return os.path.abspath(os.path.expanduser(str(path)))
+
+
+def _event_key_label(event: str) -> str:
+    return EVENT_KEY_LABELS.get(event, re.sub(r"(?<!^)(?=[A-Z])", "_", event).lower())
+
+
+def _normalized_timeout(event: str, value: Any) -> int:
+    try:
+        timeout = int(value) if value is not None else None
+    except (TypeError, ValueError):
+        timeout = None
+    if event in {"SessionEnd", "Interrupt"}:
+        timeout = SESSION_END_DEFAULT_TIMEOUT_SEC if timeout is None else timeout
+        return max(1, min(timeout, SESSION_END_MAX_TIMEOUT_SEC))
+    timeout = DEFAULT_TIMEOUT_SEC if timeout is None else timeout
+    return max(1, timeout)
+
+
+def _canonical_hash(value: dict[str, Any]) -> str:
+    serialized = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(serialized).hexdigest()
+
+
+def _normalized_command_identity(
+    event: str,
+    matcher: Any,
+    handler: dict[str, Any],
+) -> dict[str, Any]:
+    command = handler.get("command")
+    if os.name == "nt" and isinstance(handler.get("commandWindows"), str):
+        command = handler["commandWindows"]
+    if not isinstance(command, str):
+        command = ""
+
+    normalized_handler: dict[str, Any] = {
+        "type": "command",
+        "command": command,
+        "timeout": _normalized_timeout(event, handler.get("timeout")),
+        "async": bool(handler.get("async", False)),
+    }
+    status_message = handler.get("statusMessage")
+    if isinstance(status_message, str):
+        normalized_handler["statusMessage"] = status_message
+
+    if event in ADDITIONAL_CONTEXT_EVENTS:
+        limit = handler.get("additionalContextLimit")
+        if isinstance(limit, int) and not isinstance(limit, bool) and limit != DEFAULT_ADDITIONAL_CONTEXT_LIMIT:
+            normalized_handler["additionalContextLimit"] = limit
+
+    identity: dict[str, Any] = {
+        "event_name": _event_key_label(event),
+        "hooks": [normalized_handler],
+    }
+    if isinstance(matcher, str):
+        identity["matcher"] = matcher
+    return identity
+
+
+def _managed_hook_entries(path: Path) -> list[dict[str, Any]]:
+    data = load(path)
+    hooks = data.get("hooks", {})
+    if not isinstance(hooks, dict):
+        return []
+    source = _absolute_display_path(path)
+    result: list[dict[str, Any]] = []
+    for event, groups in hooks.items():
+        if not isinstance(event, str) or not isinstance(groups, list):
+            continue
+        for group_index, group in enumerate(groups):
+            if not isinstance(group, dict):
+                continue
+            matcher = group.get("matcher")
+            handlers = group.get("hooks", [])
+            if not isinstance(handlers, list):
+                continue
+            for handler_index, handler in enumerate(handlers):
+                if not is_managed_hook(handler):
+                    continue
+                assert isinstance(handler, dict)
+                key = f"{source}:{_event_key_label(event)}:{group_index}:{handler_index}"
+                current_hash = _canonical_hash(_normalized_command_identity(event, matcher, handler))
+                result.append(
+                    {
+                        "event": event,
+                        "group_index": group_index,
+                        "handler_index": handler_index,
+                        "key": key,
+                        "current_hash": current_hash,
+                    }
+                )
+    return result
+
+
+def _fallback_hook_states(text: str) -> dict[str, dict[str, Any]]:
+    """Minimal parser for hook trust state when stdlib tomllib is unavailable."""
+    states: dict[str, dict[str, Any]] = {}
+    current: str | None = None
+    header = re.compile(r'^\s*\[hooks\.state\.(?P<key>.+)\]\s*$')
+    for raw_line in text.splitlines():
+        match = header.match(raw_line)
+        if match:
+            token = match.group("key").strip()
+            current = None
+            if len(token) >= 2 and token[0] == token[-1] == "'":
+                current = token[1:-1]
+            elif len(token) >= 2 and token[0] == token[-1] == '"':
+                try:
+                    current = json.loads(token)
+                except json.JSONDecodeError:
+                    current = token[1:-1].replace('\\"', '"').replace("\\\\", "\\")
+            if current is not None:
+                states.setdefault(current, {})
+            continue
+        if current is None:
+            continue
+        trusted = re.match(r'^\s*trusted_hash\s*=\s*"([^"]+)"\s*(?:#.*)?$', raw_line)
+        if trusted:
+            states[current]["trusted_hash"] = trusted.group(1)
+            continue
+        enabled = re.match(r"^\s*enabled\s*=\s*(true|false)\s*(?:#.*)?$", raw_line, re.IGNORECASE)
+        if enabled:
+            states[current]["enabled"] = enabled.group(1).lower() == "true"
+    return states
+
+
+def _load_hook_states(config: Path) -> tuple[dict[str, dict[str, Any]], str | None]:
+    if not config.exists():
+        return {}, None
+    try:
+        text = config.read_text(encoding="utf-8-sig")
+    except OSError as exc:
+        return {}, str(exc)
+    try:
+        import tomllib  # Python 3.11+
+    except ImportError:
+        return _fallback_hook_states(text), None
+    try:
+        parsed = tomllib.loads(text)
+    except Exception as exc:  # invalid config should not crash install/update
+        fallback = _fallback_hook_states(text)
+        return fallback, None if fallback else str(exc)
+    hooks = parsed.get("hooks", {}) if isinstance(parsed, dict) else {}
+    state = hooks.get("state", {}) if isinstance(hooks, dict) else {}
+    if not isinstance(state, dict):
+        return {}, None
+    result: dict[str, dict[str, Any]] = {}
+    for key, value in state.items():
+        if isinstance(key, str) and isinstance(value, dict):
+            result[key] = value
+    return result, None
+
+
+def trust_report(path: Path, config: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {
+            "status": "missing",
+            "ready": False,
+            "authorization_required": False,
+            "total": 0,
+            "trusted": 0,
+            "untrusted": 0,
+            "modified": 0,
+            "disabled": 0,
+            "entries": [],
+            "error": None,
+        }
+
+    entries = _managed_hook_entries(path)
+    if not entries:
+        return {
+            "status": "missing",
+            "ready": False,
+            "authorization_required": False,
+            "total": 0,
+            "trusted": 0,
+            "untrusted": 0,
+            "modified": 0,
+            "disabled": 0,
+            "entries": [],
+            "error": None,
+        }
+
+    states, state_error = _load_hook_states(config)
+    counts = {"trusted": 0, "untrusted": 0, "modified": 0, "disabled": 0}
+    for entry in entries:
+        state = states.get(entry["key"], {})
+        enabled = state.get("enabled") is not False
+        trusted_hash = state.get("trusted_hash") if isinstance(state.get("trusted_hash"), str) else None
+        if not enabled:
+            status = "disabled"
+        elif trusted_hash == entry["current_hash"]:
+            status = "trusted"
+        elif trusted_hash:
+            status = "modified"
+        else:
+            status = "untrusted"
+        counts[status] += 1
+        entry["status"] = status
+        entry["enabled"] = enabled
+        entry["trusted_hash"] = trusted_hash
+
+    if state_error:
+        aggregate = "unknown"
+    elif counts["disabled"]:
+        aggregate = "disabled"
+    elif counts["modified"]:
+        aggregate = "modified"
+    elif counts["untrusted"]:
+        aggregate = "untrusted"
+    else:
+        aggregate = "trusted"
+
+    return {
+        "status": aggregate,
+        "ready": aggregate == "trusted",
+        "authorization_required": bool(counts["untrusted"] or counts["modified"]),
+        "total": len(entries),
+        **counts,
+        "entries": entries,
+        "error": state_error,
+        "hooks_path": _absolute_display_path(path),
+        "config_path": _absolute_display_path(config),
+    }
+
+
+def _print_trust_report(report: dict[str, Any]) -> None:
+    status = report.get("status", "unknown")
+    total = int(report.get("total", 0) or 0)
+    trusted = int(report.get("trusted", 0) or 0)
+    if status == "trusted":
+        print(f"FlowPilot hook trust: trusted ({trusted}/{total})")
+    elif status == "modified":
+        print("FlowPilot hook trust: changed since approval; review required with /hooks")
+    elif status == "untrusted":
+        print("FlowPilot hook trust: approval required; review with /hooks")
+    elif status == "disabled":
+        print("FlowPilot hook trust: one or more managed hooks are disabled in Codex")
+    elif status == "missing":
+        print("FlowPilot hook trust: managed hooks are not installed")
+    else:
+        detail = report.get("error") or "trust state could not be verified"
+        print(f"FlowPilot hook trust: unknown ({detail})")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("action", choices=("install", "uninstall", "check"))
+    parser.add_argument("action", choices=("install", "uninstall", "check", "status"))
     parser.add_argument("--hooks", required=True, type=Path)
     parser.add_argument("--script", type=Path)
+    parser.add_argument("--config", type=Path)
+    parser.add_argument("--json", action="store_true")
     args = parser.parse_args()
     if args.action == "install":
         if args.script is None:
@@ -138,7 +428,20 @@ def main() -> int:
     if args.action == "uninstall":
         uninstall(args.hooks)
         return 0
-    return check(args.hooks)
+    if args.action == "check":
+        return check(args.hooks)
+
+    config = args.config or args.hooks.parent / "config.toml"
+    report = trust_report(args.hooks, config)
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        _print_trust_report(report)
+    if report["ready"]:
+        return 0
+    if report["status"] == "missing":
+        return 1
+    return 2
 
 
 if __name__ == "__main__":

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -146,7 +146,8 @@ printf '%s\n' "$doctor_output"
 [[ "$doctor_output" == *"release policy defaults installed"* ]]
 [[ "$doctor_output" == *"FlowPilot lifecycle hooks installed"* ]]
 [[ "$doctor_output" == *"thread-attributed telemetry may be unavailable"* ]]
-[[ "$doctor_output" == *"Ready. FlowPilot strategy runtime and deterministic telemetry are installed."* ]]
+[[ "$doctor_output" == *"FlowPilot hook authorization: approval required"* ]]
+[[ "$doctor_output" == *"Installed with action required"* ]]
 
 for CODEX_TEST_VERSION in 0.151.0 0.151.0-alpha.1; do
   export CODEX_TEST_VERSION
@@ -157,7 +158,8 @@ done
 no_cli_output="$(env PATH="$CODEX_FLOW_BIN_DIR:/usr/bin:/bin" "$CODEX_FLOW_BIN_DIR/codex-flow" doctor 2>&1)"
 printf '%s\n' "$no_cli_output"
 [[ "$no_cli_output" == *"Codex CLI not found in PATH"* ]]
-[[ "$no_cli_output" == *"Core FlowPilot strategy runtime is installed and healthy"* ]]
+[[ "$no_cli_output" == *"Hook review is required, but Codex CLI is not in PATH"* ]]
+[[ "$no_cli_output" == *"Installed with action required"* ]]
 
 python3 - "$CODEX_HOME/hooks.json" <<'PY'
 import json, sys

--- a/tests/telemetry.sh
+++ b/tests/telemetry.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+python3 "$ROOT_DIR/tests/test_hook_trust.py"
 bash "$ROOT_DIR/tests/account-snapshot.sh"
 bash "$ROOT_DIR/tests/telemetry-core.sh"
 bash "$ROOT_DIR/tests/telemetry-repair.sh"

--- a/tests/test_hook_trust.py
+++ b/tests/test_hook_trust.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "manage-hooks.py"
+SPEC = importlib.util.spec_from_file_location("manage_hooks", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+manage_hooks = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(manage_hooks)
+
+
+def _toml_basic(value: str) -> str:
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def _write_trust_state(config: Path, report: dict, *, disabled_key: str | None = None) -> None:
+    lines: list[str] = []
+    for entry in report["entries"]:
+        lines.append(f"[hooks.state.{_toml_basic(entry['key'])}]")
+        lines.append(f"trusted_hash = {_toml_basic(entry['current_hash'])}")
+        if entry["key"] == disabled_key:
+            lines.append("enabled = false")
+        lines.append("")
+    config.write_text("\n".join(lines), encoding="utf-8")
+
+
+class HookTrustTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.home = Path(self.tmp.name) / ".codex"
+        self.home.mkdir(parents=True)
+        self.hooks = self.home / "hooks.json"
+        self.config = self.home / "config.toml"
+        self.script = self.home / "codex-flow" / "telemetry.py"
+        self.script.parent.mkdir(parents=True)
+        self.script.write_text("# fixture\n", encoding="utf-8")
+        manage_hooks.install(self.hooks, self.script)
+
+    def report(self) -> dict:
+        return manage_hooks.trust_report(self.hooks, self.config)
+
+    def test_fresh_install_requires_review(self) -> None:
+        report = self.report()
+        self.assertEqual(report["status"], "untrusted")
+        self.assertFalse(report["ready"])
+        self.assertTrue(report["authorization_required"])
+        self.assertEqual(report["untrusted"], 4)
+        self.assertEqual(report["total"], 4)
+
+    def test_exact_current_hash_is_trusted(self) -> None:
+        initial = self.report()
+        _write_trust_state(self.config, initial)
+        report = self.report()
+        self.assertEqual(report["status"], "trusted")
+        self.assertTrue(report["ready"])
+        self.assertFalse(report["authorization_required"])
+        self.assertEqual(report["trusted"], 4)
+
+    def test_changed_hook_definition_is_modified(self) -> None:
+        initial = self.report()
+        _write_trust_state(self.config, initial)
+
+        payload = json.loads(self.hooks.read_text(encoding="utf-8"))
+        payload["hooks"]["Stop"][0]["hooks"][0]["timeout"] = 16
+        self.hooks.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+        report = self.report()
+        self.assertEqual(report["status"], "modified")
+        self.assertFalse(report["ready"])
+        self.assertTrue(report["authorization_required"])
+        self.assertEqual(report["modified"], 1)
+        self.assertEqual(report["trusted"], 3)
+
+    def test_trust_detection_does_not_depend_on_codex_cli_in_path(self) -> None:
+        initial = self.report()
+        _write_trust_state(self.config, initial)
+        empty_path = str(Path(self.tmp.name) / "empty-bin")
+        Path(empty_path).mkdir()
+        with mock.patch.dict(os.environ, {"PATH": empty_path}, clear=False):
+            report = self.report()
+        self.assertEqual(report["status"], "trusted")
+        self.assertTrue(report["ready"])
+
+    def test_disabled_hook_is_reported_separately(self) -> None:
+        initial = self.report()
+        disabled_key = initial["entries"][0]["key"]
+        _write_trust_state(self.config, initial, disabled_key=disabled_key)
+        report = self.report()
+        self.assertEqual(report["status"], "disabled")
+        self.assertFalse(report["ready"])
+        self.assertFalse(report["authorization_required"])
+        self.assertEqual(report["disabled"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- detect persisted Codex hook trust state for FlowPilot lifecycle hooks
- mirror Codex hook key and normalized SHA-256 identity rules so changed hooks become `modified`
- distinguish `trusted`, `untrusted`, `modified`, `disabled`, `missing`, and `unknown`
- surface authorization state in `codex-flow doctor` without blocking install/update
- tell users to use the same `CODEX_HOME` and `/hooks` when review is required; Codex CLI can remain optional after trust is established
- add regression coverage for fresh install, trusted state, hash changes, disabled hooks, and CLI absence
- align installer smoke expectations with the new authorization-aware doctor output

## Behavior

`doctor` now separates hook installation from hook authorization. An untrusted or modified hook produces an actionable warning rather than a core health-check failure. OTA already runs `doctor` after managed hooks are synchronized, so a hash-changing update immediately surfaces the re-authorization requirement.

## Safety

The detector is read-only with respect to trust state: it never writes `trusted_hash` or auto-approves hooks.
