### PR TITLE
feat(strategies): apply convergence lifecycle to all strategies

### DIFF
--- a/.github/workflows/shared-strategy-lifecycle-ci.yml
+++ b/.github/workflows/shared-strategy-lifecycle-ci.yml
@@ -3,13 +3,17 @@ name: shared-strategy-lifecycle-ci
 on:
   push:
     paths:
+      - 'scripts/strategy_runtime.py'
       - 'scripts/strategies/**'
       - 'tests/test_shared_strategy_lifecycle.py'
+      - 'tests/test_task_phase_runtime.py'
       - '.github/workflows/shared-strategy-lifecycle-ci.yml'
   pull_request:
     paths:
+      - 'scripts/strategy_runtime.py'
       - 'scripts/strategies/**'
       - 'tests/test_shared_strategy_lifecycle.py'
+      - 'tests/test_task_phase_runtime.py'
       - '.github/workflows/shared-strategy-lifecycle-ci.yml'
 
 jobs:
@@ -19,9 +23,14 @@ jobs:
       - uses: actions/checkout@v4
       - name: Syntax
         run: |
+          python3 -m py_compile scripts/strategy_runtime.py
           python3 -m py_compile scripts/strategies/balanced.py
           python3 -m py_compile scripts/strategies/quality.py
           python3 -m py_compile scripts/strategies/speed.py
+          python3 -m py_compile scripts/strategies/task_phase_runtime.py
           python3 -m py_compile tests/test_shared_strategy_lifecycle.py
+          python3 -m py_compile tests/test_task_phase_runtime.py
       - name: Cross-strategy lifecycle contract
         run: python3 tests/test_shared_strategy_lifecycle.py
+      - name: Phase-aware task admission
+        run: python3 tests/test_task_phase_runtime.py

--- a/.github/workflows/shared-strategy-lifecycle-ci.yml
+++ b/.github/workflows/shared-strategy-lifecycle-ci.yml
@@ -1,0 +1,27 @@
+name: shared-strategy-lifecycle-ci
+
+on:
+  push:
+    paths:
+      - 'scripts/strategies/**'
+      - 'tests/test_shared_strategy_lifecycle.py'
+      - '.github/workflows/shared-strategy-lifecycle-ci.yml'
+  pull_request:
+    paths:
+      - 'scripts/strategies/**'
+      - 'tests/test_shared_strategy_lifecycle.py'
+      - '.github/workflows/shared-strategy-lifecycle-ci.yml'
+
+jobs:
+  shared-strategy-lifecycle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Syntax
+        run: |
+          python3 -m py_compile scripts/strategies/balanced.py
+          python3 -m py_compile scripts/strategies/quality.py
+          python3 -m py_compile scripts/strategies/speed.py
+          python3 -m py_compile tests/test_shared_strategy_lifecycle.py
+      - name: Cross-strategy lifecycle contract
+        run: python3 tests/test_shared_strategy_lifecycle.py

--- a/docs/strategy-runtime.md
+++ b/docs/strategy-runtime.md
@@ -1,568 +1,117 @@
 # FlowPilot Multi-Strategy Runtime
 
-FlowPilot is the semantic profiler and execution runtime for codex-flow. **Policy schema v4** separates the optimization objective from execution constraints, while **ExecutionPlan schema v10** carries the concrete WorkerBudget, task intent, per-role capability/reasoning policy, topology, bounded lifecycle policy, optional cumulative task budget, and optional reasoning-rollout decision selected for one task.
+FlowPilot is the semantic profiler and execution runtime for codex-flow. Persistent policy remains **schema v4**. The execution contract introduced by this runtime is **ExecutionPlan schema v11** with a canonical cumulative task budget, shared Worker lifecycle semantics, bounded implementation units, read-only review retries, and phase-aware admission.
 
 ```text
-User Task
-   ↓
-Task Profiler (FlowPilot semantic reasoning)
-   ↓
-TaskProfile
-   ↓
-Strategy Runtime
-   ├─ policy precedence
-   ├─ Strategy Registry
-   │  ├─ efficient
-   │  ├─ balanced
-   │  ├─ quality
-   │  └─ speed
-   ├─ WorkerBudget
-   ├─ Strategy resource hooks
-   ├─ Modifiers
-   ├─ runtime / quota state
-   └─ generic Plan Compiler
-   ↓
-ExecutionPlan v10
-   ↓
-──────────────── hard boundary ────────────────
-   ↓
-Flow Runtime (FlowPilot)
-   ↓
-Role Agents
-   ├─ worker-explorer
-   ├─ worker-implementer
-   └─ worker-reviewer
-   ↓
-Parent final verification / bounded repair
-   ↓
+User task
+  ↓
+FlowPilot semantic TaskProfile
+  ↓
+strategy_runtime.py + strategy registry
+  ↓
+ExecutionPlan v11
+  ↓
+──────────────── authoritative boundary ────────────────
+  ↓
+FlowPilot execution
+  ├─ exploration
+  ├─ bounded implementation
+  ├─ required read-only review
+  └─ Parent finalization
+  ↓
 Telemetry
 ```
 
-The critical invariant is:
+The invariant is:
 
 > **FlowPilot profiles. `strategy_runtime.py` plus the strategy registry decide. FlowPilot executes the returned plan.**
 
-The Skill must not keep another copy of strategy topology, Worker counts, capability selection, reasoning policy, review policy, task-budget policy, phase-admission policy, or quota logic.
+The Skill must not keep a second copy of strategy topology, Worker counts, role capability/reasoning policy, lifecycle thresholds, task-budget limits, phase-admission rules, or quota logic.
 
 ## Design invariants
 
-1. **Strategy is an optimization objective, not an executor.**
-2. **Routing is a constraint, not a strategy.** `direct`, `delegate`, and `adaptive` are orthogonal to strategy selection.
-3. **WorkerBudget is a preference envelope, not a fixed Worker count.** Runtime converts it into concrete counts using TaskProfile evidence and hard ceilings.
-4. **Strategy semantics stay in StrategySpec modules.** The generic compiler may invoke strategy hooks, but it must not branch on built-in literals such as `efficient`, `balanced`, `quality`, or `speed`.
-5. **Quality intent is task semantics, not technical risk.** `quality_intent=strong|absolute` represents explicit user optimization intent and must not be encoded by faking `risk=critical`.
-6. **Only the selected strategy consumes strategy-specific semantics.** A non-`quality` strategy may carry `quality_intent` for observability, but that field must not alter its topology or resources.
-7. **Model capability and reasoning effort are independent axes.** `latest-efficient + max` is not assumed equivalent to `latest-capable`.
-8. **Capability is role-scoped.** Explorer, Implementer, and Reviewer may receive different capability/model/reasoning choices in one plan.
-9. **Modifiers are orthogonal behavior controls.** Review rigor and fan-out do not create combinatorial strategy names.
-10. **Role Agents are strategy-agnostic capabilities.** Explorer, implementer, and reviewer prompts are reused across strategies.
-11. **Model slugs are not strategy semantics.** Strategy expresses capability/resource intent; policy/runtime resolve current models.
-12. **Expensive Parent capability is reserved for high-value semantic decisions.** Delegated Worker roles use at least one higher reasoning tier than Parent whenever the effort ladder permits it.
-13. **`max` is the top effort tier.** If Parent is explicitly forced to `max`, Worker roles can only equal `max`; the plan records this limitation.
-14. **Writable fan-out requires evidence.** Multiple implementers require already-proven isolated, non-overlapping writable workstreams.
-15. **Safety and hard ceilings belong to Runtime.** A strategy cannot bypass write-conflict checks, `writable_workstreams`, modifiers, runtime ceilings, or repair ceilings.
-16. **`max_concurrent_threads` is a per-stage ceiling.** Exploration, implementation, and review are separate stages, so `planned_worker_count` may exceed it.
-17. **Configured floors are hard floors.** Strategy/quota state may not silently lower them.
-18. **Task profiling is continuous.** Material evidence or explicit quality-intent changes require re-profile + recompile rather than ad-hoc plan mutation.
-19. **Telemetry is observational.** Planning adds no LLM calls merely to estimate usage or quota.
-20. **Release defaults have one source of truth.** `policy/defaults.toml` drives installer and planner defaults.
-21. **Installer/update policy round-trips are lossless for supported fields.**
-22. **Bounded implementation is explicit and finite.** `minimum_work_units` and optional `maximum_work_units` constrain one manifest; cumulative task reservations are enforced separately by the durable task-budget ledger.
-23. **Path evidence is preflight only.** `write_paths` provide lexical overlap checks, not an OS lock, durable scheduler enforcement, symlink resolution, or cross-process fencing.
-24. **Lineage is explicit.** Bounded units use `(scope_id, unit_id, generation)`; replacement/replan increments generation, checkpoint/continue does not, and Parent accepts only current-generation evidence.
-25. **Reasoning rollout is scoped and observable.** Only delegated `efficient` Worker roles consume the optional `legacy|shadow|adaptive` decision; direct/non-efficient plans remain unchanged, and proposed/selected effort is planner intent rather than runtime-observed usage.
-26. **Every delegated built-in strategy has a cumulative task envelope.** Task budgets are strategy-owned and differ by optimization objective, but all use the same durable admission ledger and cannot be reset by replanning.
-27. **Required completion has a reserved tail.** A new delegated task with reviewer Workers stores an effective ledger soft deadline early enough to preserve the immutable plan's review-stage hard window. General work stops there; required read-only review may continue until the absolute task hard deadline.
-28. **The initial budget plan owns the ledger for the whole task.** A later replan may change execution topology but cannot replace, extend, or reinitialize the task budget. Phase status/reservation continues to use the initial budget-plan identity.
-29. **Running old ledgers are grandfathered.** A task initialized before phase-aware admission retains its original soft deadline and does not gain a retroactive review-tail reservation after an upgrade.
+1. Strategy is an optimization objective; routing is an orthogonal execution constraint.
+2. WorkerBudget is an envelope, not a mandatory Worker count.
+3. Strategy-specific tuning lives in `scripts/strategies/*.py`; the generic compiler normalizes it against runtime/safety constraints.
+4. `quality_intent` is user optimization intent and is not equivalent to technical risk.
+5. Model capability and reasoning effort are independent axes.
+6. Multiple writable implementers require already-proven isolated writable workstreams.
+7. `max_concurrent_threads` is a per-stage concurrency ceiling, not a whole-task Worker total.
+8. Bounded work units are logical acceptance transactions, not permission to create extra writers.
+9. `minimum_work_units=1` for all built-in strategies; no strategy mechanically forces a fake split.
+10. A task-level budget is durable across implementation attempts/replans/replacements and cannot be reset by recompiling a later plan.
+11. ExecutionPlan is the only canonical task-budget source. Phase runtime validates and executes it; it does not derive a second budget.
+12. Required review and Parent finalization have explicit time windows.
+13. Review failure retries are read-only `retry_review`, not writable implementation replans.
+14. A returned checkpoint is harvested before any fallback that could discard useful work.
+15. `wait()` timeouts are not Worker timeouts.
+16. Telemetry is observational and never calls a model only to estimate usage or latency.
+17. The new task-ledger contract has no grandfather/adoption path because no earlier persisted-task format containing this feature was released. Incompatible task-ledger schema/policy fails closed.
 
-## Strategy Registry, WorkerBudget, and resource hooks
+## Strategy registry
 
-Built-in strategies live under:
+Built-in strategies:
 
 ```text
 scripts/strategies/
-├── __init__.py
-├── base.py
 ├── efficient.py
 ├── balanced.py
 ├── quality.py
 ├── speed.py
+├── base.py
 ├── lifecycle_runtime.py
 ├── work_unit_runtime.py
 ├── task_budget_runtime.py
 └── task_phase_runtime.py
 ```
 
-`base.py` defines `StrategySpec`, `WorkerBudget`, the optional `TaskBudgetPolicy` hook, and strict `ReasoningRolloutPolicy` / `ReasoningRolloutDecision` contracts.
-
-```text
-WorkerBudget
-  max_explorers
-  max_implementers
-  max_reviewers
-  max_total_workers
-  speculation: low | medium | high
-```
-
-A StrategySpec can express:
+Each StrategySpec supplies the optimization preferences used by the generic compiler:
 
 ```text
 adaptive_route(task)
 effort(task, role)
 worker_budget(task)
 independent_review(task)
-capability(task, role)       → worker | parent
-exploration_bonus(task)      → non-negative integer
-reviewer_bonus(task)         → non-negative integer
-notes(task)                  → tuple[str, ...]
-task_budget(task)            → TaskBudgetPolicy | None
-reasoning_rollout(task, role, policy, parent_reasoning, legacy_worker_reasoning)
-                             → ReasoningRolloutDecision
-allow_parallel_write
-quota_sensitive
+capability(task, role)
+exploration_bonus(task)
+reviewer_bonus(task)
+notes(task)
+lifecycle(task, stage)
+task_budget(task)
+reasoning_rollout(...) | none
 ```
 
-The role-based `capability()` hook is intentionally abstract. `"worker"` means the configured efficient Worker policy; `"parent"` means the configured Parent-class capability policy. Strategy modules do not hard-code model slugs.
+The compiler owns generic policy precedence, runtime ceilings, writable-isolation proof, quota normalization, concrete topology, and final ExecutionPlan construction.
 
-Runtime remains responsible for generic mechanics only:
+## ExecutionPlan schema v11
 
-```text
-policy precedence
-TaskProfile validation
-routing overrides
-modifiers
-configured reasoning floors
-Worker-role-over-Parent reasoning invariant
-base exploration/reviewer demand formulas
-strategy bonus application
-writable isolation proof
-write-conflict checks
-per-stage thread ceilings
-quota normalization/enforcement
-role-resource materialization
-ExecutionPlan construction
-```
-
-This split lets strategies become more aggressive without duplicating safety logic or leaking strategy-specific conditions back into the compiler.
-
-### StagePolicy and bounded implementation
-
-`StagePolicy` carries lifecycle preferences plus optional bounded-unit controls:
-
-```text
-work_unit_mode: single | bounded
-minimum_work_units
-join_between_work_units
-maximum_work_units | none
-require_write_paths
-soft_timeout_seconds | none
-checkpoint_rearm_seconds | none
-max_worker_repair_attempts | none
-```
-
-All four built-in strategies use the same convergence/recovery contract for delegated implementation: first soft checkpoint, explicit-meaningful-progress multi-round checkpoint rearm, harvest-before-fallback, remaining-delta replan, local repair bounds, generation lineage, and evidence-based bounded units. Strategy modules tune only the thresholds and maximum logical units.
-
-| Strategy | Implementation soft checkpoint | Rearm cooldown | Local repairs | Max work units | Worker hard ceiling |
-| --- | --- | --- | --- | --- | --- |
-| `efficient` | 600 / 900 / 1200s | 180 / 240 / 300s | 1–2 | 1–3 | 1800s |
-| `balanced` | 1200 / 1500 / 1800s | 240 / 300 / 360s | 1–2 | 1–3 | 2400s |
-| `quality` | 1800 / 2400 / 2700s | 360 / 480 / 600s | 2–3 | 1–4 | 3600s |
-| `speed` | 420 / 600 / 720s | 180s | 1 | 1–4 | 1200s |
-
-Every strategy keeps `minimum_work_units=1`. Complexity, risk, repo-wide scope, or quality intent may raise only `maximum_work_units`; they never force a fake split. Parent raises the unit count only with an independent acceptance delta, validation boundary, and ownership/dependency evidence. High technical risk in `quality` may therefore permit up to three evidence-backed units while still allowing one unit when no natural split exists. A new bounded policy with `require_write_paths=true` requires every manifest unit to include a non-negative `generation` and non-empty normalized repo-relative POSIX `write_paths`. Older plans that omit the new fields retain legacy serial compatibility.
-
-`maximum_work_units` is checked by the deterministic work-unit validator after the plan is compiled. It is a manifest bound, not a quota or worker-count. When a strategy emits a task budget, the compiler requires its `max_work_units` to equal the implementation StagePolicy maximum. The validator also rejects duplicate acceptance deltas, unsafe paths, path overlap without a direct/transitive dependency, and any parallel group with missing/overlapping paths or dependencies.
-
-`write_paths` checks are static lexical preflight only. They reject absolute/traversal/glob/backslash/NUL/Windows drive or UNC forms and detect equal or ancestor/descendant overlaps; they do not resolve symlinks, lock the OS, fence processes, persist checkpoints, or enforce a durable scheduler. The surrounding runtime must enforce writable fencing and persist/compare the current `(scope_id, unit_id, generation)` lineage.
-
-Lifecycle soft timeout remains an advisory checkpoint/convergence budget. An unharvested received checkpoint is harvested before terminal success/failure, cancellation, idle, or hard-timeout fallback; a requested checkpoint without a payload does not defer hard/idle fallback. The first soft checkpoint is unchanged. A later checkpoint requires an explicit Worker `last_meaningful_progress_at` later than the latest harvested timestamp plus the policy's minimum `checkpoint_rearm_seconds` cooldown; legacy `last_progress_at` activity cannot re-arm a harvested checkpoint. Missing rearm policy keeps older plans one-shot. The lifecycle evaluator reports these decisions and cooldown observability (`checkpoint_rearm_at` / `checkpoint_rearm_remaining_seconds`); neither it nor the task helpers automatically schedule/cancel Workers.
-
-### Cumulative task budgets and phase-aware admission
-
-Every delegated built-in strategy emits `task_budget`; direct plans emit `task_budget=null`. The strategy value remains immutable planner intent, while the phase helper may derive a stricter effective **ledger soft timeout** for a new task when required review needs a completion tail.
-
-| Strategy | Task soft / hard | Max work units | Max implementation attempts | Replans | Replacements |
-| --- | --- | ---: | ---: | ---: | ---: |
-| `efficient` | 1500 / 1800s | 1–3 | work units + 1 | 1 | 1 |
-| `speed` | 1200 / 1800s | 1–4 | work units + 1 | 1 | 1 |
-| `balanced` | 2400–3000 / 3000–3600s | 1–3 | work units + 2 | 2 | 2 |
-| `quality` | 4800–6000 / 6000–7200s | 1–4 | work units + 3 | 3 | 3 |
-
-The wider balanced/quality envelopes are deliberate: task budgets are finite admission boundaries, not a demand that every strategy optimize to efficient's 30-minute target. Speed retains a 30-minute total hard cap. `task_budget.max_work_units` must equal `implementation_stage.maximum_work_units`.
-
-For a newly initialized phase-aware task with `reviewer_workers > 0`, the ledger is initialized through `task_phase_runtime.py init` using:
-
-```text
-effective_soft_timeout = min(
-  ExecutionPlan.task_budget.soft_timeout_seconds,
-  ExecutionPlan.task_budget.hard_timeout_seconds - review_stage.hard_timeout_seconds
-)
-```
-
-The hard timeout and every reservation counter are unchanged. This moves the raw ledger's real soft deadline to the general-work cutoff, so its atomic reserve path itself rejects genuinely new work after the cutoff while preserving idempotent replay of an already recorded reservation.
-
-General work means exploration plus writable implementation work, including work units, implementation attempts, replans, replacements, and Parent repairs that would reopen writes. At the effective soft deadline, no new general work starts. Existing writable implementation must checkpoint/converge and reach a terminal or safely harvested/fenced state before required completion consumes the reserved tail.
-
-Required completion means the immutable initial plan's already-required read-only independent review followed by Parent final verification. It is allowed after the effective soft deadline and until the absolute task hard deadline. A soft deadline therefore never silently skips `review_mode=independent+parent` or an explicit strict review. At the hard deadline no new reviewer, replacement Worker, or Parent writer starts.
-
-The first ExecutionPlan used to initialize the ledger becomes the task's **initial budget plan**. Every `task_phase_runtime.py status` or `reserve` call for the lifetime of that task continues to use that initial budget plan, even when material evidence causes a later ExecutionPlan recompile. The new plan controls current topology, role resources, lifecycle and remaining-delta execution, but it does not replace or extend the original ledger. Replan uses the same state path, counters, hard deadline, effective soft deadline, and initial budget-plan identity. If the recompiled plan would require work outside remaining original admission, it must converge/fail closed rather than reset the budget.
-
-For compatibility, `task_phase_runtime.py` recognizes a pre-phase running ledger whose stored fingerprint exactly matches the initial plan's original `task_budget`. That task is reported as `legacy_unclamped=true`; it keeps its old soft deadline and receives no retroactive review-tail reservation. New tasks are always initialized through the phase helper and use the clamped policy when required.
-
-The phase helper returns `permits_phase_start`, `permits_general_work`, `permits_required_completion`, `general_work_deadline`, `required_completion_reserve_seconds`, `checkpoint_convergence_required`, `required_completion_handoff`, and `legacy_unclamped`. The raw `task_budget_runtime.py` remains the durable atomic counter/ledger implementation; the phase helper is the scheduling admission layer. FlowPilot must not use raw `permits_new_work` as a generic spawn gate once phase-aware execution is active.
-
-### Efficient reasoning rollout
-
-The optional `[reasoning.rollout]` section is release-defaulted to:
-
-```toml
-[reasoning.rollout]
-mode = "shadow"
-minimum = "high"
-routine = "high"
-complex = "xhigh"
-critical = "max"
-```
-
-It is consumed only by delegated `efficient` Worker roles. The runtime first
-computes the historical (legacy) Worker effort. The proposal is then:
-
-```text
-max(rollout class target, rollout minimum, parent_reasoning)
-```
-
-`legacy` is a kill switch and selects the historical effort. `shadow` also
-selects historical effort but reports the proposal. `adaptive` selects the
-proposal, including when it equals Parent at the `max` ceiling. The plan's
-`reasoning_rollout` object records `mode`, `legacy_worker_reasoning`,
-`proposed_worker_reasoning`, `selected_worker_reasoning`, and `applied`; all
-planned Explorer/Implementer/Reviewer reasoning fields match the selected
-value. Direct and non-efficient plans emit `null` and retain their previous
-behavior.
-
-User policy may set the mode and floors. Repository policy can only raise the
-rollout floors and cannot change a user's `legacy` or `shadow` mode to
-`adaptive`. `--efficient-reasoning legacy|shadow|adaptive` is a current-task
-override and does not mutate persistent policy. The fields describe requested
-planner intent, not runtime-observed/effective effort. When per-spawn override
-is unsupported, the runtime falls back to the installed baseline; later
-telemetry may record the observed value. Rollout planning itself makes no
-telemetry calls and does not schedule Workers.
-
-Reasoning rollout remains intentionally efficient-specific in this change. The current policy surface and CLI are explicitly an efficient A/B rollout; balanced, quality, and speed keep their existing reasoning semantics until they have strategy-specific rollout contracts rather than inheriting efficient's proposal accidentally.
-
-## Built-in strategy budgets
-
-The numbers below are **maximum strategy envelopes**, not promises that every task will spawn that many agents. Runtime still requires task evidence and respects the configured thread ceiling.
-
-| Strategy | Typical demanding-task budget | Speculation | Writable fan-out | Quota-sensitive |
-| --- | --- | --- | --- | --- |
-| `efficient` | up to 2 explorers / 2 implementers / 1 reviewer / 5 total | low | only with proven isolation + aggressive modifier | yes |
-| `balanced` | up to 3 explorers / 3 implementers / 1 reviewer / 5 total | medium | proven isolated workstreams | yes |
-| `quality` normal | up to 4 explorers / 3 implementers / 2 reviewers / 6–7 total | high | proven isolated workstreams | no |
-| `quality` strong | up to 4 explorers / 3 implementers / 2 reviewers / 7 total | high | proven isolated workstreams | no |
-| `quality` absolute | up to 4 explorers / 4 implementers / 2 reviewers / 8 total | high | proven isolated workstreams | no |
-| `speed` | up to 4 explorers / 8 implementers / 1 reviewer / 8 total | high | saturate proven isolated workstreams | no |
-
-With the default runtime ceiling of four threads, a `speed` or absolute-quality plan can use four isolated implementers simultaneously when four real writable workstreams are proven.
-
-### `efficient`
-
-Objective: minimize expensive Parent usage and total waste while moving deep execution/debug loops to cheaper Workers.
-
-- small low-risk work stays direct;
-- iterative, cross-module, repo-wide, uncertain, or exploration-heavy work delegates more readily;
-- demanding work can use multiple explorers instead of forcing Parent to perform all discovery;
-- quota pressure collapses speculative fan-out and may reduce repair budget;
-- all roles remain on the configured efficient Worker capability policy.
-
-### `balanced`
-
-Objective: balance quality, quota, and latency.
-
-- moderate parallel exploration;
-- up to three isolated implementation workstreams;
-- quota pressure can reduce topology to a conservative shape;
-- Worker-role reasoning remains deeper than Parent reasoning;
-- convergence/recovery and cumulative task admission use the shared runtime with balanced-specific thresholds;
-- `quality_intent` does not change topology/resources because `balanced` does not consume it.
-
-### `quality`
-
-Objective: maximize correctness through deep reasoning, broader exploration, independent verification, and premium capability at the stages where it has the highest decision value.
-
-`quality_intent` has three levels:
-
-```text
-normal
-  ordinary quality target
-  prefer latest-efficient roles with deep/max reasoning
-
-strong
-  explicit quality-over-cost preference
-  target xhigh Parent / max Worker-role reasoning
-  ordinary Explorer stays latest-efficient
-  Implementer / Reviewer may use Parent-class latest-capable
-
-absolute
-  explicit highest-quality preference
-  correctness > quota / latency inside hard safety ceilings
-  target max Parent / max Worker-role reasoning
-  ordinary Explorer stays latest-efficient
-  Implementer / Reviewer may use Parent-class latest-capable
-  allow up to two independent reviewers and the largest quality WorkerBudget
-```
-
-Additional rules:
-
-- normal complex/high-risk/high-verification tasks still target `xhigh` Parent and `max` Worker-role reasoning;
-- high technical risk may raise bounded-unit maximum to three but never raises `minimum_work_units` above one;
-- `strong/absolute` quality preference alone does **not** make read-only exploration premium-model work;
-- when `complexity=critical` or `risk=critical`, Explorer / Implementer / Reviewer may all use Parent-class capability because discovery itself becomes high-risk decision work;
-- strong/absolute intent remains subject to runtime safety ceilings, write-conflict checks, proven writable workstreams, shared checkpoint/recovery, and the quality task envelope;
-- quota pressure does not cost-collapse `quality`, because the strategy is not quota-sensitive.
-
-This produces the intended economic shape for a routine strong-quality task:
-
-```text
-Parent       latest-capable / xhigh
-Explorer     latest-efficient / max
-Implementer  latest-capable / max
-Reviewer     latest-capable / max
-```
-
-Capability and reasoning remain independent: Explorer can be cheap-model `max` while Implementer/Reviewer use Parent-class `max`.
-
-### `speed`
-
-Objective: minimize wall-clock latency by saturating safe Worker concurrency.
-
-- non-small parallelizable work delegates;
-- writable implementation count scales with `writable_workstreams`, budget, and runtime ceiling instead of being hard-coded to two;
-- read-only exploration can fan out independently;
-- speed never authorizes overlapping writes;
-- shared task admission keeps repeated units/replans/replacements inside a 30-minute total hard cap;
-- `quality_intent` does not alter speed topology/resources.
-
-## Role Agents
-
-```text
-worker-explorer
-  read-only discovery, evidence collection, competing hypotheses
-
-worker-implementer
-  isolated implementation, tests, debugging, bounded repair
-
-worker-reviewer
-  independent read-only review, regression hunting, acceptance validation
-```
-
-The same role can be used differently by each strategy. ExecutionPlan v10 makes resource selection, optional task budget, and optional reasoning rollout explicit rather than treating “Worker” as one task-wide capability bucket.
-
-## Policy precedence
-
-Strongest to weakest:
-
-```text
-hard runtime / safety ceilings
-  > explicit current-task overrides
-  > repository .codex-flow.toml
-  > ~/.codex/codex-flow.toml
-  > codex-flow release defaults
-```
-
-Repository policy may choose strategy/routing/modifiers, raise reasoning floors, and tighten runtime ceilings. It cannot silently weaken user floors.
-
-## Policy schema v4
-
-The persistent policy remains schema v4. WorkerBudget and `quality_intent` are per-task ExecutionPlan concepts and therefore do **not** require a persistent-policy schema bump.
-
-```toml
-schema_version = 4
-
-[strategy]
-profile = "efficient"
-
-[routing]
-mode = "adaptive"
-
-[modifiers]
-review = "auto"
-fanout = "auto"
-```
-
-Current fresh-install reasoning defaults are intentionally asymmetric:
-
-```toml
-[parent]
-min_reasoning_effort = "high"
-routine_effort = "high"
-complex_effort = "high"
-critical_effort = "xhigh"
-
-[worker]
-min_reasoning_effort = "xhigh"
-routine_effort = "xhigh"
-complex_effort = "xhigh"
-critical_effort = "max"
-```
-
-Runtime then enforces for every delegated Worker role:
-
-```text
-role_reasoning >= next_tier(parent_reasoning)
-```
-
-where:
-
-```text
-high  → xhigh
-xhigh → max
-max   → max
-```
-
-User/repository floors can still raise either side. Capability escalation remains independent from this effort ladder.
-
-## Routing and modifiers
-
-Routing is independent from strategy:
-
-- `adaptive`: selected strategy supplies direct/delegate preference from TaskProfile;
-- `direct`: Parent executes with no subagents;
-- `delegate`: delegated execution when supported and safely scoped.
-
-Modifiers:
-
-```text
-review: auto | standard | strict
-fanout: auto | conservative | aggressive
-```
-
-`conservative` reduces speculative exploration and writable fan-out. `aggressive` can increase safe fan-out but still cannot invent isolated writable workstreams or exceed strategy/runtime budgets.
-
-## TaskProfile contract
-
-```text
-TaskProfile
-  complexity: small | routine | complex | critical
-  uncertainty: low | medium | high
-  risk: low | medium | high | critical
-  scope: local | module | cross-module | repo-wide
-  parallelism: none | limited | high
-  write_conflict: low | high
-  exploration_need: low | medium | high
-  verification_cost: low | medium | high
-  iteration_intensity: one-shot | iterative | heavy-loop
-  writable_workstreams: positive integer
-  quality_intent: normal | strong | absolute
-```
-
-`quality_intent` defaults to `normal`. It is set only from explicit current-task user intent. Generic requests to be careful, review code, or produce good work do not automatically imply `strong` or `absolute`.
-
-`writable_workstreams` is evidence, not a desired Worker count. `4` means four isolated non-overlapping writable scopes/worktrees have actually been identified. Runtime may then authorize up to four implementers if strategy budget and hard ceilings allow it.
-
-`parallelism=none` remains a hard TaskProfile constraint: execution stages are sequential and explorer fan-out is disabled.
-
-## Dynamic fan-out
-
-Runtime calculates **strategy-agnostic base exploration demand** from:
-
-```text
-uncertainty
-exploration_need
-complexity
-scope
-verification_cost
-```
-
-The selected strategy may add `exploration_bonus(task)`. For example, only `quality` translates `strong/absolute quality_intent` into extra exploration demand. Therefore the same `quality_intent` on `balanced` cannot silently create extra explorers.
-
-Writable implementation fan-out requires all of:
-
-```text
-parallelism == high
-write_conflict == low
-writable_workstreams >= 2
-strategy allows parallel write OR fanout modifier == aggressive
-```
-
-Implementation count is bounded by:
-
-```text
-writable_workstreams
-strategy.worker_budget.max_implementers
-runtime.max_concurrent_threads
-```
-
-Review demand follows the same split: Runtime owns a generic technical-risk base formula; the selected strategy may add `reviewer_bonus(task)`. Absolute quality uses that hook to request the second independent reviewer.
-
-The total plan can therefore look like:
-
-```text
-2 explorers
-→ 4 isolated implementers
-→ 2 independent reviewers
-→ Parent final verification
-```
-
-while `max_concurrent_threads=4`, because at no single stage are more than four Workers active concurrently.
-
-## RuntimeState and quota
-
-```text
-quota_pressure: unknown | low | medium | high | critical
-max_concurrent_threads
-max_repair_cycles
-```
-
-Quota is read from the existing app-server rate-limit path and normalized before strategy use. `unknown` is used when reliable state is unavailable.
-
-For quota-sensitive strategies (`efficient`, `balanced`), high/critical pressure can reduce explorers, implementers, reviewers, and repair budget. It does **not** reduce configured reasoning floors or the Worker-role-over-Parent reasoning invariant.
-
-`quality` is deliberately not quota-sensitive. Strong/absolute quality retains Parent-class capability for high-value Implementer/Reviewer roles under quota pressure; ordinary Explorer capability remains independently selected. Hard runtime and safety ceilings still apply.
-
-## ExecutionPlan v10
-
-The deterministic planner emits:
+The important runtime fields are:
 
 ```text
 ExecutionPlan
-  schema_version = 10
+  schema_version = 11
   strategy
   routing
   review_modifier
   fanout_modifier
   quality_intent
 
-  parent_capability_policy
-  parent_model_floor
-  parent_reasoning
+  parent_* capability/reasoning
+  explorer_* capability/model/reasoning | none
+  implementer_* capability/model/reasoning | none
+  reviewer_* capability/model/reasoning | none
   reasoning_rollout | none
-    mode: legacy | shadow | adaptive
-    legacy_worker_reasoning
-    proposed_worker_reasoning
-    selected_worker_reasoning
-    applied
-
-  explorer_capability_policy | none
-  explorer_model | none
-  explorer_reasoning | none
-
-  implementer_capability_policy | none
-  implementer_model | none
-  implementer_reasoning | none
-
-  reviewer_capability_policy | none
-  reviewer_model | none
-  reviewer_reasoning | none
 
   worker_budget
-    max_explorers
-    max_implementers
-    max_reviewers
-    max_total_workers
-    speculation
+  exploration_workers
+  implementation_workers
+  reviewer_workers
+  planned_worker_count
+  max_concurrent_threads
+
+  exploration_stage | none
+  implementation_stage | none
+  review_stage | none
 
   task_budget | none
     soft_timeout_seconds
@@ -571,119 +120,286 @@ ExecutionPlan
     max_implementation_attempts
     max_replans
     max_replacements
+    max_review_attempts
+    parent_finalization_seconds
 
-  exploration_workers
-  implementation_workers
-  reviewer_workers
-  planned_worker_count
-  exploration_stage | none
-  implementation_stage | none
-  review_stage | none
-    join_policy
-    min_successful_workers
-    idle_timeout_seconds
-    hard_timeout_seconds
-    soft_timeout_seconds | none
-    checkpoint_rearm_seconds | none
-    max_worker_repair_attempts | none
-    work_unit_mode: single | bounded
-    minimum_work_units
-    join_between_work_units
-    maximum_work_units | none
-    require_write_paths
-    cancel_if_superseded
-    cancel_stragglers_after_quorum
-    fallback_policy
   review_mode
-
   max_repair_cycles
-  max_concurrent_threads
-  escalate_on_failure
   quota_pressure
-  repo_policy | none
-  context_mode
   notes
 ```
 
-The concrete per-role resource fields and `*_workers` values are authoritative. FlowPilot must execute them and must not reinterpret either the strategy name or quality intent after compilation. `task_budget` is planner intent; the phase helper's effective soft timeout is derived at ledger initialization and returned as `effective_task_budget`.
+Direct plans have no delegated stages and `task_budget=null`.
 
-When an execution stage is absent, its role resources are `none`. For example, if `exploration_workers=0`, all `explorer_*` fields are `none`; when `review_mode=parent`, `reviewer_workers=0` and all `reviewer_*` fields are `none`.
-
-## Anti-monolith guard
-
-Tests explicitly reject built-in strategy comparisons in `scripts/strategy_runtime.py`:
+For delegated work, compiler validation includes:
 
 ```text
-strategy == "efficient"
-strategy == "balanced"
-strategy == "quality"
-strategy == "speed"
+implementation_stage.maximum_work_units == task_budget.max_work_units
+implementation_workers <= task_budget.max_work_units
+implementation_workers <= task_budget.max_implementation_attempts
+reviewer_workers <= task_budget.max_review_attempts  # when review is planned
 ```
 
-and their `!=` forms. This guard is intentionally regex-based so it matches the real source text rather than escaped shell literals.
+When no reviewer Worker is planned, canonical `max_review_attempts=0`.
 
-Behavioral tests additionally compare `balanced` plans under `quality_intent=normal` and `strong` and require topology/resources to remain identical. Role-resource tests require routine strong/absolute quality to keep Explorer efficient while promoting Implementer/Reviewer.
+## Shared Worker lifecycle
 
-## Installer and update round-trip
+All four strategies use the same lifecycle mechanics. Strategies tune only thresholds and maximum logical units.
 
-For supported global policy fields:
+| Strategy | Implementation soft checkpoint | Rearm | Worker-local repairs | Max logical units | Worker hard ceiling |
+| --- | --- | --- | --- | --- | --- |
+| `efficient` | 600 / 900 / 1200s | 180 / 240 / 300s | 1–2 | 1–3 | 1800s |
+| `balanced` | 1200 / 1500 / 1800s | 240 / 300 / 360s | 1–2 | 1–3 | 2400s |
+| `quality` | 1800 / 2400 / 2700s | 360 / 480 / 600s | 2–3 | 1–4 | 3600s |
+| `speed` | 420 / 600 / 720s | 180s | 1 | 1–4 | 1200s |
+
+Lifecycle semantics:
+
+- `last_progress_at` is liveness activity.
+- `last_meaningful_progress_at` is acceptance-relevant progress.
+- soft timeout requests/converges toward checkpoints but does not itself cancel a Worker.
+- repeated checkpoint requests require explicit meaningful progress after the latest harvest plus `checkpoint_rearm_seconds`.
+- an unharvested received checkpoint is harvested before terminal failure, hard timeout, idle fallback, cancellation handling, or writer replacement.
+- implementation `replan` operates on uncovered/remaining delta, not the original complete task.
+
+### Review lifecycle
+
+Review fallback is `retry_review`.
+
+It is intentionally distinct from implementation `replan`:
 
 ```text
-explicit CODEX_FLOW_* environment override
-  > existing ~/.codex/codex-flow.toml value
-  > policy/defaults.toml release value
+review failure
+  → retry_review
+  → read-only replacement_allowed
+  → consume review_attempt
+  → no replan_scope
+  → no writable scope
+  → no writer fence
 ```
 
-Existing users keep their configured reasoning matrix during reinstall/update. Fresh installs receive the Worker-first defaults. `quality_intent` is not persisted by the installer because it is a current-task semantic signal.
+A reviewer retry can occur only while phase admission says `permits_review_start=true`.
 
-The optional reasoning-rollout matrix is round-tripped as well. Missing
-`[reasoning.rollout]` on a schema-v3/v4 policy defaults to release `shadow`
-(`high/high/xhigh/max`). The policy schema does not bump. The Unix and
-PowerShell installers preserve existing rollout mode/floors and validate new
-values; the Codex global `default_subagent_reasoning_effort` remains the
-legacy Worker minimum and is not lowered to the rollout's `high` minimum.
+## Evidence-based bounded implementation
 
-Both installers copy the entire `scripts/strategies` directory into the installed state directory, so `task_phase_runtime.py` is delivered together with lifecycle, work-unit, and task-budget helpers on Unix and Windows.
+`StagePolicy` carries:
 
-## CLI
+```text
+work_unit_mode: single | bounded
+minimum_work_units
+join_between_work_units
+maximum_work_units | none
+require_write_paths
+```
+
+All built-in strategies keep `minimum_work_units=1`. Complexity/risk/scope/quality may raise only the maximum.
+
+A split is valid only when Parent has evidence for an independent acceptance delta, validation boundary, ownership/dependency boundary, or already-proven isolated writable stream. Do not split solely to satisfy a number.
+
+For strategies that permit parallel writers, `implementation_maximum_work_units()` also accounts for real writer topology:
+
+```text
+topology_floor = min(writable_workstreams, strategy.max_implementers)
+maximum_work_units = max(semantic_maximum, topology_floor)
+```
+
+This prevents impossible plans such as four proven implementers with only one logical unit/attempt budget.
+
+The deterministic manifest validator checks:
+
+- required unit fields and types;
+- normalized repository-relative POSIX `write_paths`;
+- no absolute/traversal/glob/backslash/NUL/Windows-drive paths;
+- dependency ordering for overlapping paths/write scopes;
+- no dependency-linked units inside one parallel group;
+- parallel width <= compiled implementation/thread concurrency;
+- manifest count <= `maximum_work_units`.
+
+`write_paths` are lexical preflight only. They are not OS locks, symlink resolution, or durable scheduler fencing.
+
+## Canonical cumulative task budget
+
+Each delegated built-in strategy emits a raw task envelope. The compiler then canonicalizes it against the actual planned topology/review stage.
+
+Typical raw general-work envelopes:
+
+| Strategy | Soft | Base hard | Work units | Implementation attempts | Replans | Replacements | Review attempts | Parent finalization |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `efficient` | 1500s | 1800s | 1–3 | units + 1 | 1 | 1 | 2 | 150s |
+| `speed` | 1200s | 1800s | 1–4 | units + 1 | 1 | 1 | 2 | 120s |
+| `balanced` | 2400–3000s | 3000–3600s | 1–3 | units + 2 | 2 | 2 | 2 | 180s |
+| `quality` | 4800–6000s | 6000–7200s | 1–4 | units + 3 | 3 | 3 | 2–4 | 300s |
+
+When reviewer Workers are planned:
+
+```text
+completion_tail = review_stage.hard_timeout_seconds
+                + task_budget.parent_finalization_seconds
+
+canonical_hard = max(
+  raw_hard,
+  task_budget.soft_timeout_seconds + completion_tail
+)
+```
+
+The resulting canonical budget is written directly into ExecutionPlan. No runtime helper later rewrites the soft/hard values.
+
+Example: `efficient + strict review` keeps its complete 1500-second general-work window and receives the required completion tail instead of shrinking implementation to make review fit.
+
+## Phase-aware admission
+
+Initialize the task ledger with the exact initial ExecutionPlan:
 
 ```bash
-codex-flow strategy show
-codex-flow strategy show --effective
-codex-flow strategy profiles
-codex-flow strategy set quality
-codex-flow strategy routing adaptive
-
-codex-flow strategy plan --efficient-reasoning legacy|shadow|adaptive --complexity complex
-
-codex-flow strategy plan \
-  --profile quality \
-  --quality-intent strong \
-  --complexity complex \
-  --uncertainty high \
-  --parallelism high
-
-codex-flow strategy plan \
-  --profile quality \
-  --quality-intent absolute \
-  --parallelism high \
-  --write-conflict low \
-  --writable-workstreams 4
+python3 ~/.codex/codex-flow/strategies/task_phase_runtime.py init \
+  --state-file <state> \
+  --task-id <task-id> \
+  --plan-json '<ExecutionPlan v11 JSON>' \
+  --now <unix-seconds>
 ```
 
-The resulting JSON shows quality intent, WorkerBudget, strategy-owned task budget for delegated built-in strategies, concrete per-stage Worker counts, separate Explorer / Implementer / Reviewer capability/model/reasoning resources, and (for delegated efficient work) the reasoning-rollout decision. Legacy/proposed/selected fields are planner intent; they are not runtime-observed usage. If per-spawn overrides are unavailable, the installed baseline is used and later telemetry may record the observed effort.
+The initial budget-plan identity owns this ledger for the task lifetime. A later recompiled plan may control current execution semantics but cannot replace/reset/extend the original ledger.
 
-## Adding a new built-in strategy
+The phase timeline is:
 
-A new strategy should:
+```text
+started_at
+  |
+  | general exploration + writable implementation
+  v
+soft_deadline = general_work_deadline
+  |
+  | required read-only review
+  v
+review_deadline = hard_deadline - parent_finalization_seconds
+  |
+  | Parent finalization only
+  v
+hard_deadline = absolute stop
+```
 
-1. add `scripts/strategies/<name>.py`;
-2. export one `STRATEGY = StrategySpec(...)`;
-3. define a clear optimization objective, WorkerBudget, and only the resource/demand hooks it needs;
-4. register the strategy in `scripts/strategies/__init__.py`;
-5. reuse TaskProfile and ExecutionPlan contracts;
-6. avoid model-slug-specific semantics;
-7. leave isolation checks, reasoning invariant, modifiers, quota enforcement, hard ceilings, task-ledger mechanics, and phase admission in shared Runtime;
-8. never add built-in-strategy literal branches to the generic compiler;
-9. add deterministic planner tests, including isolation from unrelated task semantics;
-10. avoid creating a new Skill/Agent unless a genuinely new execution role exists.
+### General work
+
+General reservation kinds:
+
+```text
+work_unit
+implementation_attempt
+replan
+replacement
+```
+
+They must use `phase=implementation`. New general reservations are rejected at soft deadline. Exact replay of an already-recorded reservation stays idempotent because the durable ledger checks identity before its deadline gate.
+
+### Required review
+
+Reviewer starts/retries reserve:
+
+```text
+phase=required_completion
+kind=review_attempt
+```
+
+A new reviewer is admitted only before `review_deadline`. At/after that boundary, phase action becomes `finalize_parent`; no reviewer start/retry may consume the Parent finalization reserve.
+
+### Parent finalization
+
+From `review_deadline` until hard deadline:
+
+- no new reviewer;
+- no reopened writable implementation;
+- Parent reconciles already-collected review evidence and runs final non-writing verification/delivery work;
+- at hard deadline action is `stop`.
+
+Important phase output:
+
+```text
+permits_general_work
+permits_required_completion
+permits_review_start
+permits_parent_finalization
+general_work_deadline
+review_deadline
+hard_deadline
+checkpoint_convergence_required
+required_completion_handoff
+action
+```
+
+## Durable ledger
+
+`task_budget_runtime.py` schema v2 stores hashes/limits/reservations, not prompts or output payloads.
+
+Reservation kinds:
+
+```text
+work_unit
+implementation_attempt
+replan
+replacement
+review_attempt
+```
+
+The ledger uses file locking, atomic replace, monotonic timestamps, policy/task fingerprints, bounded counters, and idempotent reservation IDs.
+
+The phase helper is the scheduling/admission layer. Raw ledger flags are not a substitute for phase-specific decisions.
+
+## Initial-plan identity and replan
+
+Replanning never receives a fresh task budget.
+
+```text
+initial ExecutionPlan
+  → initialize ledger once
+  → reserve/execute
+  → evidence changes
+  → compile newer ExecutionPlan for current topology/lifecycle
+  → keep initial plan + same ledger for cumulative admission
+```
+
+If newer execution cannot fit the remaining original budget, converge/fail closed rather than resetting counters/deadlines.
+
+Completed bounded units and harvested checkpoints remain evidence unless concrete new information invalidates them.
+
+## Efficient reasoning rollout
+
+Reasoning rollout remains intentionally `efficient`-specific:
+
+```text
+legacy   select historical Worker effort
+shadow   report proposal, select historical effort
+adaptive select proposal
+```
+
+Proposal:
+
+```text
+max(rollout class target, rollout minimum, parent_reasoning)
+```
+
+The plan records intent. Runtime-observed effort must come from runtime evidence and must not be fabricated from the requested value.
+
+## Quota and telemetry
+
+Quota state comes from reliable runtime/app-server data or is `unknown`; it is never guessed.
+
+Telemetry is deterministic and observational. A telemetry failure is fail-open and must not block checkpoint harvest, fencing, cancellation, or delivery.
+
+Use homogeneous samples and success/censoring context before tuning latency thresholds or moving an effort rollout from shadow to adaptive.
+
+## Current limitations
+
+The contract deliberately distinguishes deterministic policy from capabilities supplied by the surrounding scheduler/runtime:
+
+- `write_paths` do not provide OS-level locking or symlink-safe ownership.
+- lifecycle helpers evaluate state but do not independently schedule/cancel Workers.
+- checkpoints require the surrounding runtime to persist/use the returned payload.
+- generation lineage must be enforced when integrating real Worker output.
+- reasoning rollout is currently efficient-specific.
+- task-budget values are policy envelopes, not empirical latency predictions.
+
+These limitations should be addressed through scheduler/runtime integration and telemetry-guided tuning, not by weakening the deterministic contracts above.
+
+## Version invariant
+
+Persistent policy schema remains v4. ExecutionPlan schema v11 and task-ledger schema v2 are the only supported interpretation of this unreleased task-execution contract. There is intentionally no `legacy_unclamped`, effective-budget migration, or grandfathered pre-phase task-ledger path.

--- a/docs/strategy-runtime.md
+++ b/docs/strategy-runtime.md
@@ -42,7 +42,7 @@ The critical invariant is:
 
 > **FlowPilot profiles. `strategy_runtime.py` plus the strategy registry decide. FlowPilot executes the returned plan.**
 
-The Skill must not keep another copy of strategy topology, Worker counts, capability selection, reasoning policy, review policy, task-budget policy, or quota logic.
+The Skill must not keep another copy of strategy topology, Worker counts, capability selection, reasoning policy, review policy, task-budget policy, phase-admission policy, or quota logic.
 
 ## Design invariants
 
@@ -72,6 +72,9 @@ The Skill must not keep another copy of strategy topology, Worker counts, capabi
 24. **Lineage is explicit.** Bounded units use `(scope_id, unit_id, generation)`; replacement/replan increments generation, checkpoint/continue does not, and Parent accepts only current-generation evidence.
 25. **Reasoning rollout is scoped and observable.** Only delegated `efficient` Worker roles consume the optional `legacy|shadow|adaptive` decision; direct/non-efficient plans remain unchanged, and proposed/selected effort is planner intent rather than runtime-observed usage.
 26. **Every delegated built-in strategy has a cumulative task envelope.** Task budgets are strategy-owned and differ by optimization objective, but all use the same durable admission ledger and cannot be reset by replanning.
+27. **Required completion has a reserved tail.** A new delegated task with reviewer Workers stores an effective ledger soft deadline early enough to preserve the immutable plan's review-stage hard window. General work stops there; required read-only review may continue until the absolute task hard deadline.
+28. **The initial budget plan owns the ledger for the whole task.** A later replan may change execution topology but cannot replace, extend, or reinitialize the task budget. Phase status/reservation continues to use the initial budget-plan identity.
+29. **Running old ledgers are grandfathered.** A task initialized before phase-aware admission retains its original soft deadline and does not gain a retroactive review-tail reservation after an upgrade.
 
 ## Strategy Registry, WorkerBudget, and resource hooks
 
@@ -87,7 +90,8 @@ scripts/strategies/
 ├── speed.py
 ├── lifecycle_runtime.py
 ├── work_unit_runtime.py
-└── task_budget_runtime.py
+├── task_budget_runtime.py
+└── task_phase_runtime.py
 ```
 
 `base.py` defines `StrategySpec`, `WorkerBudget`, the optional `TaskBudgetPolicy` hook, and strict `ReasoningRolloutPolicy` / `ReasoningRolloutDecision` contracts.
@@ -157,7 +161,7 @@ checkpoint_rearm_seconds | none
 max_worker_repair_attempts | none
 ```
 
-All four built-in strategies now use the same convergence/recovery contract for delegated implementation: first soft checkpoint, explicit-meaningful-progress multi-round checkpoint rearm, harvest-before-fallback, remaining-delta replan, local repair bounds, generation lineage, and evidence-based bounded units. Strategy modules tune only the thresholds and maximum logical units.
+All four built-in strategies use the same convergence/recovery contract for delegated implementation: first soft checkpoint, explicit-meaningful-progress multi-round checkpoint rearm, harvest-before-fallback, remaining-delta replan, local repair bounds, generation lineage, and evidence-based bounded units. Strategy modules tune only the thresholds and maximum logical units.
 
 | Strategy | Implementation soft checkpoint | Rearm cooldown | Local repairs | Max work units | Worker hard ceiling |
 | --- | --- | --- | --- | --- | --- |
@@ -166,17 +170,17 @@ All four built-in strategies now use the same convergence/recovery contract for 
 | `quality` | 1800 / 2400 / 2700s | 360 / 480 / 600s | 2–3 | 1–4 | 3600s |
 | `speed` | 420 / 600 / 720s | 180s | 1 | 1–4 | 1200s |
 
-Every strategy keeps `minimum_work_units=1`. Complexity, risk, repo-wide scope, or quality intent may raise only `maximum_work_units`; they never force a fake split. Parent raises the unit count only with an independent acceptance delta, validation boundary, and ownership/dependency evidence. A new bounded policy with `require_write_paths=true` requires every manifest unit to include a non-negative `generation` and non-empty normalized repo-relative POSIX `write_paths`. Older plans that omit the new fields retain legacy serial compatibility.
+Every strategy keeps `minimum_work_units=1`. Complexity, risk, repo-wide scope, or quality intent may raise only `maximum_work_units`; they never force a fake split. Parent raises the unit count only with an independent acceptance delta, validation boundary, and ownership/dependency evidence. High technical risk in `quality` may therefore permit up to three evidence-backed units while still allowing one unit when no natural split exists. A new bounded policy with `require_write_paths=true` requires every manifest unit to include a non-negative `generation` and non-empty normalized repo-relative POSIX `write_paths`. Older plans that omit the new fields retain legacy serial compatibility.
 
 `maximum_work_units` is checked by the deterministic work-unit validator after the plan is compiled. It is a manifest bound, not a quota or worker-count. When a strategy emits a task budget, the compiler requires its `max_work_units` to equal the implementation StagePolicy maximum. The validator also rejects duplicate acceptance deltas, unsafe paths, path overlap without a direct/transitive dependency, and any parallel group with missing/overlapping paths or dependencies.
 
 `write_paths` checks are static lexical preflight only. They reject absolute/traversal/glob/backslash/NUL/Windows drive or UNC forms and detect equal or ancestor/descendant overlaps; they do not resolve symlinks, lock the OS, fence processes, persist checkpoints, or enforce a durable scheduler. The surrounding runtime must enforce writable fencing and persist/compare the current `(scope_id, unit_id, generation)` lineage.
 
-Lifecycle soft timeout remains an advisory checkpoint/convergence budget. An unharvested received checkpoint is harvested before terminal success/failure, cancellation, idle, or hard-timeout fallback; a requested checkpoint without a payload does not defer hard/idle fallback. The first soft checkpoint is unchanged. A later checkpoint requires an explicit Worker `last_meaningful_progress_at` later than the latest harvested timestamp plus the policy's minimum `checkpoint_rearm_seconds` cooldown; legacy `last_progress_at` activity cannot re-arm a harvested checkpoint. Missing rearm policy keeps older plans one-shot. The lifecycle evaluator reports these decisions and cooldown observability (`checkpoint_rearm_at` / `checkpoint_rearm_remaining_seconds`), while `scripts/strategies/task_budget_runtime.py` provides the separate cross-process task ledger; neither helper automatically schedules or cancels Workers.
+Lifecycle soft timeout remains an advisory checkpoint/convergence budget. An unharvested received checkpoint is harvested before terminal success/failure, cancellation, idle, or hard-timeout fallback; a requested checkpoint without a payload does not defer hard/idle fallback. The first soft checkpoint is unchanged. A later checkpoint requires an explicit Worker `last_meaningful_progress_at` later than the latest harvested timestamp plus the policy's minimum `checkpoint_rearm_seconds` cooldown; legacy `last_progress_at` activity cannot re-arm a harvested checkpoint. Missing rearm policy keeps older plans one-shot. The lifecycle evaluator reports these decisions and cooldown observability (`checkpoint_rearm_at` / `checkpoint_rearm_remaining_seconds`); neither it nor the task helpers automatically schedule/cancel Workers.
 
-### Cumulative task budgets
+### Cumulative task budgets and phase-aware admission
 
-Every delegated built-in strategy now emits `task_budget`; direct plans emit `task_budget=null`. The exact policy is strategy-owned and immutable for the task ledger.
+Every delegated built-in strategy emits `task_budget`; direct plans emit `task_budget=null`. The strategy value remains immutable planner intent, while the phase helper may derive a stricter effective **ledger soft timeout** for a new task when required review needs a completion tail.
 
 | Strategy | Task soft / hard | Max work units | Max implementation attempts | Replans | Replacements |
 | --- | --- | ---: | ---: | ---: | ---: |
@@ -185,11 +189,28 @@ Every delegated built-in strategy now emits `task_budget`; direct plans emit `ta
 | `balanced` | 2400–3000 / 3000–3600s | 1–3 | work units + 2 | 2 | 2 |
 | `quality` | 4800–6000 / 6000–7200s | 1–4 | work units + 3 | 3 | 3 |
 
-The wider balanced/quality envelopes are deliberate: task budgets are a finite admission boundary, not a demand that every strategy optimize to efficient's 30-minute target. Speed retains a 30-minute total hard cap. `task_budget.max_work_units` must equal `implementation_stage.maximum_work_units`.
+The wider balanced/quality envelopes are deliberate: task budgets are finite admission boundaries, not a demand that every strategy optimize to efficient's 30-minute target. Speed retains a 30-minute total hard cap. `task_budget.max_work_units` must equal `implementation_stage.maximum_work_units`.
 
-FlowPilot initializes the ledger immediately after initial compilation, checks `status` before every Worker spawn and after each join/wait, reserves logical work units/implementation attempts/replans/replacements, and calls `finish` when the task completes. Exploration/review Workers consume the wall-clock deadline but not implementation counters. Replanning reuses the original state path and cannot reset counters. Bounded `work_unit` reservations use the validator's stable logical fingerprint (generation excluded); `implementation_attempt` reservations use the generation-aware fingerprint. At the plan's soft deadline no new work may start; existing Workers checkpoint/converge. At the plan's hard deadline received checkpoints are harvested first, then active writers are fenced/cancelled and no replacement or Parent writer may start. The helper stores task/policy hashes and reservation hashes rather than raw prompt, path, or output data; it returns decisions but is not a scheduler.
+For a newly initialized phase-aware task with `reviewer_workers > 0`, the ledger is initialized through `task_phase_runtime.py init` using:
 
-FlowPilot must read the exact soft/hard deadlines and counters from the immutable ExecutionPlan. It must never hard-code efficient's `1500/1800` values for another strategy.
+```text
+effective_soft_timeout = min(
+  ExecutionPlan.task_budget.soft_timeout_seconds,
+  ExecutionPlan.task_budget.hard_timeout_seconds - review_stage.hard_timeout_seconds
+)
+```
+
+The hard timeout and every reservation counter are unchanged. This moves the raw ledger's real soft deadline to the general-work cutoff, so its atomic reserve path itself rejects genuinely new work after the cutoff while preserving idempotent replay of an already recorded reservation.
+
+General work means exploration plus writable implementation work, including work units, implementation attempts, replans, replacements, and Parent repairs that would reopen writes. At the effective soft deadline, no new general work starts. Existing writable implementation must checkpoint/converge and reach a terminal or safely harvested/fenced state before required completion consumes the reserved tail.
+
+Required completion means the immutable initial plan's already-required read-only independent review followed by Parent final verification. It is allowed after the effective soft deadline and until the absolute task hard deadline. A soft deadline therefore never silently skips `review_mode=independent+parent` or an explicit strict review. At the hard deadline no new reviewer, replacement Worker, or Parent writer starts.
+
+The first ExecutionPlan used to initialize the ledger becomes the task's **initial budget plan**. Every `task_phase_runtime.py status` or `reserve` call for the lifetime of that task continues to use that initial budget plan, even when material evidence causes a later ExecutionPlan recompile. The new plan controls current topology, role resources, lifecycle and remaining-delta execution, but it does not replace or extend the original ledger. Replan uses the same state path, counters, hard deadline, effective soft deadline, and initial budget-plan identity. If the recompiled plan would require work outside remaining original admission, it must converge/fail closed rather than reset the budget.
+
+For compatibility, `task_phase_runtime.py` recognizes a pre-phase running ledger whose stored fingerprint exactly matches the initial plan's original `task_budget`. That task is reported as `legacy_unclamped=true`; it keeps its old soft deadline and receives no retroactive review-tail reservation. New tasks are always initialized through the phase helper and use the clamped policy when required.
+
+The phase helper returns `permits_phase_start`, `permits_general_work`, `permits_required_completion`, `general_work_deadline`, `required_completion_reserve_seconds`, `checkpoint_convergence_required`, `required_completion_handoff`, and `legacy_unclamped`. The raw `task_budget_runtime.py` remains the durable atomic counter/ledger implementation; the phase helper is the scheduling admission layer. FlowPilot must not use raw `permits_new_work` as a generic spawn gate once phase-aware execution is active.
 
 ### Efficient reasoning rollout
 
@@ -296,6 +317,7 @@ absolute
 Additional rules:
 
 - normal complex/high-risk/high-verification tasks still target `xhigh` Parent and `max` Worker-role reasoning;
+- high technical risk may raise bounded-unit maximum to three but never raises `minimum_work_units` above one;
 - `strong/absolute` quality preference alone does **not** make read-only exploration premium-model work;
 - when `complexity=critical` or `risk=critical`, Explorer / Implementer / Reviewer may all use Parent-class capability because discovery itself becomes high-risk decision work;
 - strong/absolute intent remains subject to runtime safety ceilings, write-conflict checks, proven writable workstreams, shared checkpoint/recovery, and the quality task envelope;
@@ -583,7 +605,7 @@ ExecutionPlan
   notes
 ```
 
-The concrete per-role resource fields and `*_workers` values are authoritative. FlowPilot must execute them and must not reinterpret either the strategy name or quality intent after compilation.
+The concrete per-role resource fields and `*_workers` values are authoritative. FlowPilot must execute them and must not reinterpret either the strategy name or quality intent after compilation. `task_budget` is planner intent; the phase helper's effective soft timeout is derived at ledger initialization and returned as `effective_task_budget`.
 
 When an execution stage is absent, its role resources are `none`. For example, if `exploration_workers=0`, all `explorer_*` fields are `none`; when `review_mode=parent`, `reviewer_workers=0` and all `reviewer_*` fields are `none`.
 
@@ -620,6 +642,8 @@ The optional reasoning-rollout matrix is round-tripped as well. Missing
 PowerShell installers preserve existing rollout mode/floors and validate new
 values; the Codex global `default_subagent_reasoning_effort` remains the
 legacy Worker minimum and is not lowered to the rollout's `high` minimum.
+
+Both installers copy the entire `scripts/strategies` directory into the installed state directory, so `task_phase_runtime.py` is delivered together with lifecycle, work-unit, and task-budget helpers on Unix and Windows.
 
 ## CLI
 
@@ -659,7 +683,7 @@ A new strategy should:
 4. register the strategy in `scripts/strategies/__init__.py`;
 5. reuse TaskProfile and ExecutionPlan contracts;
 6. avoid model-slug-specific semantics;
-7. leave isolation checks, reasoning invariant, modifiers, quota enforcement, and hard ceilings in `strategy_runtime.py`;
+7. leave isolation checks, reasoning invariant, modifiers, quota enforcement, hard ceilings, task-ledger mechanics, and phase admission in shared Runtime;
 8. never add built-in-strategy literal branches to the generic compiler;
 9. add deterministic planner tests, including isolation from unrelated task semantics;
 10. avoid creating a new Skill/Agent unless a genuinely new execution role exists.

--- a/docs/strategy-runtime.md
+++ b/docs/strategy-runtime.md
@@ -302,6 +302,8 @@ kind=review_attempt
 
 A new reviewer is admitted only before `review_deadline`. At/after that boundary, phase action becomes `finalize_parent`; no reviewer start/retry may consume the Parent finalization reserve.
 
+The phase helper deliberately rejects reviewer admission once that window closes. The raw ledger remains an atomic counter store and is not a standalone scheduler/admission API for reviewer spawning.
+
 ### Parent finalization
 
 From `review_deadline` until hard deadline:

--- a/docs/strategy-runtime.md
+++ b/docs/strategy-runtime.md
@@ -302,7 +302,7 @@ kind=review_attempt
 
 A new reviewer is admitted only before `review_deadline`. At/after that boundary, phase action becomes `finalize_parent`; no reviewer start/retry may consume the Parent finalization reserve.
 
-The phase helper deliberately rejects reviewer admission once that window closes. The raw ledger remains an atomic counter store and is not a standalone scheduler/admission API for reviewer spawning.
+`task_phase_runtime.py` is the mandatory reviewer admission gate. Callers must not bypass it by invoking raw `task_budget_runtime.py reserve --kind review_attempt` directly.
 
 ### Parent finalization
 

--- a/docs/strategy-runtime.md
+++ b/docs/strategy-runtime.md
@@ -43,10 +43,11 @@ The Skill must not keep a second copy of strategy topology, Worker counts, role 
 11. ExecutionPlan is the only canonical task-budget source. Phase runtime validates and executes it; it does not derive a second budget.
 12. Required review and Parent finalization have explicit time windows.
 13. Review failure retries are read-only `retry_review`, not writable implementation replans.
-14. A returned checkpoint is harvested before any fallback that could discard useful work.
-15. `wait()` timeouts are not Worker timeouts.
-16. Telemetry is observational and never calls a model only to estimate usage or latency.
-17. The new task-ledger contract has no grandfather/adoption path because no earlier persisted-task format containing this feature was released. Incompatible task-ledger schema/policy fails closed.
+14. `action=finalize_parent` closes reviewer admission; it does not prove that a required/quorum reviewer join succeeded. Unsatisfied required review fails closed.
+15. A returned checkpoint is harvested before any fallback that could discard useful work.
+16. `wait()` timeouts are not Worker timeouts.
+17. Telemetry is observational and never calls a model only to estimate usage or latency.
+18. The new task-ledger contract has no grandfather/adoption path because no earlier persisted-task format containing this feature was released. Incompatible task-ledger schema/policy fails closed.
 
 ## Strategy registry
 
@@ -144,14 +145,14 @@ When no reviewer Worker is planned, canonical `max_review_attempts=0`.
 
 ## Shared Worker lifecycle
 
-All four strategies use the same lifecycle mechanics. Strategies tune only thresholds and maximum logical units.
+All four strategies use the same lifecycle mechanics. Strategies tune thresholds and semantic logical-unit baselines; already-proven isolated writable topology may raise the total logical-unit envelope within the strategy WorkerBudget.
 
-| Strategy | Implementation soft checkpoint | Rearm | Worker-local repairs | Max logical units | Worker hard ceiling |
+| Strategy | Implementation soft checkpoint | Rearm | Worker-local repairs | Logical-unit envelope | Worker hard ceiling |
 | --- | --- | --- | --- | --- | --- |
-| `efficient` | 600 / 900 / 1200s | 180 / 240 / 300s | 1–2 | 1–3 | 1800s |
-| `balanced` | 1200 / 1500 / 1800s | 240 / 300 / 360s | 1–2 | 1–3 | 2400s |
-| `quality` | 1800 / 2400 / 2700s | 360 / 480 / 600s | 2–3 | 1–4 | 3600s |
-| `speed` | 420 / 600 / 720s | 180s | 1 | 1–4 | 1200s |
+| `efficient` | 600 / 900 / 1200s | 180 / 240 / 300s | 1–2 | semantic 1–3; topology-backed ≤2 where applicable | 1800s |
+| `balanced` | 1200 / 1500 / 1800s | 240 / 300 / 360s | 1–2 | semantic 1–3; topology-backed ≤3 | 2400s |
+| `quality` | 1800 / 2400 / 2700s | 360 / 480 / 600s | 2–3 | semantic 1–4; topology-backed ≤4 | 3600s |
+| `speed` | 420 / 600 / 720s | 180s | 1 | semantic 1 / 3 / 4; topology-backed ≤8 | 1200s |
 
 Lifecycle semantics:
 
@@ -178,7 +179,7 @@ review failure
   → no writer fence
 ```
 
-A reviewer retry can occur only while phase admission says `permits_review_start=true`.
+A reviewer retry can occur only while phase admission says `permits_review_start=true`. For required/quorum review, successful completion still requires at least `review_stage.min_successful_workers` accepted reviewer results; reaching `review_deadline` does not satisfy that join by itself.
 
 ## Evidence-based bounded implementation
 
@@ -192,7 +193,7 @@ maximum_work_units | none
 require_write_paths
 ```
 
-All built-in strategies keep `minimum_work_units=1`. Complexity/risk/scope/quality may raise only the maximum.
+All built-in strategies keep `minimum_work_units=1`. Complexity/risk/scope/quality may raise the semantic maximum, while already-proven isolated writable topology may raise the total envelope only within the strategy's implementer budget.
 
 A split is valid only when Parent has evidence for an independent acceptance delta, validation boundary, ownership/dependency boundary, or already-proven isolated writable stream. Do not split solely to satisfy a number.
 
@@ -203,7 +204,7 @@ topology_floor = min(writable_workstreams, strategy.max_implementers)
 maximum_work_units = max(semantic_maximum, topology_floor)
 ```
 
-This prevents impossible plans such as four proven implementers with only one logical unit/attempt budget.
+This prevents impossible plans such as four proven implementers with only one logical unit/attempt budget. The resulting logical-unit count may exceed simultaneous `implementation_workers`; planned slots are reused across serial waves. Speed is the clearest example: its routine semantic baseline is one unit, but eight independently proven writable workstreams may produce an eight-unit envelope even when runtime concurrency executes them in smaller waves.
 
 The deterministic manifest validator checks:
 
@@ -225,10 +226,10 @@ Typical raw general-work envelopes:
 
 | Strategy | Soft | Base hard | Work units | Implementation attempts | Replans | Replacements | Review attempts | Parent finalization |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| `efficient` | 1500s | 1800s | 1–3 | units + 1 | 1 | 1 | 2 | 150s |
-| `speed` | 1200s | 1800s | 1–4 | units + 1 | 1 | 1 | 2 | 120s |
-| `balanced` | 2400–3000s | 3000–3600s | 1–3 | units + 2 | 2 | 2 | 2 | 180s |
-| `quality` | 4800–6000s | 6000–7200s | 1–4 | units + 3 | 3 | 3 | 2–4 | 300s |
+| `efficient` | 1500s | 1800s | semantic 1–3; topology-backed ≤2 where applicable | units + 1 | 1 | 1 | 2 | 150s |
+| `speed` | 1200s | 1800s | semantic 1 / 3 / 4; topology-backed ≤8 | units + 1 | 1 | 1 | 2 | 120s |
+| `balanced` | 2400–3000s | 3000–3600s | semantic/topology ≤3 | units + 2 | 2 | 2 | 2 | 180s |
+| `quality` | 4800–6000s | 6000–7200s | semantic/topology ≤4 | units + 3 | 3 | 3 | 2–4 | 300s |
 
 When reviewer Workers are planned:
 
@@ -291,6 +292,8 @@ replacement
 
 They must use `phase=implementation`. New general reservations are rejected at soft deadline. Exact replay of an already-recorded reservation stays idempotent because the durable ledger checks identity before its deadline gate.
 
+Existing writable Workers may need bounded convergence after soft, but they do not gain permission to open new general reservations. Before Parent-only finalization begins, every writer must be terminal/cancel-confirmed or safely fenced and every returned checkpoint must have been harvested.
+
 ### Required review
 
 Reviewer starts/retries reserve:
@@ -302,6 +305,8 @@ kind=review_attempt
 
 A new reviewer is admitted only before `review_deadline`. At/after that boundary, phase action becomes `finalize_parent`; no reviewer start/retry may consume the Parent finalization reserve.
 
+`action=finalize_parent` is only an admission-state transition. It does **not** prove that required review completed. If `review_stage.join_policy` requires/quorums reviewer evidence and fewer than `review_stage.min_successful_workers` accepted results exist at `review_deadline`, fail/escalate from the collected evidence rather than silently downgrade to Parent-only success.
+
 `task_phase_runtime.py` is the mandatory reviewer admission gate. Callers must not bypass it by invoking raw `task_budget_runtime.py reserve --kind review_attempt` directly.
 
 ### Parent finalization
@@ -310,7 +315,9 @@ From `review_deadline` until hard deadline:
 
 - no new reviewer;
 - no reopened writable implementation;
+- no unresolved live writer may continue consuming the finalization reserve;
 - Parent reconciles already-collected review evidence and runs final non-writing verification/delivery work;
+- a required/quorum review that missed its join remains a failure/escalation condition, not a successful Parent-only fallback;
 - at hard deadline action is `stop`.
 
 Important phase output:

--- a/docs/strategy-runtime.md
+++ b/docs/strategy-runtime.md
@@ -42,7 +42,7 @@ The critical invariant is:
 
 > **FlowPilot profiles. `strategy_runtime.py` plus the strategy registry decide. FlowPilot executes the returned plan.**
 
-The Skill must not keep another copy of strategy topology, Worker counts, capability selection, reasoning policy, review policy, or quota logic.
+The Skill must not keep another copy of strategy topology, Worker counts, capability selection, reasoning policy, review policy, task-budget policy, or quota logic.
 
 ## Design invariants
 
@@ -71,6 +71,7 @@ The Skill must not keep another copy of strategy topology, Worker counts, capabi
 23. **Path evidence is preflight only.** `write_paths` provide lexical overlap checks, not an OS lock, durable scheduler enforcement, symlink resolution, or cross-process fencing.
 24. **Lineage is explicit.** Bounded units use `(scope_id, unit_id, generation)`; replacement/replan increments generation, checkpoint/continue does not, and Parent accepts only current-generation evidence.
 25. **Reasoning rollout is scoped and observable.** Only delegated `efficient` Worker roles consume the optional `legacy|shadow|adaptive` decision; direct/non-efficient plans remain unchanged, and proposed/selected effort is planner intent rather than runtime-observed usage.
+26. **Every delegated built-in strategy has a cumulative task envelope.** Task budgets are strategy-owned and differ by optimization objective, but all use the same durable admission ledger and cannot be reset by replanning.
 
 ## Strategy Registry, WorkerBudget, and resource hooks
 
@@ -156,7 +157,16 @@ checkpoint_rearm_seconds | none
 max_worker_repair_attempts | none
 ```
 
-For the `efficient` strategy, routine implementation stays single (`minimum_work_units=maximum_work_units=1`) and uses a 180-second post-harvest checkpoint cooldown. Complex, cross-module, repo-wide, and heavy-loop implementation uses a 240-second cooldown; critical or critical-risk implementation uses 300 seconds. Together with the 600/900/1200-second soft budgets, these place a possible second checkpoint at 780/1140/1500 seconds, before the 1800-second hard ceiling. Complex, cross-module, critical, and critical-risk work uses bounded mode with `minimum_work_units=1` and `maximum_work_units=2`; repo-wide or heavy-loop work uses bounded mode with `minimum_work_units=1` and `maximum_work_units=3`. Parent should raise the unit count only with an independent acceptance delta, validation boundary, and ownership/dependency evidence. A new bounded policy with `require_write_paths=true` requires every manifest unit to include a non-negative `generation` and non-empty normalized repo-relative POSIX `write_paths`. Older plans that omit the new fields retain legacy serial compatibility.
+All four built-in strategies now use the same convergence/recovery contract for delegated implementation: first soft checkpoint, explicit-meaningful-progress multi-round checkpoint rearm, harvest-before-fallback, remaining-delta replan, local repair bounds, generation lineage, and evidence-based bounded units. Strategy modules tune only the thresholds and maximum logical units.
+
+| Strategy | Implementation soft checkpoint | Rearm cooldown | Local repairs | Max work units | Worker hard ceiling |
+| --- | --- | --- | --- | --- | --- |
+| `efficient` | 600 / 900 / 1200s | 180 / 240 / 300s | 1–2 | 1–3 | 1800s |
+| `balanced` | 1200 / 1500 / 1800s | 240 / 300 / 360s | 1–2 | 1–3 | 2400s |
+| `quality` | 1800 / 2400 / 2700s | 360 / 480 / 600s | 2–3 | 1–4 | 3600s |
+| `speed` | 420 / 600 / 720s | 180s | 1 | 1–4 | 1200s |
+
+Every strategy keeps `minimum_work_units=1`. Complexity, risk, repo-wide scope, or quality intent may raise only `maximum_work_units`; they never force a fake split. Parent raises the unit count only with an independent acceptance delta, validation boundary, and ownership/dependency evidence. A new bounded policy with `require_write_paths=true` requires every manifest unit to include a non-negative `generation` and non-empty normalized repo-relative POSIX `write_paths`. Older plans that omit the new fields retain legacy serial compatibility.
 
 `maximum_work_units` is checked by the deterministic work-unit validator after the plan is compiled. It is a manifest bound, not a quota or worker-count. When a strategy emits a task budget, the compiler requires its `max_work_units` to equal the implementation StagePolicy maximum. The validator also rejects duplicate acceptance deltas, unsafe paths, path overlap without a direct/transitive dependency, and any parallel group with missing/overlapping paths or dependencies.
 
@@ -164,11 +174,22 @@ For the `efficient` strategy, routine implementation stays single (`minimum_work
 
 Lifecycle soft timeout remains an advisory checkpoint/convergence budget. An unharvested received checkpoint is harvested before terminal success/failure, cancellation, idle, or hard-timeout fallback; a requested checkpoint without a payload does not defer hard/idle fallback. The first soft checkpoint is unchanged. A later checkpoint requires an explicit Worker `last_meaningful_progress_at` later than the latest harvested timestamp plus the policy's minimum `checkpoint_rearm_seconds` cooldown; legacy `last_progress_at` activity cannot re-arm a harvested checkpoint. Missing rearm policy keeps older plans one-shot. The lifecycle evaluator reports these decisions and cooldown observability (`checkpoint_rearm_at` / `checkpoint_rearm_remaining_seconds`), while `scripts/strategies/task_budget_runtime.py` provides the separate cross-process task ledger; neither helper automatically schedules or cancels Workers.
 
-### Efficient cumulative task budget
+### Cumulative task budgets
 
-Only delegated `efficient` plans currently emit `task_budget`. It has a 1500-second soft deadline and 1800-second hard deadline. The reservation caps are: routine/local/module work units `1` and implementation attempts `2`; complex, cross-module, or critical work units `2` and attempts `3`; repo-wide or heavy-loop work units `3` and attempts `4`. `max_replans=1` and `max_replacements=1` apply to every efficient delegated task. Direct plans and legacy strategies emit `task_budget=null`.
+Every delegated built-in strategy now emits `task_budget`; direct plans emit `task_budget=null`. The exact policy is strategy-owned and immutable for the task ledger.
 
-FlowPilot initializes the ledger immediately after initial compilation, checks `status` before every Worker spawn and after each join/wait, reserves logical work units/implementation attempts/replans/replacements, and calls `finish` when the task completes. Exploration/review Workers consume the wall-clock deadline but not implementation counters. Replanning reuses the original state path and cannot reset counters. Bounded `work_unit` reservations use the validator's stable logical fingerprint (generation excluded); `implementation_attempt` reservations use the generation-aware fingerprint. At soft deadline no new work may start; existing Workers checkpoint/converge. At hard deadline received checkpoints are harvested first, then active writers are fenced/cancelled and no replacement or Parent writer may start. The helper stores task/policy hashes and reservation hashes rather than raw prompt, path, or output data; it returns decisions but is not a scheduler.
+| Strategy | Task soft / hard | Max work units | Max implementation attempts | Replans | Replacements |
+| --- | --- | ---: | ---: | ---: | ---: |
+| `efficient` | 1500 / 1800s | 1–3 | work units + 1 | 1 | 1 |
+| `speed` | 1200 / 1800s | 1–4 | work units + 1 | 1 | 1 |
+| `balanced` | 2400–3000 / 3000–3600s | 1–3 | work units + 2 | 2 | 2 |
+| `quality` | 4800–6000 / 6000–7200s | 1–4 | work units + 3 | 3 | 3 |
+
+The wider balanced/quality envelopes are deliberate: task budgets are a finite admission boundary, not a demand that every strategy optimize to efficient's 30-minute target. Speed retains a 30-minute total hard cap. `task_budget.max_work_units` must equal `implementation_stage.maximum_work_units`.
+
+FlowPilot initializes the ledger immediately after initial compilation, checks `status` before every Worker spawn and after each join/wait, reserves logical work units/implementation attempts/replans/replacements, and calls `finish` when the task completes. Exploration/review Workers consume the wall-clock deadline but not implementation counters. Replanning reuses the original state path and cannot reset counters. Bounded `work_unit` reservations use the validator's stable logical fingerprint (generation excluded); `implementation_attempt` reservations use the generation-aware fingerprint. At the plan's soft deadline no new work may start; existing Workers checkpoint/converge. At the plan's hard deadline received checkpoints are harvested first, then active writers are fenced/cancelled and no replacement or Parent writer may start. The helper stores task/policy hashes and reservation hashes rather than raw prompt, path, or output data; it returns decisions but is not a scheduler.
+
+FlowPilot must read the exact soft/hard deadlines and counters from the immutable ExecutionPlan. It must never hard-code efficient's `1500/1800` values for another strategy.
 
 ### Efficient reasoning rollout
 
@@ -208,6 +229,8 @@ is unsupported, the runtime falls back to the installed baseline; later
 telemetry may record the observed value. Rollout planning itself makes no
 telemetry calls and does not schedule Workers.
 
+Reasoning rollout remains intentionally efficient-specific in this change. The current policy surface and CLI are explicitly an efficient A/B rollout; balanced, quality, and speed keep their existing reasoning semantics until they have strategy-specific rollout contracts rather than inheriting efficient's proposal accidentally.
+
 ## Built-in strategy budgets
 
 The numbers below are **maximum strategy envelopes**, not promises that every task will spawn that many agents. Runtime still requires task evidence and respects the configured thread ceiling.
@@ -241,6 +264,7 @@ Objective: balance quality, quota, and latency.
 - up to three isolated implementation workstreams;
 - quota pressure can reduce topology to a conservative shape;
 - Worker-role reasoning remains deeper than Parent reasoning;
+- convergence/recovery and cumulative task admission use the shared runtime with balanced-specific thresholds;
 - `quality_intent` does not change topology/resources because `balanced` does not consume it.
 
 ### `quality`
@@ -274,7 +298,7 @@ Additional rules:
 - normal complex/high-risk/high-verification tasks still target `xhigh` Parent and `max` Worker-role reasoning;
 - `strong/absolute` quality preference alone does **not** make read-only exploration premium-model work;
 - when `complexity=critical` or `risk=critical`, Explorer / Implementer / Reviewer may all use Parent-class capability because discovery itself becomes high-risk decision work;
-- strong/absolute intent remains subject to runtime safety ceilings, write-conflict checks, and proven writable workstreams;
+- strong/absolute intent remains subject to runtime safety ceilings, write-conflict checks, proven writable workstreams, shared checkpoint/recovery, and the quality task envelope;
 - quota pressure does not cost-collapse `quality`, because the strategy is not quota-sensitive.
 
 This produces the intended economic shape for a routine strong-quality task:
@@ -296,6 +320,7 @@ Objective: minimize wall-clock latency by saturating safe Worker concurrency.
 - writable implementation count scales with `writable_workstreams`, budget, and runtime ceiling instead of being hard-coded to two;
 - read-only exploration can fan out independently;
 - speed never authorizes overlapping writes;
+- shared task admission keeps repeated units/replans/replacements inside a 30-minute total hard cap;
 - `quality_intent` does not alter speed topology/resources.
 
 ## Role Agents
@@ -622,7 +647,7 @@ codex-flow strategy plan \
   --writable-workstreams 4
 ```
 
-The resulting JSON shows quality intent, WorkerBudget, concrete per-stage Worker counts, separate Explorer / Implementer / Reviewer capability/model/reasoning resources, and (for delegated efficient work) the reasoning-rollout decision. Legacy/proposed/selected fields are planner intent; they are not runtime-observed usage. If per-spawn overrides are unavailable, the installed baseline is used and later telemetry may record the observed effort.
+The resulting JSON shows quality intent, WorkerBudget, strategy-owned task budget for delegated built-in strategies, concrete per-stage Worker counts, separate Explorer / Implementer / Reviewer capability/model/reasoning resources, and (for delegated efficient work) the reasoning-rollout decision. Legacy/proposed/selected fields are planner intent; they are not runtime-observed usage. If per-spawn overrides are unavailable, the installed baseline is used and later telemetry may record the observed effort.
 
 ## Adding a new built-in strategy
 

--- a/scripts/strategies/balanced.py
+++ b/scripts/strategies/balanced.py
@@ -1,7 +1,15 @@
 """Balanced quality/quota/latency strategy."""
 from __future__ import annotations
 
-from .base import StagePolicy, StrategySpec, WorkerBudget, never, small_low_risk_is_direct, standard_effort
+from .base import (
+    StagePolicy,
+    StrategySpec,
+    TaskBudgetPolicy,
+    WorkerBudget,
+    never,
+    small_low_risk_is_direct,
+    standard_effort,
+)
 
 
 def adaptive_route(task) -> str:
@@ -57,6 +65,25 @@ def implementation_maximum_work_units(task) -> int:
     return 1
 
 
+def task_budget(task) -> TaskBudgetPolicy:
+    """Bound cumulative balanced work without forcing efficient-style latency."""
+    maximum_work_units = implementation_maximum_work_units(task)
+    if task.complexity == "critical" or task.risk == "critical" or task.scope == "repo-wide" or task.iteration_intensity == "heavy-loop":
+        soft_timeout, hard_timeout = 3000, 3600
+    elif task.complexity == "complex" or task.scope == "cross-module" or task.risk == "high":
+        soft_timeout, hard_timeout = 2700, 3300
+    else:
+        soft_timeout, hard_timeout = 2400, 3000
+    return TaskBudgetPolicy(
+        soft_timeout_seconds=soft_timeout,
+        hard_timeout_seconds=hard_timeout,
+        max_work_units=maximum_work_units,
+        max_implementation_attempts=maximum_work_units + 2,
+        max_replans=2,
+        max_replacements=2,
+    )
+
+
 def lifecycle(task, stage: str) -> StagePolicy:
     if stage == "exploration":
         return StagePolicy("quorum", 1, 180, 1200, True, True, "parent_delta")
@@ -95,4 +122,5 @@ STRATEGY = StrategySpec(
     lifecycle=lifecycle,
     allow_parallel_write=True,
     quota_sensitive=True,
+    task_budget=task_budget,
 )

--- a/scripts/strategies/balanced.py
+++ b/scripts/strategies/balanced.py
@@ -111,9 +111,7 @@ def lifecycle(task, stage: str) -> StagePolicy:
             require_write_paths=bounded_mode,
         )
     if stage == "review":
-        # Keep strict review feasible inside the smallest balanced task envelope
-        # while retaining a Parent finalization reserve after reviewer completion.
-        return StagePolicy("required", 1, 180, 1380, True, False, "parent_delta")
+        return StagePolicy("required", 1, 180, 1800, True, False, "parent_delta")
     raise ValueError(f"invalid lifecycle stage: {stage}")
 
 

--- a/scripts/strategies/balanced.py
+++ b/scripts/strategies/balanced.py
@@ -18,11 +18,68 @@ def worker_budget(task) -> WorkerBudget:
     return WorkerBudget(2, 2, 1, 4, "medium")
 
 
-def lifecycle(_task, stage: str) -> StagePolicy:
+def implementation_soft_timeout(task) -> int:
+    if task.complexity == "critical" or task.risk == "critical":
+        return 1800
+    if task.complexity == "complex" or task.scope == "repo-wide" or task.iteration_intensity == "heavy-loop":
+        return 1500
+    return 1200
+
+
+def implementation_checkpoint_rearm_seconds(task) -> int:
+    if task.complexity == "critical" or task.risk == "critical":
+        return 360
+    if (
+        task.complexity == "complex"
+        or task.scope in {"cross-module", "repo-wide"}
+        or task.iteration_intensity == "heavy-loop"
+    ):
+        return 300
+    return 240
+
+
+def implementation_repair_attempts(task) -> int:
+    if (
+        task.complexity in {"complex", "critical"}
+        or task.risk == "critical"
+        or task.scope == "repo-wide"
+        or task.iteration_intensity == "heavy-loop"
+    ):
+        return 2
+    return 1
+
+
+def implementation_maximum_work_units(task) -> int:
+    if task.scope == "repo-wide" or task.iteration_intensity == "heavy-loop":
+        return 3
+    if task.complexity in {"complex", "critical"} or task.scope == "cross-module" or task.risk == "critical":
+        return 2
+    return 1
+
+
+def lifecycle(task, stage: str) -> StagePolicy:
     if stage == "exploration":
         return StagePolicy("quorum", 1, 180, 1200, True, True, "parent_delta")
     if stage == "implementation":
-        return StagePolicy("required", 1, 240, 2400, False, False, "replan")
+        maximum_work_units = implementation_maximum_work_units(task)
+        bounded_mode = maximum_work_units > 1
+        return StagePolicy(
+            "required",
+            1,
+            240,
+            2400,
+            False,
+            False,
+            "replan",
+            soft_timeout_seconds=implementation_soft_timeout(task),
+            checkpoint_rearm_seconds=implementation_checkpoint_rearm_seconds(task),
+            max_worker_repair_attempts=implementation_repair_attempts(task),
+            work_unit_mode="bounded" if bounded_mode else "single",
+            minimum_work_units=1,
+            join_between_work_units=bounded_mode,
+            maximum_work_units=maximum_work_units,
+            require_write_paths=bounded_mode,
+        )
     if stage == "review":
         return StagePolicy("required", 1, 180, 1800, True, False, "parent_delta")
     raise ValueError(f"invalid lifecycle stage: {stage}")

--- a/scripts/strategies/balanced.py
+++ b/scripts/strategies/balanced.py
@@ -59,10 +59,13 @@ def implementation_repair_attempts(task) -> int:
 
 def implementation_maximum_work_units(task) -> int:
     if task.scope == "repo-wide" or task.iteration_intensity == "heavy-loop":
-        return 3
-    if task.complexity in {"complex", "critical"} or task.scope == "cross-module" or task.risk == "critical":
-        return 2
-    return 1
+        semantic_maximum = 3
+    elif task.complexity in {"complex", "critical"} or task.scope == "cross-module" or task.risk == "critical":
+        semantic_maximum = 2
+    else:
+        semantic_maximum = 1
+    topology_floor = min(task.writable_workstreams, worker_budget(task).max_implementers)
+    return max(semantic_maximum, topology_floor)
 
 
 def task_budget(task) -> TaskBudgetPolicy:
@@ -108,7 +111,9 @@ def lifecycle(task, stage: str) -> StagePolicy:
             require_write_paths=bounded_mode,
         )
     if stage == "review":
-        return StagePolicy("required", 1, 180, 1800, True, False, "parent_delta")
+        # Keep strict review feasible inside the smallest balanced task envelope
+        # while retaining a Parent finalization reserve after reviewer completion.
+        return StagePolicy("required", 1, 180, 1380, True, False, "parent_delta")
     raise ValueError(f"invalid lifecycle stage: {stage}")
 
 

--- a/scripts/strategies/balanced.py
+++ b/scripts/strategies/balanced.py
@@ -37,22 +37,13 @@ def implementation_soft_timeout(task) -> int:
 def implementation_checkpoint_rearm_seconds(task) -> int:
     if task.complexity == "critical" or task.risk == "critical":
         return 360
-    if (
-        task.complexity == "complex"
-        or task.scope in {"cross-module", "repo-wide"}
-        or task.iteration_intensity == "heavy-loop"
-    ):
+    if task.complexity == "complex" or task.scope in {"cross-module", "repo-wide"} or task.iteration_intensity == "heavy-loop":
         return 300
     return 240
 
 
 def implementation_repair_attempts(task) -> int:
-    if (
-        task.complexity in {"complex", "critical"}
-        or task.risk == "critical"
-        or task.scope == "repo-wide"
-        or task.iteration_intensity == "heavy-loop"
-    ):
+    if task.complexity in {"complex", "critical"} or task.risk == "critical" or task.scope == "repo-wide" or task.iteration_intensity == "heavy-loop":
         return 2
     return 1
 
@@ -69,7 +60,6 @@ def implementation_maximum_work_units(task) -> int:
 
 
 def task_budget(task) -> TaskBudgetPolicy:
-    """Bound cumulative balanced work without forcing efficient-style latency."""
     maximum_work_units = implementation_maximum_work_units(task)
     if task.complexity == "critical" or task.risk == "critical" or task.scope == "repo-wide" or task.iteration_intensity == "heavy-loop":
         soft_timeout, hard_timeout = 3000, 3600
@@ -84,6 +74,8 @@ def task_budget(task) -> TaskBudgetPolicy:
         max_implementation_attempts=maximum_work_units + 2,
         max_replans=2,
         max_replacements=2,
+        max_review_attempts=2,
+        parent_finalization_seconds=180,
     )
 
 
@@ -94,13 +86,7 @@ def lifecycle(task, stage: str) -> StagePolicy:
         maximum_work_units = implementation_maximum_work_units(task)
         bounded_mode = maximum_work_units > 1
         return StagePolicy(
-            "required",
-            1,
-            240,
-            2400,
-            False,
-            False,
-            "replan",
+            "required", 1, 240, 2400, False, False, "replan",
             soft_timeout_seconds=implementation_soft_timeout(task),
             checkpoint_rearm_seconds=implementation_checkpoint_rearm_seconds(task),
             max_worker_repair_attempts=implementation_repair_attempts(task),
@@ -111,7 +97,7 @@ def lifecycle(task, stage: str) -> StagePolicy:
             require_write_paths=bounded_mode,
         )
     if stage == "review":
-        return StagePolicy("required", 1, 180, 1800, True, False, "parent_delta")
+        return StagePolicy("required", 1, 180, 1800, True, False, "retry_review")
     raise ValueError(f"invalid lifecycle stage: {stage}")
 
 

--- a/scripts/strategies/base.py
+++ b/scripts/strategies/base.py
@@ -303,13 +303,29 @@ class StagePolicy:
 
 
 def standard_lifecycle(_task: Task, stage: str) -> StagePolicy:
-    """Balanced lifecycle baseline for future strategies that do not override it."""
+    """V11-safe balanced lifecycle baseline for future strategies."""
     if stage == "exploration":
         return StagePolicy("quorum", 1, 180, 1200, True, True, "parent_delta")
     if stage == "implementation":
-        return StagePolicy("required", 1, 240, 2400, False, False, "replan")
+        return StagePolicy(
+            "required",
+            1,
+            240,
+            2400,
+            False,
+            False,
+            "replan",
+            soft_timeout_seconds=1200,
+            checkpoint_rearm_seconds=240,
+            max_worker_repair_attempts=1,
+            work_unit_mode="single",
+            minimum_work_units=1,
+            join_between_work_units=False,
+            maximum_work_units=1,
+            require_write_paths=False,
+        )
     if stage == "review":
-        return StagePolicy("required", 1, 180, 1800, True, False, "parent_delta")
+        return StagePolicy("required", 1, 180, 1800, True, False, "retry_review")
     raise ValueError(f"invalid lifecycle stage: {stage}")
 
 

--- a/scripts/strategies/base.py
+++ b/scripts/strategies/base.py
@@ -20,7 +20,7 @@ ReasoningRolloutFn = Callable[
 
 STAGES = ("exploration", "implementation", "review")
 JOIN_POLICIES = ("opportunistic", "quorum", "required")
-FALLBACK_POLICIES = ("continue_partial", "parent_delta", "replan", "fail")
+FALLBACK_POLICIES = ("continue_partial", "parent_delta", "replan", "retry_review", "fail")
 WORK_UNIT_MODES = ("single", "bounded")
 
 
@@ -68,9 +68,11 @@ class WorkerBudget:
 class TaskBudgetPolicy:
     """Cumulative task budget carried across Worker attempts and replans.
 
-    This is deliberately separate from :class:`StagePolicy`: stage lifecycle
-    limits describe one Worker stage, while these counters are reservations in
-    a durable task ledger and therefore cannot be reset by recompiling a plan.
+    Stage lifecycle limits describe one Worker stage. These task-level counters
+    are durable reservations across attempts/replans. `max_review_attempts`
+    counts read-only reviewer Worker starts independently from implementation
+    replans/replacements. `parent_finalization_seconds` is a deterministic tail
+    reserved after the review-stage hard window whenever reviewers are planned.
     """
 
     soft_timeout_seconds: int
@@ -79,6 +81,8 @@ class TaskBudgetPolicy:
     max_implementation_attempts: int
     max_replans: int
     max_replacements: int
+    max_review_attempts: int = 0
+    parent_finalization_seconds: int = 120
 
     @classmethod
     def from_dict(cls, value: Any) -> "TaskBudgetPolicy":
@@ -91,6 +95,8 @@ class TaskBudgetPolicy:
             "max_implementation_attempts",
             "max_replans",
             "max_replacements",
+            "max_review_attempts",
+            "parent_finalization_seconds",
         )
         missing = [name for name in required if name not in value]
         if missing:
@@ -110,9 +116,9 @@ class TaskBudgetPolicy:
             ("max_implementation_attempts", self.max_implementation_attempts),
             ("max_replans", self.max_replans),
             ("max_replacements", self.max_replacements),
+            ("max_review_attempts", self.max_review_attempts),
+            ("parent_finalization_seconds", self.parent_finalization_seconds),
         ):
-            # bool is an int subclass, but accepting it here makes malformed
-            # JSON policy silently turn into a real budget.
             if type(value) is not int:
                 raise ValueError(f"{name} must be an integer")
             if value < 0:
@@ -125,6 +131,8 @@ class TaskBudgetPolicy:
             raise ValueError("max_work_units must be positive")
         if self.max_implementation_attempts < 1:
             raise ValueError("max_implementation_attempts must be positive")
+        if self.parent_finalization_seconds < 1:
+            raise ValueError("parent_finalization_seconds must be positive")
 
 
 REASONING_ROLLOUT_MODES = ("legacy", "shadow", "adaptive")
@@ -194,24 +202,13 @@ class ReasoningRolloutDecision:
 class StagePolicy:
     """Strategy-owned lifecycle preference for one delegated execution stage.
 
-    The planner normalizes worker counts and applies hard Runtime time ceilings.
-    FlowPilot owns live progress/scope observation and executes the resulting
-    policy without treating a wait-call timeout as a Worker timeout. A soft
-    timeout is an advisory convergence/checkpoint budget and never implies
-    cancellation by itself. `max_worker_repair_attempts`, when set on an
-    implementation stage, bounds local validation-failure fix loops inside one
-    Worker and is independent from Parent-level `max_repair_cycles`.
-    `checkpoint_rearm_seconds`, when set, is the minimum cooldown after a
-    harvested checkpoint before a later checkpoint may be requested. A later
-    checkpoint also requires an explicit acceptance-relevant progress timestamp
-    from the Worker; absent fields retain one-shot compatibility.
+    Soft timeout is advisory convergence/checkpoint budget and never implies
+    cancellation by itself. `max_worker_repair_attempts` bounds Worker-local
+    validation/fix loops independently from Parent-level repair cycles.
 
-    `work_unit_mode=bounded` requires Parent to partition implementation into
-    multiple acceptance-bounded units and join back to Parent between units.
-    This is a logical execution boundary, not permission for overlapping writers.
-    `maximum_work_units`, when set, is a plan-level manifest bound; it does not
-    create additional worker capacity. `require_write_paths` opts a new bounded
-    policy into path-level preflight validation.
+    `work_unit_mode=bounded` describes logical acceptance-bounded transactions,
+    not permission for overlapping writers. `retry_review` is a read-only review
+    fallback and must never reopen writable implementation scope.
     """
 
     join_policy: str
@@ -336,12 +333,7 @@ class StrategySpec:
 
 
 def standard_effort(task: Task, role: str) -> str:
-    """Cheap-parent / strong-worker baseline.
-
-    Parent effort is reserved for high-value orchestration. Worker effort is one
-    tier higher by default because the efficient worker model is materially
-    cheaper and should absorb the deep execution loop.
-    """
+    """Cheap-parent / strong-worker baseline."""
     if task.complexity == "critical" or task.risk == "critical":
         return "xhigh" if role == "parent" else "max"
     return "high" if role == "parent" else "xhigh"

--- a/scripts/strategies/efficient.py
+++ b/scripts/strategies/efficient.py
@@ -79,34 +79,25 @@ def implementation_minimum_work_units(task) -> int:
 
 
 def implementation_maximum_work_units(task) -> int:
-    """Bounded plans reserve room for independently evidenced deltas."""
+    """Bound logical units while never under-provisioning proven writer topology."""
     if task.scope == "repo-wide" or task.iteration_intensity == "heavy-loop":
-        return 3
-    if task.complexity in {"complex", "critical"} or task.scope == "cross-module" or task.risk == "critical":
-        return 2
-    return 1
+        semantic_maximum = 3
+    elif task.complexity in {"complex", "critical"} or task.scope == "cross-module" or task.risk == "critical":
+        semantic_maximum = 2
+    else:
+        semantic_maximum = 1
+    topology_floor = min(task.writable_workstreams, worker_budget(task).max_implementers)
+    return max(semantic_maximum, topology_floor)
 
 
 def task_budget(task) -> TaskBudgetPolicy:
-    """Return the efficient strategy's cumulative task-level reservation caps."""
-    if task.scope == "repo-wide" or task.iteration_intensity == "heavy-loop":
-        max_work_units = 3
-        max_attempts = 4
-    elif (
-        task.complexity in {"complex", "critical"}
-        or task.scope == "cross-module"
-        or task.risk == "critical"
-    ):
-        max_work_units = 2
-        max_attempts = 3
-    else:
-        max_work_units = 1
-        max_attempts = 2
+    """Return cumulative caps consistent with the final writable topology envelope."""
+    max_work_units = implementation_maximum_work_units(task)
     return TaskBudgetPolicy(
         soft_timeout_seconds=1500,
         hard_timeout_seconds=1800,
         max_work_units=max_work_units,
-        max_implementation_attempts=max_attempts,
+        max_implementation_attempts=max_work_units + 1,
         max_replans=1,
         max_replacements=1,
     )
@@ -169,7 +160,9 @@ def lifecycle(task, stage: str) -> StagePolicy:
             require_write_paths=bounded_mode,
         )
     if stage == "review":
-        return StagePolicy("quorum", 1, 150, 1200, True, True, "parent_delta")
+        # Efficient strict review must fit inside the 1800s whole-task envelope
+        # together with exploration/implementation convergence and Parent finalization.
+        return StagePolicy("quorum", 1, 150, 300, True, True, "parent_delta")
     raise ValueError(f"invalid lifecycle stage: {stage}")
 
 

--- a/scripts/strategies/efficient.py
+++ b/scripts/strategies/efficient.py
@@ -118,10 +118,6 @@ def reasoning_rollout(
         class_target = policy.complex
     else:
         class_target = policy.routine
-    # Rollout proposal intentionally starts from the explicit rollout floors
-    # and Parent effort. Legacy's next-tier bump is the behavior being tested;
-    # including it here would make adaptive unable to select an effort equal to
-    # Parent, defeating the rollout's allow-equal contract.
     proposed = _max_effort(class_target, policy.minimum, parent_reasoning)
     selected = proposed if policy.mode == "adaptive" else legacy_worker_reasoning
     decision = ReasoningRolloutDecision(
@@ -160,9 +156,7 @@ def lifecycle(task, stage: str) -> StagePolicy:
             require_write_paths=bounded_mode,
         )
     if stage == "review":
-        # Efficient strict review must fit inside the 1800s whole-task envelope
-        # together with exploration/implementation convergence and Parent finalization.
-        return StagePolicy("quorum", 1, 150, 300, True, True, "parent_delta")
+        return StagePolicy("quorum", 1, 150, 1200, True, True, "parent_delta")
     raise ValueError(f"invalid lifecycle stage: {stage}")
 
 

--- a/scripts/strategies/efficient.py
+++ b/scripts/strategies/efficient.py
@@ -35,7 +35,6 @@ def worker_budget(task) -> WorkerBudget:
 
 
 def implementation_soft_timeout(task) -> int:
-    """Advisory convergence budget; the hard implementation ceiling stays unchanged."""
     if task.complexity == "critical" or task.risk == "critical":
         return 1200
     if task.complexity == "complex" or task.scope == "repo-wide" or task.iteration_intensity == "heavy-loop":
@@ -44,17 +43,11 @@ def implementation_soft_timeout(task) -> int:
 
 
 def implementation_checkpoint_rearm_seconds(task) -> int:
-    """Require a minimum cooldown before a harvested checkpoint can re-arm.
-
-    Keep the second checkpoint comfortably ahead of the 1800-second efficient
-    implementation ceiling while scaling the cooldown with task complexity.
-    """
     if task.complexity == "critical" or task.risk == "critical":
         return 300
     if (
         task.complexity == "complex"
-        or task.scope == "repo-wide"
-        or task.scope == "cross-module"
+        or task.scope in {"cross-module", "repo-wide"}
         or task.iteration_intensity == "heavy-loop"
     ):
         return 240
@@ -62,7 +55,6 @@ def implementation_checkpoint_rearm_seconds(task) -> int:
 
 
 def implementation_repair_attempts(task) -> int:
-    """Bound local test-fix loops without conflating them with lifecycle fallback."""
     if (
         task.complexity in {"complex", "critical"}
         or task.risk == "critical"
@@ -73,13 +65,11 @@ def implementation_repair_attempts(task) -> int:
     return 1
 
 
-def implementation_minimum_work_units(task) -> int:
-    """Default to one unit; evidence may still opt the stage into bounded mode."""
+def implementation_minimum_work_units(_task) -> int:
     return 1
 
 
 def implementation_maximum_work_units(task) -> int:
-    """Bound logical units while never under-provisioning proven writer topology."""
     if task.scope == "repo-wide" or task.iteration_intensity == "heavy-loop":
         semantic_maximum = 3
     elif task.complexity in {"complex", "critical"} or task.scope == "cross-module" or task.risk == "critical":
@@ -91,7 +81,6 @@ def implementation_maximum_work_units(task) -> int:
 
 
 def task_budget(task) -> TaskBudgetPolicy:
-    """Return cumulative caps consistent with the final writable topology envelope."""
     max_work_units = implementation_maximum_work_units(task)
     return TaskBudgetPolicy(
         soft_timeout_seconds=1500,
@@ -100,17 +89,12 @@ def task_budget(task) -> TaskBudgetPolicy:
         max_implementation_attempts=max_work_units + 1,
         max_replans=1,
         max_replacements=1,
+        max_review_attempts=2,
+        parent_finalization_seconds=150,
     )
 
 
-def reasoning_rollout(
-    task,
-    _role: str,
-    policy,
-    parent_reasoning: str,
-    legacy_worker_reasoning: str,
-) -> ReasoningRolloutDecision:
-    """Compare current efficient Worker effort with the rollout proposal."""
+def reasoning_rollout(task, _role: str, policy, parent_reasoning: str, legacy_worker_reasoning: str) -> ReasoningRolloutDecision:
     policy.validate()
     if task.complexity == "critical" or task.risk == "critical":
         class_target = policy.critical
@@ -139,13 +123,7 @@ def lifecycle(task, stage: str) -> StagePolicy:
         maximum_work_units = implementation_maximum_work_units(task)
         bounded_mode = maximum_work_units > 1
         return StagePolicy(
-            "required",
-            1,
-            180,
-            1800,
-            False,
-            False,
-            "replan",
+            "required", 1, 180, 1800, False, False, "replan",
             soft_timeout_seconds=implementation_soft_timeout(task),
             checkpoint_rearm_seconds=implementation_checkpoint_rearm_seconds(task),
             max_worker_repair_attempts=implementation_repair_attempts(task),
@@ -156,7 +134,7 @@ def lifecycle(task, stage: str) -> StagePolicy:
             require_write_paths=bounded_mode,
         )
     if stage == "review":
-        return StagePolicy("quorum", 1, 150, 1200, True, True, "parent_delta")
+        return StagePolicy("quorum", 1, 150, 1200, True, True, "retry_review")
     raise ValueError(f"invalid lifecycle stage: {stage}")
 
 

--- a/scripts/strategies/lifecycle_runtime.py
+++ b/scripts/strategies/lifecycle_runtime.py
@@ -1,13 +1,5 @@
 #!/usr/bin/env python3
-"""Deterministic Worker lifecycle evaluator for FlowPilot.
-
-This module is copied automatically with the strategy package by both Unix and
-Windows installers. It turns observable Worker facts plus an ExecutionPlan
-StagePolicy into a deterministic lifecycle decision. Semantic scope overlap
-remains a Parent responsibility; timing/state transitions, checkpoint harvest,
-cancellation requirements, remaining-delta replans, and writable replacement
-fencing do not.
-"""
+"""Deterministic Worker lifecycle evaluator for FlowPilot."""
 from __future__ import annotations
 
 import argparse
@@ -20,6 +12,7 @@ FALLBACK_ACTIONS = {
     "continue_partial": "continue_partial",
     "parent_delta": "parent_delta",
     "replan": "replan",
+    "retry_review": "retry_review",
     "fail": "fail",
 }
 JOIN_POLICIES = {"opportunistic", "quorum", "required"}
@@ -32,13 +25,9 @@ CHECKPOINT_REUSE_MODES = {"retained_workspace", "harvested_snapshot_only"}
 
 
 def _strict_timeout(value: Any, label: str) -> float:
-    """Accept JSON numbers only (never bool or numeric strings)."""
     if type(value) not in (int, float):
         raise ValueError(f"{label} must be a number")
-    try:
-        result = float(value)
-    except (OverflowError, ValueError) as exc:
-        raise ValueError(f"{label} must be a finite number") from exc
+    result = float(value)
     if not math.isfinite(result):
         raise ValueError(f"{label} must be finite")
     return result
@@ -75,14 +64,12 @@ class LifecyclePolicy:
         for key in ("cancel_if_superseded", "cancel_stragglers_after_quorum"):
             if type(value[key]) is not bool:
                 raise ValueError(f"{key} must be boolean")
-        if type(value["join_policy"]) is not str:
-            raise ValueError("join_policy must be a string")
-        if type(value["fallback_policy"]) is not str:
-            raise ValueError("fallback_policy must be a string")
+        if type(value["join_policy"]) is not str or type(value["fallback_policy"]) is not str:
+            raise ValueError("join_policy and fallback_policy must be strings")
         if type(value["min_successful_workers"]) is not int:
             raise ValueError("min_successful_workers must be an integer")
-        raw_soft_timeout = value.get("soft_timeout_seconds")
-        raw_checkpoint_rearm = value.get("checkpoint_rearm_seconds")
+        raw_soft = value.get("soft_timeout_seconds")
+        raw_rearm = value.get("checkpoint_rearm_seconds")
         policy = cls(
             join_policy=value["join_policy"],
             min_successful_workers=value["min_successful_workers"],
@@ -91,112 +78,83 @@ class LifecyclePolicy:
             cancel_if_superseded=value["cancel_if_superseded"],
             cancel_stragglers_after_quorum=value["cancel_stragglers_after_quorum"],
             fallback_policy=value["fallback_policy"],
-            soft_timeout_seconds=(None if raw_soft_timeout is None else _strict_timeout(raw_soft_timeout, "soft_timeout_seconds")),
-            checkpoint_rearm_seconds=(
-                None
-                if raw_checkpoint_rearm is None
-                else _strict_timeout(raw_checkpoint_rearm, "checkpoint_rearm_seconds")
-            ),
+            soft_timeout_seconds=None if raw_soft is None else _strict_timeout(raw_soft, "soft_timeout_seconds"),
+            checkpoint_rearm_seconds=None if raw_rearm is None else _strict_timeout(raw_rearm, "checkpoint_rearm_seconds"),
         )
         policy.validate()
         return policy
 
     def validate(self) -> None:
-        if type(self.join_policy) is not str:
-            raise ValueError("join_policy must be a string")
-        if type(self.fallback_policy) is not str:
-            raise ValueError("fallback_policy must be a string")
-        if type(self.min_successful_workers) is not int:
-            raise ValueError("min_successful_workers must be an integer")
-        for label, value in (
-            ("cancel_if_superseded", self.cancel_if_superseded),
-            ("cancel_stragglers_after_quorum", self.cancel_stragglers_after_quorum),
-        ):
-            if type(value) is not bool:
-                raise ValueError(f"{label} must be boolean")
-        for label, value in (
-            ("idle_timeout_seconds", self.idle_timeout_seconds),
-            ("hard_timeout_seconds", self.hard_timeout_seconds),
-        ):
-            if type(value) not in (int, float) or not math.isfinite(float(value)):
-                raise ValueError(f"{label} must be finite number")
-        for label, value in (
-            ("soft_timeout_seconds", self.soft_timeout_seconds),
-            ("checkpoint_rearm_seconds", self.checkpoint_rearm_seconds),
-        ):
-            if value is not None and (
-                type(value) not in (int, float)
-                or not math.isfinite(float(value))
-            ):
-                raise ValueError(f"{label} must be finite number")
         if self.join_policy not in JOIN_POLICIES:
             raise ValueError(f"invalid join policy: {self.join_policy}")
-        if self.min_successful_workers < 0:
-            raise ValueError("min_successful_workers cannot be negative")
+        if self.fallback_policy not in FALLBACK_ACTIONS:
+            raise ValueError(f"invalid fallback policy: {self.fallback_policy}")
+        if type(self.min_successful_workers) is not int or self.min_successful_workers < 0:
+            raise ValueError("min_successful_workers must be a non-negative integer")
         if self.join_policy == "opportunistic" and self.min_successful_workers != 0:
             raise ValueError("opportunistic stage must use min_successful_workers=0")
         if self.join_policy != "opportunistic" and self.min_successful_workers < 1:
             raise ValueError(f"{self.join_policy} stage requires at least one successful worker")
-        if self.idle_timeout_seconds <= 0:
-            raise ValueError("idle_timeout_seconds must be positive")
+        for label, value in (("idle_timeout_seconds", self.idle_timeout_seconds), ("hard_timeout_seconds", self.hard_timeout_seconds)):
+            if type(value) not in (int, float) or not math.isfinite(float(value)) or value <= 0:
+                raise ValueError(f"{label} must be a positive finite number")
         if self.hard_timeout_seconds < self.idle_timeout_seconds:
             raise ValueError("hard_timeout_seconds must be >= idle_timeout_seconds")
         if self.soft_timeout_seconds is not None:
-            if self.soft_timeout_seconds <= 0:
-                raise ValueError("soft_timeout_seconds must be positive when set")
-            if self.soft_timeout_seconds >= self.hard_timeout_seconds:
-                raise ValueError("soft_timeout_seconds must be lower than hard_timeout_seconds")
+            if type(self.soft_timeout_seconds) not in (int, float) or not math.isfinite(float(self.soft_timeout_seconds)):
+                raise ValueError("soft_timeout_seconds must be finite")
+            if self.soft_timeout_seconds <= 0 or self.soft_timeout_seconds >= self.hard_timeout_seconds:
+                raise ValueError("soft_timeout_seconds must be positive and lower than hard_timeout_seconds")
         if self.checkpoint_rearm_seconds is not None:
-            if self.checkpoint_rearm_seconds <= 0:
-                raise ValueError("checkpoint_rearm_seconds must be positive when set")
-            if self.checkpoint_rearm_seconds >= self.hard_timeout_seconds:
-                raise ValueError("checkpoint_rearm_seconds must be lower than hard_timeout_seconds")
-            if (
-                self.soft_timeout_seconds is not None
-                and self.soft_timeout_seconds + self.checkpoint_rearm_seconds >= self.hard_timeout_seconds
-            ):
-                raise ValueError(
-                    "checkpoint_rearm_seconds must leave time for a second checkpoint before hard_timeout_seconds"
-                )
-        if self.fallback_policy not in FALLBACK_ACTIONS:
-            raise ValueError(f"invalid fallback policy: {self.fallback_policy}")
+            if type(self.checkpoint_rearm_seconds) not in (int, float) or not math.isfinite(float(self.checkpoint_rearm_seconds)):
+                raise ValueError("checkpoint_rearm_seconds must be finite")
+            if self.checkpoint_rearm_seconds <= 0 or self.checkpoint_rearm_seconds >= self.hard_timeout_seconds:
+                raise ValueError("checkpoint_rearm_seconds must be positive and lower than hard_timeout_seconds")
+            if self.soft_timeout_seconds is not None and self.soft_timeout_seconds + self.checkpoint_rearm_seconds >= self.hard_timeout_seconds:
+                raise ValueError("checkpoint_rearm_seconds must leave time for a second checkpoint before hard_timeout_seconds")
 
 
 @dataclass(frozen=True)
 class CheckpointRecord:
-    """One immutable checkpoint event in a Worker generation."""
-
     sequence: int
     generation: int
     requested_at: float
     received_at: float | None = None
     harvested_at: float | None = None
 
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> "CheckpointRecord":
+        if type(value) is not dict:
+            raise ValueError("checkpoint record must be an object")
+        for key in ("sequence", "generation"):
+            if type(value.get(key)) is not int:
+                raise ValueError(f"checkpoint {key} must be an integer")
+        if "requested_at" not in value:
+            raise ValueError("checkpoint record missing requested_at")
+        return cls(
+            sequence=value["sequence"],
+            generation=value["generation"],
+            requested_at=_strict_timeout(value["requested_at"], "checkpoint requested_at"),
+            received_at=None if value.get("received_at") is None else _strict_timeout(value["received_at"], "checkpoint received_at"),
+            harvested_at=None if value.get("harvested_at") is None else _strict_timeout(value["harvested_at"], "checkpoint harvested_at"),
+        )
+
     def validate(self, *, started_at: float, now: float) -> None:
-        if type(self.sequence) is not int or self.sequence < 1:
-            raise ValueError("checkpoint sequence must be a positive integer")
-        if type(self.generation) is not int or self.generation < 0:
-            raise ValueError("checkpoint generation must be a non-negative integer")
-        times = {
-            "checkpoint requested_at": self.requested_at,
-            "checkpoint received_at": self.received_at,
-            "checkpoint harvested_at": self.harvested_at,
-        }
-        for label, value in times.items():
+        if self.sequence < 1 or self.generation < 0:
+            raise ValueError("checkpoint sequence must be positive and generation non-negative")
+        for label, value in (
+            ("requested_at", self.requested_at),
+            ("received_at", self.received_at),
+            ("harvested_at", self.harvested_at),
+        ):
             if value is None:
                 continue
             if type(value) not in (int, float) or not math.isfinite(float(value)):
-                raise ValueError(f"{label} must be a finite number")
+                raise ValueError(f"checkpoint {label} must be finite")
             if value > EPOCH_MILLISECONDS_THRESHOLD:
-                raise ValueError(
-                    f"{label} must use seconds, not milliseconds; pass Unix seconds such as time.time()"
-                )
-            if value < started_at:
-                raise ValueError(f"{label} cannot precede started_at")
-            if value > now:
-                raise ValueError(f"{label} cannot be in the future")
-        if self.requested_at < started_at or self.requested_at > now:
-            raise ValueError("checkpoint requested_at must be between started_at and now")
+                raise ValueError(f"checkpoint {label} must use Unix seconds")
+            if value < started_at or value > now:
+                raise ValueError(f"checkpoint {label} must be between started_at and now")
         if self.received_at is not None and self.received_at < self.requested_at:
             raise ValueError("checkpoint received_at cannot precede requested_at")
         if self.harvested_at is not None:
@@ -204,28 +162,6 @@ class CheckpointRecord:
                 raise ValueError("checkpoint harvested_at requires received_at")
             if self.harvested_at < self.received_at:
                 raise ValueError("checkpoint harvested_at cannot precede received_at")
-
-    @classmethod
-    def from_dict(cls, value: dict[str, Any]) -> "CheckpointRecord":
-        if type(value) is not dict:
-            raise ValueError("checkpoint record must be an object")
-        required = ("sequence", "generation", "requested_at")
-        missing = [key for key in required if key not in value]
-        if missing:
-            raise ValueError(f"checkpoint record missing fields: {missing}")
-        for key in ("sequence", "generation"):
-            if type(value[key]) is not int:
-                raise ValueError(f"checkpoint {key} must be an integer")
-        for key in ("requested_at", "received_at", "harvested_at"):
-            if key in value and value[key] is not None:
-                _strict_timeout(value[key], f"checkpoint {key}")
-        return cls(
-            sequence=value["sequence"],
-            generation=value["generation"],
-            requested_at=_strict_timeout(value["requested_at"], "checkpoint requested_at"),
-            received_at=(None if value.get("received_at") is None else _strict_timeout(value["received_at"], "checkpoint received_at")),
-            harvested_at=(None if value.get("harvested_at") is None else _strict_timeout(value["harvested_at"], "checkpoint harvested_at")),
-        )
 
 
 @dataclass(frozen=True)
@@ -250,19 +186,7 @@ class WorkerObservation:
     checkpoint_sequence: tuple[CheckpointRecord, ...] | None = None
 
     def meaningful_progress_at(self) -> float:
-        # Backward compatibility: callers that do not yet distinguish liveness
-        # activity from acceptance-relevant progress retain historical behavior.
         return self.last_progress_at if self.last_meaningful_progress_at is None else self.last_meaningful_progress_at
-
-    def checkpoint_status(self) -> str:
-        records = self.checkpoint_records()
-        if records and records[-1].harvested_at is not None:
-            return "harvested"
-        if records and records[-1].received_at is not None:
-            return "received"
-        if records:
-            return "requested"
-        return "not_requested"
 
     def checkpoint_records(self) -> tuple[CheckpointRecord, ...]:
         if self.checkpoint_sequence is not None:
@@ -276,78 +200,56 @@ class WorkerObservation:
         return records[-1] if records else None
 
     def latest_harvested_checkpoint(self) -> CheckpointRecord | None:
-        """Return the newest durable checkpoint baseline in this generation."""
         harvested = [record for record in self.checkpoint_records() if record.harvested_at is not None]
         return harvested[-1] if harvested else None
+
+    def checkpoint_status(self) -> str:
+        latest = self.latest_checkpoint()
+        if latest is None:
+            return "not_requested"
+        if latest.harvested_at is not None:
+            return "harvested"
+        if latest.received_at is not None:
+            return "received"
+        return "requested"
 
     def validate(self) -> None:
         if not self.scope_id:
             raise ValueError("scope_id is required")
-        if type(self.generation) is not int or self.generation < 0:
-            raise ValueError("generation must be a non-negative integer")
         if self.stage not in {"exploration", "implementation", "review"}:
             raise ValueError(f"invalid stage: {self.stage}")
-        timestamps = {
-            "started_at": self.started_at,
-            "last_progress_at": self.last_progress_at,
-            "now": self.now,
-        }
-        optional_timestamps = {
-            "last_meaningful_progress_at": self.last_meaningful_progress_at,
-            "checkpoint_requested_at": self.checkpoint_requested_at,
-            "checkpoint_received_at": self.checkpoint_received_at,
-            "checkpoint_harvested_at": self.checkpoint_harvested_at,
-        }
-        timestamps.update({key: value for key, value in optional_timestamps.items() if value is not None})
-        if any(type(value) not in (int, float) for value in timestamps.values()):
-            raise ValueError("timestamps must be numbers")
-        if any(not math.isfinite(value) for value in timestamps.values()):
-            raise ValueError("timestamps must be finite seconds")
-        if any(value < 0 for value in timestamps.values()):
-            raise ValueError("timestamps cannot be negative")
-        if any(value > EPOCH_MILLISECONDS_THRESHOLD for value in timestamps.values()):
-            raise ValueError(
-                "timestamps must use seconds, not milliseconds; pass Unix seconds such as time.time()"
-            )
-        if self.last_progress_at < self.started_at:
-            raise ValueError("last_progress_at cannot precede started_at")
-        if self.last_progress_at > self.now:
-            raise ValueError("last_progress_at cannot be in the future")
+        if type(self.generation) is not int or self.generation < 0:
+            raise ValueError("generation must be a non-negative integer")
+        timestamps = [self.started_at, self.last_progress_at, self.now]
+        timestamps.extend(v for v in (
+            self.last_meaningful_progress_at,
+            self.checkpoint_requested_at,
+            self.checkpoint_received_at,
+            self.checkpoint_harvested_at,
+        ) if v is not None)
+        if any(type(v) not in (int, float) or not math.isfinite(float(v)) or v < 0 for v in timestamps):
+            raise ValueError("timestamps must be finite non-negative seconds")
+        if any(v > EPOCH_MILLISECONDS_THRESHOLD for v in timestamps):
+            raise ValueError("timestamps must use Unix seconds")
         if self.now < self.started_at:
             raise ValueError("now cannot precede started_at")
-        meaningful_at = self.meaningful_progress_at()
-        if meaningful_at < self.started_at:
-            raise ValueError("last_meaningful_progress_at cannot precede started_at")
-        if meaningful_at > self.last_progress_at:
-            raise ValueError("last_meaningful_progress_at cannot be newer than last_progress_at")
-        for label in ("checkpoint_requested_at", "checkpoint_received_at", "checkpoint_harvested_at"):
-            value = getattr(self, label)
-            if value is not None and value < self.started_at:
-                raise ValueError(f"{label} cannot precede started_at")
-            if value is not None and value > self.now:
-                raise ValueError(f"{label} cannot be in the future")
-        has_old_checkpoint = any(
-            value is not None
-            for value in (self.checkpoint_requested_at, self.checkpoint_received_at, self.checkpoint_harvested_at)
-        )
-        if self.checkpoint_sequence is not None and has_old_checkpoint:
+        if self.last_progress_at < self.started_at or self.last_progress_at > self.now:
+            raise ValueError("last_progress_at must be between started_at and now")
+        meaningful = self.meaningful_progress_at()
+        if meaningful < self.started_at or meaningful > self.last_progress_at:
+            raise ValueError("last_meaningful_progress_at must be between started_at and last_progress_at")
+        has_legacy_checkpoint = any(v is not None for v in (
+            self.checkpoint_requested_at,
+            self.checkpoint_received_at,
+            self.checkpoint_harvested_at,
+        ))
+        if self.checkpoint_sequence is not None and has_legacy_checkpoint:
             raise ValueError("legacy checkpoint fields cannot be combined with checkpoint sequence")
-        if self.checkpoint_sequence is None and self.checkpoint_received_at is not None and self.checkpoint_requested_at is None:
-            raise ValueError("checkpoint_received_at requires checkpoint_requested_at")
-        if self.checkpoint_sequence is None and self.checkpoint_harvested_at is not None and self.checkpoint_received_at is None:
-            raise ValueError("checkpoint_harvested_at requires checkpoint_received_at")
-        if self.checkpoint_sequence is None and (
-            self.checkpoint_requested_at is not None
-            and self.checkpoint_received_at is not None
-            and self.checkpoint_received_at < self.checkpoint_requested_at
-        ):
-            raise ValueError("checkpoint_received_at cannot precede checkpoint_requested_at")
-        if self.checkpoint_sequence is None and (
-            self.checkpoint_received_at is not None
-            and self.checkpoint_harvested_at is not None
-            and self.checkpoint_harvested_at < self.checkpoint_received_at
-        ):
-            raise ValueError("checkpoint_harvested_at cannot precede checkpoint_received_at")
+        if self.checkpoint_sequence is None:
+            if self.checkpoint_received_at is not None and self.checkpoint_requested_at is None:
+                raise ValueError("checkpoint_received_at requires checkpoint_requested_at")
+            if self.checkpoint_harvested_at is not None and self.checkpoint_received_at is None:
+                raise ValueError("checkpoint_harvested_at requires checkpoint_received_at")
         records = self.checkpoint_records()
         for index, record in enumerate(records, start=1):
             if record.sequence != index:
@@ -357,12 +259,14 @@ class WorkerObservation:
             record.validate(started_at=self.started_at, now=self.now)
             if index < len(records) and record.harvested_at is None:
                 raise ValueError("every checkpoint except the latest must be harvested")
-            if index > 1 and records[index - 2].harvested_at is None:
-                raise ValueError("a new checkpoint cannot start before the previous one is harvested")
-            if index > 1 and record.requested_at < records[index - 2].harvested_at:
-                raise ValueError("checkpoint requested_at cannot precede the previous harvested checkpoint")
-        if self.checkpoint_status() not in CHECKPOINT_STATUSES:  # pragma: no cover
-            raise AssertionError(f"invalid checkpoint status: {self.checkpoint_status()}")
+            if index > 1:
+                previous = records[index - 2]
+                if previous.harvested_at is None:
+                    raise ValueError("a new checkpoint cannot start before the previous one is harvested")
+                if record.requested_at < previous.harvested_at:
+                    raise ValueError("checkpoint requested_at cannot precede previous harvest")
+        if self.checkpoint_status() not in CHECKPOINT_STATUSES:
+            raise AssertionError("invalid checkpoint status")
         if self.terminal_success and self.terminal_failure:
             raise ValueError("worker cannot be both terminal-success and terminal-failure")
         if self.cancel_confirmed and (self.terminal_success or self.terminal_failure):
@@ -396,65 +300,43 @@ class LifecycleDecision:
         return asdict(self)
 
 
-def _progress_metrics(
-    policy: LifecyclePolicy,
-    observation: WorkerObservation,
-) -> tuple[float, float, float, str]:
+def _progress_metrics(policy: LifecyclePolicy, observation: WorkerObservation) -> tuple[float, float, float, str]:
     idle = max(0.0, observation.now - observation.last_progress_at)
     wall = max(0.0, observation.now - observation.started_at)
     meaningful_at = observation.meaningful_progress_at()
     meaningful_idle = max(0.0, observation.now - meaningful_at)
-    has_meaningful_delta = meaningful_at > observation.started_at
-    if has_meaningful_delta and meaningful_idle < policy.idle_timeout_seconds:
+    if meaningful_at > observation.started_at and meaningful_idle < policy.idle_timeout_seconds:
         quality = "meaningful"
     elif observation.in_flight or idle < policy.idle_timeout_seconds:
         quality = "activity_only"
     else:
         quality = "none"
-    if quality not in PROGRESS_QUALITIES:  # pragma: no cover - defensive invariant
-        raise AssertionError(f"invalid progress quality: {quality}")
     return idle, meaningful_idle, wall, quality
 
 
-def _replan_contract(
-    observation: WorkerObservation,
-    fallback_policy: str | None,
-) -> tuple[str | None, str | None]:
+def _replan_contract(observation: WorkerObservation, fallback_policy: str | None) -> tuple[str | None, str | None]:
     if fallback_policy != "replan":
         return None, None
     if observation.latest_harvested_checkpoint() is None:
         return "uncovered_scope", None
-    scope = "checkpoint_remaining_delta"
-    reuse = "harvested_snapshot_only" if observation.replacement_isolated else "retained_workspace"
-    if scope not in REPLAN_SCOPES or reuse not in CHECKPOINT_REUSE_MODES:  # pragma: no cover
-        raise AssertionError("invalid replan checkpoint contract")
-    return scope, reuse
+    return (
+        "checkpoint_remaining_delta",
+        "harvested_snapshot_only" if observation.replacement_isolated else "retained_workspace",
+    )
 
 
-def _decision(
-    policy: LifecyclePolicy,
-    observation: WorkerObservation,
-    *,
-    state: str,
-    action: str,
-    reason: str,
-    cancel_required: bool,
-    replacement_allowed: bool,
-    fence_required: bool,
-    fallback_policy: str | None,
-) -> LifecycleDecision:
+def _decision(policy: LifecyclePolicy, observation: WorkerObservation, *, state: str, action: str, reason: str, cancel_required: bool, replacement_allowed: bool, fence_required: bool, fallback_policy: str | None) -> LifecycleDecision:
     idle, meaningful_idle, wall, quality = _progress_metrics(policy, observation)
-    replan_scope, checkpoint_reuse_mode = _replan_contract(observation, fallback_policy)
-    latest_checkpoint = observation.latest_checkpoint()
-    latest_sequence = latest_checkpoint.sequence if latest_checkpoint is not None else 0
+    replan_scope, reuse = _replan_contract(observation, fallback_policy)
+    latest = observation.latest_checkpoint()
     latest_harvested = observation.latest_harvested_checkpoint()
-    next_sequence = latest_sequence + 1 if action == "request_checkpoint" else None
+    latest_sequence = latest.sequence if latest is not None else 0
     if latest_harvested is not None and policy.checkpoint_rearm_seconds is not None:
-        checkpoint_rearm_at = latest_harvested.harvested_at + policy.checkpoint_rearm_seconds
-        checkpoint_rearm_remaining = max(0.0, checkpoint_rearm_at - observation.now)
+        rearm_at = latest_harvested.harvested_at + policy.checkpoint_rearm_seconds
+        rearm_remaining = max(0.0, rearm_at - observation.now)
     else:
-        checkpoint_rearm_at = None
-        checkpoint_rearm_remaining = None
+        rearm_at = None
+        rearm_remaining = None
     return LifecycleDecision(
         state=state,
         action=action,
@@ -467,28 +349,24 @@ def _decision(
         progress_quality=quality,
         checkpoint_status=observation.checkpoint_status(),
         replan_scope=replan_scope,
-        checkpoint_reuse_mode=checkpoint_reuse_mode,
+        checkpoint_reuse_mode=reuse,
         wall_seconds=wall,
         fallback_policy=fallback_policy,
         checkpoint_generation=observation.generation,
         checkpoint_sequence=latest_sequence,
-        next_checkpoint_sequence=next_sequence,
-        harvested_checkpoint_sequence=(latest_harvested.sequence if latest_harvested is not None else 0),
-        checkpoint_rearm_at=checkpoint_rearm_at,
-        checkpoint_rearm_remaining_seconds=checkpoint_rearm_remaining,
+        next_checkpoint_sequence=latest_sequence + 1 if action == "request_checkpoint" else None,
+        harvested_checkpoint_sequence=latest_harvested.sequence if latest_harvested is not None else 0,
+        checkpoint_rearm_at=rearm_at,
+        checkpoint_rearm_remaining_seconds=rearm_remaining,
     )
 
 
 def _checkpoint_harvest_decision(policy: LifecyclePolicy, observation: WorkerObservation) -> LifecycleDecision:
     return _decision(
-        policy,
-        observation,
+        policy, observation,
         state="progressing" if observation.last_progress_at > observation.started_at or observation.in_flight else "running",
         action="harvest_checkpoint",
-        reason=(
-            "worker checkpoint is available; harvest completed work, changed files/current patch state, "
-            "validation evidence, blockers, and remaining delta before any cancellation or fallback"
-        ),
+        reason="worker checkpoint is available; harvest durable work before any fallback",
         cancel_required=False,
         replacement_allowed=False,
         fence_required=False,
@@ -496,44 +374,33 @@ def _checkpoint_harvest_decision(policy: LifecyclePolicy, observation: WorkerObs
     )
 
 
-def _fallback_decision(
-    policy: LifecyclePolicy,
-    observation: WorkerObservation,
-    *,
-    state: str,
-    reason: str,
-    terminal: bool,
-) -> LifecycleDecision:
+def _fallback_decision(policy: LifecyclePolicy, observation: WorkerObservation, *, state: str, reason: str, terminal: bool) -> LifecycleDecision:
+    if policy.fallback_policy == "retry_review" and observation.stage != "review":
+        raise ValueError("retry_review fallback is only valid for review stage")
     fallback = FALLBACK_ACTIONS[policy.fallback_policy]
     cancel_required = not terminal
     fallback_creates_writer = policy.fallback_policy in WRITER_FALLBACKS
-    fence_required = (
-        observation.stage == "implementation"
-        and observation.writable
-        and fallback_creates_writer
-    )
-    if fence_required and not terminal and not observation.replacement_isolated:
-        # Hard safety invariant: Parent delta and replacement Workers are both
-        # downstream writers. Never let either write the same live scope while
-        # the old Worker may resume. Confirm cancellation/termination first, or
-        # move the downstream writer into a fresh isolated worktree and fence
-        # the old output from integration.
+    fence_required = observation.stage == "implementation" and observation.writable and fallback_creates_writer
+
+    if policy.fallback_policy == "retry_review":
+        action = "retry_review"
+        replacement_allowed = True
+        reason += "; replacement is read-only and must consume a review_attempt reservation"
+    elif fence_required and not terminal and not observation.replacement_isolated:
         action = "request_cancel"
         replacement_allowed = False
     else:
         action = fallback
-        replacement_allowed = fallback == "replan" and (
-            not fence_required or terminal or observation.replacement_isolated
-        )
+        replacement_allowed = fallback == "replan" and (not fence_required or terminal or observation.replacement_isolated)
         if fence_required and observation.replacement_isolated and not terminal:
-            reason += "; downstream writer is explicitly isolated and old output is fenced from integration"
+            reason += "; downstream writer is isolated and old output is fenced"
+
     if policy.fallback_policy == "replan" and observation.latest_harvested_checkpoint() is not None:
-        reason += "; replan is restricted to the harvested checkpoint remaining_delta and completed work must be preserved"
+        reason += "; replan is restricted to harvested remaining_delta"
     if cancel_required:
         reason += "; non-terminal Worker cancellation is required"
     return _decision(
-        policy,
-        observation,
+        policy, observation,
         state=state,
         action=action,
         reason=reason,
@@ -547,15 +414,10 @@ def _fallback_decision(
 def _superseded_decision(policy: LifecyclePolicy, observation: WorkerObservation) -> LifecycleDecision:
     terminal = observation.terminal_failure or observation.cancel_confirmed
     return _decision(
-        policy,
-        observation,
+        policy, observation,
         state="superseded",
         action="continue" if terminal else "request_cancel",
-        reason=(
-            "bounded scope is already covered with equivalent evidence; no fallback work is required"
-            if terminal
-            else "bounded scope is already covered with equivalent evidence; non-terminal Worker cancellation is required"
-        ),
+        reason="scope is already covered; no fallback work is required",
         cancel_required=not terminal,
         replacement_allowed=False,
         fence_required=False,
@@ -566,59 +428,29 @@ def _superseded_decision(policy: LifecyclePolicy, observation: WorkerObservation
 def _soft_budget_decision(policy: LifecyclePolicy, observation: WorkerObservation) -> LifecycleDecision:
     _idle, _meaningful_idle, _wall, quality = _progress_metrics(policy, observation)
     state = "progressing" if observation.last_progress_at > observation.started_at or observation.in_flight else "running"
-    if quality == "meaningful":
-        detail = "recent acceptance-relevant progress is visible"
-    elif quality == "activity_only":
-        detail = "liveness activity is visible but no recent acceptance-relevant delta is visible"
-    else:
-        detail = "no recent meaningful or liveness progress is visible"
-
     checkpoint_status = observation.checkpoint_status()
     if checkpoint_status == "not_requested":
-        action = "request_checkpoint"
-        suffix = "request a non-terminal checkpoint without cancelling Worker"
+        action, suffix = "request_checkpoint", "request a non-terminal checkpoint"
     elif checkpoint_status == "requested":
-        action = "await_checkpoint"
-        suffix = "checkpoint has been requested; let Worker reach a safe checkpoint without cancelling it"
+        action, suffix = "await_checkpoint", "checkpoint is already requested"
     elif checkpoint_status == "received":
         return _checkpoint_harvest_decision(policy, observation)
     else:
-        latest_harvested = observation.latest_harvested_checkpoint()
-        # A harvested checkpoint is a boundary.  A later checkpoint requires
-        # both explicit acceptance-relevant evidence and the policy cooldown.
-        # Do not use meaningful_progress_at() here: its legacy fallback to
-        # last_progress_at would turn liveness activity into checkpoint churn.
-        rearm_at = (
-            None
-            if latest_harvested is None or policy.checkpoint_rearm_seconds is None
-            else latest_harvested.harvested_at + policy.checkpoint_rearm_seconds
-        )
-        explicit_meaningful_at = observation.last_meaningful_progress_at
-        has_explicit_delta = (
-            latest_harvested is not None
-            and explicit_meaningful_at is not None
-            and explicit_meaningful_at > latest_harvested.harvested_at
-        )
-        cooldown_elapsed = rearm_at is not None and observation.now >= rearm_at
-        if has_explicit_delta and cooldown_elapsed:
-            action = "request_checkpoint"
-            suffix = "explicit acceptance-relevant progress arrived after the latest harvest and rearm cooldown elapsed; request the next checkpoint"
+        latest = observation.latest_harvested_checkpoint()
+        rearm_at = None if latest is None or policy.checkpoint_rearm_seconds is None else latest.harvested_at + policy.checkpoint_rearm_seconds
+        explicit = observation.last_meaningful_progress_at
+        has_delta = latest is not None and explicit is not None and explicit > latest.harvested_at
+        cooldown = rearm_at is not None and observation.now >= rearm_at
+        if has_delta and cooldown:
+            action, suffix = "request_checkpoint", "explicit meaningful progress and cooldown re-armed checkpointing"
         else:
             action = "continue"
-            if policy.checkpoint_rearm_seconds is None:
-                suffix = "checkpoint has already been harvested; automatic multi-round rearm is disabled for this legacy/one-shot policy; continue until completion or a real lifecycle boundary"
-            elif not has_explicit_delta:
-                suffix = "checkpoint has already been harvested; no explicit acceptance-relevant progress arrived after the latest harvest (last_progress_at cannot re-arm it); continue until completion or a real lifecycle boundary"
-            else:
-                remaining = max(0.0, rearm_at - observation.now) if rearm_at is not None else 0.0
-                suffix = f"checkpoint has already been harvested; explicit progress is visible but rearm cooldown has {remaining:g}s remaining; continue until completion or a real lifecycle boundary"
-
+            suffix = "harvested checkpoint remains current; no eligible rearm"
     return _decision(
-        policy,
-        observation,
+        policy, observation,
         state=state,
         action=action,
-        reason=f"soft worker execution budget reached; {detail}; {suffix}",
+        reason=f"soft worker execution budget reached; progress={quality}; {suffix}",
         cancel_required=False,
         replacement_allowed=False,
         fence_required=False,
@@ -627,75 +459,28 @@ def _soft_budget_decision(policy: LifecyclePolicy, observation: WorkerObservatio
 
 
 def evaluate_worker(policy: LifecyclePolicy, observation: WorkerObservation) -> LifecycleDecision:
-    """Evaluate one Worker without treating Parent wait intervals as evidence."""
     policy.validate()
     observation.validate()
-
     idle, _meaningful_idle, wall, _quality = _progress_metrics(policy, observation)
 
-    # Preserve already-returned partial work before any terminal failure, hard
-    # timeout, idle fallback, cancellation, or writer replacement can discard it.
     if observation.checkpoint_status() == "received":
         return _checkpoint_harvest_decision(policy, observation)
-
     if observation.terminal_success:
-        return _decision(
-            policy,
-            observation,
-            state="completed",
-            action="consume_result",
-            reason="worker reported terminal success",
-            cancel_required=False,
-            replacement_allowed=False,
-            fence_required=False,
-            fallback_policy=None,
-        )
-
+        return _decision(policy, observation, state="completed", action="consume_result", reason="worker reported terminal success", cancel_required=False, replacement_allowed=False, fence_required=False, fallback_policy=None)
     if observation.scope_superseded and policy.cancel_if_superseded:
         return _superseded_decision(policy, observation)
-
     if observation.terminal_failure:
-        return _fallback_decision(
-            policy,
-            observation,
-            state="failed",
-            reason="worker reported terminal failure",
-            terminal=True,
-        )
-
+        return _fallback_decision(policy, observation, state="failed", reason="worker reported terminal failure", terminal=True)
     if observation.cancel_confirmed:
-        return _fallback_decision(
-            policy,
-            observation,
-            state="cancelled",
-            reason="worker cancellation/termination confirmed",
-            terminal=True,
-        )
-
+        return _fallback_decision(policy, observation, state="cancelled", reason="worker cancellation/termination confirmed", terminal=True)
     if wall >= policy.hard_timeout_seconds:
-        return _fallback_decision(
-            policy,
-            observation,
-            state="stalled",
-            reason="hard worker wall-clock ceiling reached",
-            terminal=False,
-        )
-
+        return _fallback_decision(policy, observation, state="stalled", reason="hard worker wall-clock ceiling reached", terminal=False)
     if not observation.in_flight and idle >= policy.idle_timeout_seconds:
-        return _fallback_decision(
-            policy,
-            observation,
-            state="stalled",
-            reason="idle progress lease expired with no visible in-flight work",
-            terminal=False,
-        )
-
+        return _fallback_decision(policy, observation, state="stalled", reason="idle progress lease expired with no visible in-flight work", terminal=False)
     if policy.soft_timeout_seconds is not None and wall >= policy.soft_timeout_seconds:
         return _soft_budget_decision(policy, observation)
-
     return _decision(
-        policy,
-        observation,
+        policy, observation,
         state="progressing" if observation.last_progress_at > observation.started_at or observation.in_flight else "running",
         action="continue",
         reason="worker remains non-terminal with an active liveness lease",
@@ -731,21 +516,13 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--policy-json", required=True)
     parser.add_argument("--scope-id", required=True)
     parser.add_argument("--stage", choices=("exploration", "implementation", "review"), required=True)
-    parser.add_argument("--started-at", type=float, required=True, help="Unix timestamp in seconds")
-    parser.add_argument("--last-progress-at", type=float, required=True, help="Unix timestamp in seconds")
-    parser.add_argument(
-        "--last-meaningful-progress-at",
-        type=float,
-        help=(
-            "Unix timestamp for the latest acceptance-relevant delta; omit for legacy behavior "
-            "that treats last-progress-at as meaningful for progress classification, but never "
-            "for multi-round checkpoint rearm"
-        ),
-    )
-    parser.add_argument("--checkpoint-requested-at", type=float, help="Unix timestamp when Parent requested checkpoint")
-    parser.add_argument("--checkpoint-received-at", type=float, help="Unix timestamp when Worker returned checkpoint payload")
-    parser.add_argument("--checkpoint-harvested-at", type=float, help="Unix timestamp when Parent persisted/consumed checkpoint payload")
-    parser.add_argument("--now", type=float, required=True, help="Unix timestamp in seconds")
+    parser.add_argument("--started-at", type=float, required=True)
+    parser.add_argument("--last-progress-at", type=float, required=True)
+    parser.add_argument("--last-meaningful-progress-at", type=float)
+    parser.add_argument("--checkpoint-requested-at", type=float)
+    parser.add_argument("--checkpoint-received-at", type=float)
+    parser.add_argument("--checkpoint-harvested-at", type=float)
+    parser.add_argument("--now", type=float, required=True)
     parser.add_argument("--writable", action="store_true")
     parser.add_argument("--in-flight", action="store_true")
     parser.add_argument("--terminal-success", action="store_true")
@@ -753,22 +530,16 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--scope-superseded", action="store_true")
     parser.add_argument("--cancel-confirmed", action="store_true")
     parser.add_argument("--replacement-isolated", action="store_true")
-    parser.add_argument("--generation", type=int, default=0, help="non-negative Worker generation")
-    parser.add_argument(
-        "--checkpoint-sequence-json",
-        help="JSON array of immutable checkpoint records; cannot be combined with legacy checkpoint flags",
-    )
+    parser.add_argument("--generation", type=int, default=0)
+    parser.add_argument("--checkpoint-sequence-json")
     return parser
 
 
 def main(argv: Iterable[str] | None = None) -> int:
     ns = build_parser().parse_args(list(argv) if argv is not None else None)
     policy = LifecyclePolicy.from_dict(_load_json_object(ns.policy_json, "policy"))
-    checkpoint_sequence = None if ns.checkpoint_sequence_json is None else _load_checkpoint_sequence(ns.checkpoint_sequence_json)
-    if ns.checkpoint_sequence_json is not None and any(
-        value is not None
-        for value in (ns.checkpoint_requested_at, ns.checkpoint_received_at, ns.checkpoint_harvested_at)
-    ):
+    sequence = None if ns.checkpoint_sequence_json is None else _load_checkpoint_sequence(ns.checkpoint_sequence_json)
+    if sequence is not None and any(v is not None for v in (ns.checkpoint_requested_at, ns.checkpoint_received_at, ns.checkpoint_harvested_at)):
         raise ValueError("legacy checkpoint flags cannot be combined with --checkpoint-sequence-json")
     observation = WorkerObservation(
         scope_id=ns.scope_id,
@@ -788,7 +559,7 @@ def main(argv: Iterable[str] | None = None) -> int:
         cancel_confirmed=ns.cancel_confirmed,
         replacement_isolated=ns.replacement_isolated,
         generation=ns.generation,
-        checkpoint_sequence=checkpoint_sequence,
+        checkpoint_sequence=sequence,
     )
     print(json.dumps(evaluate_worker(policy, observation).to_dict(), ensure_ascii=False, sort_keys=True))
     return 0

--- a/scripts/strategies/lifecycle_runtime.py
+++ b/scripts/strategies/lifecycle_runtime.py
@@ -18,10 +18,7 @@ FALLBACK_ACTIONS = {
 JOIN_POLICIES = {"opportunistic", "quorum", "required"}
 WRITER_FALLBACKS = {"parent_delta", "replan"}
 EPOCH_MILLISECONDS_THRESHOLD = 100_000_000_000
-PROGRESS_QUALITIES = {"meaningful", "activity_only", "none"}
 CHECKPOINT_STATUSES = {"not_requested", "requested", "received", "harvested"}
-REPLAN_SCOPES = {"uncovered_scope", "checkpoint_remaining_delta"}
-CHECKPOINT_REUSE_MODES = {"retained_workspace", "harvested_snapshot_only"}
 
 
 def _strict_timeout(value: Any, label: str) -> float:
@@ -95,7 +92,10 @@ class LifecyclePolicy:
             raise ValueError("opportunistic stage must use min_successful_workers=0")
         if self.join_policy != "opportunistic" and self.min_successful_workers < 1:
             raise ValueError(f"{self.join_policy} stage requires at least one successful worker")
-        for label, value in (("idle_timeout_seconds", self.idle_timeout_seconds), ("hard_timeout_seconds", self.hard_timeout_seconds)):
+        for label, value in (
+            ("idle_timeout_seconds", self.idle_timeout_seconds),
+            ("hard_timeout_seconds", self.hard_timeout_seconds),
+        ):
             if type(value) not in (int, float) or not math.isfinite(float(value)) or value <= 0:
                 raise ValueError(f"{label} must be a positive finite number")
         if self.hard_timeout_seconds < self.idle_timeout_seconds:
@@ -110,7 +110,9 @@ class LifecyclePolicy:
                 raise ValueError("checkpoint_rearm_seconds must be finite")
             if self.checkpoint_rearm_seconds <= 0 or self.checkpoint_rearm_seconds >= self.hard_timeout_seconds:
                 raise ValueError("checkpoint_rearm_seconds must be positive and lower than hard_timeout_seconds")
-            if self.soft_timeout_seconds is not None and self.soft_timeout_seconds + self.checkpoint_rearm_seconds >= self.hard_timeout_seconds:
+            if self.soft_timeout_seconds is None:
+                raise ValueError("checkpoint_rearm_seconds requires soft_timeout_seconds")
+            if self.soft_timeout_seconds + self.checkpoint_rearm_seconds >= self.hard_timeout_seconds:
                 raise ValueError("checkpoint_rearm_seconds must leave time for a second checkpoint before hard_timeout_seconds")
 
 
@@ -126,6 +128,10 @@ class CheckpointRecord:
     def from_dict(cls, value: dict[str, Any]) -> "CheckpointRecord":
         if type(value) is not dict:
             raise ValueError("checkpoint record must be an object")
+        allowed = {"sequence", "generation", "requested_at", "received_at", "harvested_at"}
+        unknown = sorted(set(value).difference(allowed))
+        if unknown:
+            raise ValueError(f"checkpoint record has unknown fields: {unknown}")
         for key in ("sequence", "generation"):
             if type(value.get(key)) is not int:
                 raise ValueError(f"checkpoint {key} must be an integer")
@@ -172,9 +178,6 @@ class WorkerObservation:
     last_progress_at: float
     now: float
     last_meaningful_progress_at: float | None = None
-    checkpoint_requested_at: float | None = None
-    checkpoint_received_at: float | None = None
-    checkpoint_harvested_at: float | None = None
     writable: bool = False
     in_flight: bool = False
     terminal_success: bool = False
@@ -183,24 +186,19 @@ class WorkerObservation:
     cancel_confirmed: bool = False
     replacement_isolated: bool = False
     generation: int = 0
-    checkpoint_sequence: tuple[CheckpointRecord, ...] | None = None
+    checkpoint_sequence: tuple[CheckpointRecord, ...] = ()
 
     def meaningful_progress_at(self) -> float:
         return self.last_progress_at if self.last_meaningful_progress_at is None else self.last_meaningful_progress_at
 
     def checkpoint_records(self) -> tuple[CheckpointRecord, ...]:
-        if self.checkpoint_sequence is not None:
-            return self.checkpoint_sequence
-        if self.checkpoint_requested_at is None and self.checkpoint_received_at is None and self.checkpoint_harvested_at is None:
-            return ()
-        return (CheckpointRecord(1, self.generation, self.checkpoint_requested_at, self.checkpoint_received_at, self.checkpoint_harvested_at),)
+        return self.checkpoint_sequence
 
     def latest_checkpoint(self) -> CheckpointRecord | None:
-        records = self.checkpoint_records()
-        return records[-1] if records else None
+        return self.checkpoint_sequence[-1] if self.checkpoint_sequence else None
 
     def latest_harvested_checkpoint(self) -> CheckpointRecord | None:
-        harvested = [record for record in self.checkpoint_records() if record.harvested_at is not None]
+        harvested = [record for record in self.checkpoint_sequence if record.harvested_at is not None]
         return harvested[-1] if harvested else None
 
     def checkpoint_status(self) -> str:
@@ -220,13 +218,14 @@ class WorkerObservation:
             raise ValueError(f"invalid stage: {self.stage}")
         if type(self.generation) is not int or self.generation < 0:
             raise ValueError("generation must be a non-negative integer")
+        if type(self.checkpoint_sequence) is not tuple:
+            raise ValueError("checkpoint_sequence must be a tuple")
+        if self.stage != "implementation" and self.checkpoint_sequence:
+            raise ValueError("checkpoint_sequence is only valid for implementation stage")
+
         timestamps = [self.started_at, self.last_progress_at, self.now]
-        timestamps.extend(v for v in (
-            self.last_meaningful_progress_at,
-            self.checkpoint_requested_at,
-            self.checkpoint_received_at,
-            self.checkpoint_harvested_at,
-        ) if v is not None)
+        if self.last_meaningful_progress_at is not None:
+            timestamps.append(self.last_meaningful_progress_at)
         if any(type(v) not in (int, float) or not math.isfinite(float(v)) or v < 0 for v in timestamps):
             raise ValueError("timestamps must be finite non-negative seconds")
         if any(v > EPOCH_MILLISECONDS_THRESHOLD for v in timestamps):
@@ -238,29 +237,17 @@ class WorkerObservation:
         meaningful = self.meaningful_progress_at()
         if meaningful < self.started_at or meaningful > self.last_progress_at:
             raise ValueError("last_meaningful_progress_at must be between started_at and last_progress_at")
-        has_legacy_checkpoint = any(v is not None for v in (
-            self.checkpoint_requested_at,
-            self.checkpoint_received_at,
-            self.checkpoint_harvested_at,
-        ))
-        if self.checkpoint_sequence is not None and has_legacy_checkpoint:
-            raise ValueError("legacy checkpoint fields cannot be combined with checkpoint sequence")
-        if self.checkpoint_sequence is None:
-            if self.checkpoint_received_at is not None and self.checkpoint_requested_at is None:
-                raise ValueError("checkpoint_received_at requires checkpoint_requested_at")
-            if self.checkpoint_harvested_at is not None and self.checkpoint_received_at is None:
-                raise ValueError("checkpoint_harvested_at requires checkpoint_received_at")
-        records = self.checkpoint_records()
-        for index, record in enumerate(records, start=1):
+
+        for index, record in enumerate(self.checkpoint_sequence, start=1):
             if record.sequence != index:
                 raise ValueError("checkpoint sequences must be contiguous starting at 1")
             if record.generation != self.generation:
                 raise ValueError("checkpoint generation must equal observation generation")
             record.validate(started_at=self.started_at, now=self.now)
-            if index < len(records) and record.harvested_at is None:
+            if index < len(self.checkpoint_sequence) and record.harvested_at is None:
                 raise ValueError("every checkpoint except the latest must be harvested")
             if index > 1:
-                previous = records[index - 2]
+                previous = self.checkpoint_sequence[index - 2]
                 if previous.harvested_at is None:
                     raise ValueError("a new checkpoint cannot start before the previous one is harvested")
                 if record.requested_at < previous.harvested_at:
@@ -325,7 +312,18 @@ def _replan_contract(observation: WorkerObservation, fallback_policy: str | None
     )
 
 
-def _decision(policy: LifecyclePolicy, observation: WorkerObservation, *, state: str, action: str, reason: str, cancel_required: bool, replacement_allowed: bool, fence_required: bool, fallback_policy: str | None) -> LifecycleDecision:
+def _decision(
+    policy: LifecyclePolicy,
+    observation: WorkerObservation,
+    *,
+    state: str,
+    action: str,
+    reason: str,
+    cancel_required: bool,
+    replacement_allowed: bool,
+    fence_required: bool,
+    fallback_policy: str | None,
+) -> LifecycleDecision:
     idle, meaningful_idle, wall, quality = _progress_metrics(policy, observation)
     replan_scope, reuse = _replan_contract(observation, fallback_policy)
     latest = observation.latest_checkpoint()
@@ -363,7 +361,8 @@ def _decision(policy: LifecyclePolicy, observation: WorkerObservation, *, state:
 
 def _checkpoint_harvest_decision(policy: LifecyclePolicy, observation: WorkerObservation) -> LifecycleDecision:
     return _decision(
-        policy, observation,
+        policy,
+        observation,
         state="progressing" if observation.last_progress_at > observation.started_at or observation.in_flight else "running",
         action="harvest_checkpoint",
         reason="worker checkpoint is available; harvest durable work before any fallback",
@@ -374,7 +373,14 @@ def _checkpoint_harvest_decision(policy: LifecyclePolicy, observation: WorkerObs
     )
 
 
-def _fallback_decision(policy: LifecyclePolicy, observation: WorkerObservation, *, state: str, reason: str, terminal: bool) -> LifecycleDecision:
+def _fallback_decision(
+    policy: LifecyclePolicy,
+    observation: WorkerObservation,
+    *,
+    state: str,
+    reason: str,
+    terminal: bool,
+) -> LifecycleDecision:
     if policy.fallback_policy == "retry_review" and observation.stage != "review":
         raise ValueError("retry_review fallback is only valid for review stage")
     fallback = FALLBACK_ACTIONS[policy.fallback_policy]
@@ -400,7 +406,8 @@ def _fallback_decision(policy: LifecyclePolicy, observation: WorkerObservation, 
     if cancel_required:
         reason += "; non-terminal Worker cancellation is required"
     return _decision(
-        policy, observation,
+        policy,
+        observation,
         state=state,
         action=action,
         reason=reason,
@@ -414,7 +421,8 @@ def _fallback_decision(policy: LifecyclePolicy, observation: WorkerObservation, 
 def _superseded_decision(policy: LifecyclePolicy, observation: WorkerObservation) -> LifecycleDecision:
     terminal = observation.terminal_failure or observation.cancel_confirmed
     return _decision(
-        policy, observation,
+        policy,
+        observation,
         state="superseded",
         action="continue" if terminal else "request_cancel",
         reason="scope is already covered; no fallback work is required",
@@ -437,17 +445,22 @@ def _soft_budget_decision(policy: LifecyclePolicy, observation: WorkerObservatio
         return _checkpoint_harvest_decision(policy, observation)
     else:
         latest = observation.latest_harvested_checkpoint()
-        rearm_at = None if latest is None or policy.checkpoint_rearm_seconds is None else latest.harvested_at + policy.checkpoint_rearm_seconds
+        assert latest is not None
+        rearm_at = latest.harvested_at + policy.checkpoint_rearm_seconds
         explicit = observation.last_meaningful_progress_at
-        has_delta = latest is not None and explicit is not None and explicit > latest.harvested_at
-        cooldown = rearm_at is not None and observation.now >= rearm_at
+        has_delta = explicit is not None and explicit > latest.harvested_at
+        cooldown = observation.now >= rearm_at
         if has_delta and cooldown:
             action, suffix = "request_checkpoint", "explicit meaningful progress and cooldown re-armed checkpointing"
+        elif explicit is None:
+            action, suffix = "continue", "last_progress_at cannot re-arm checkpointing; explicit meaningful progress is required"
+        elif not has_delta:
+            action, suffix = "continue", "harvested checkpoint remains current; no new meaningful delta"
         else:
-            action = "continue"
-            suffix = "harvested checkpoint remains current; no eligible rearm"
+            action, suffix = "continue", "harvested checkpoint remains current; checkpoint rearm cooldown has not elapsed"
     return _decision(
-        policy, observation,
+        policy,
+        observation,
         state=state,
         action=action,
         reason=f"soft worker execution budget reached; progress={quality}; {suffix}",
@@ -461,12 +474,27 @@ def _soft_budget_decision(policy: LifecyclePolicy, observation: WorkerObservatio
 def evaluate_worker(policy: LifecyclePolicy, observation: WorkerObservation) -> LifecycleDecision:
     policy.validate()
     observation.validate()
+    if observation.stage == "implementation":
+        if policy.soft_timeout_seconds is None:
+            raise ValueError("implementation lifecycle requires soft_timeout_seconds")
+        if policy.checkpoint_rearm_seconds is None:
+            raise ValueError("implementation lifecycle requires checkpoint_rearm_seconds")
     idle, _meaningful_idle, wall, _quality = _progress_metrics(policy, observation)
 
     if observation.checkpoint_status() == "received":
         return _checkpoint_harvest_decision(policy, observation)
     if observation.terminal_success:
-        return _decision(policy, observation, state="completed", action="consume_result", reason="worker reported terminal success", cancel_required=False, replacement_allowed=False, fence_required=False, fallback_policy=None)
+        return _decision(
+            policy,
+            observation,
+            state="completed",
+            action="consume_result",
+            reason="worker reported terminal success",
+            cancel_required=False,
+            replacement_allowed=False,
+            fence_required=False,
+            fallback_policy=None,
+        )
     if observation.scope_superseded and policy.cancel_if_superseded:
         return _superseded_decision(policy, observation)
     if observation.terminal_failure:
@@ -480,7 +508,8 @@ def evaluate_worker(policy: LifecyclePolicy, observation: WorkerObservation) -> 
     if policy.soft_timeout_seconds is not None and wall >= policy.soft_timeout_seconds:
         return _soft_budget_decision(policy, observation)
     return _decision(
-        policy, observation,
+        policy,
+        observation,
         state="progressing" if observation.last_progress_at > observation.started_at or observation.in_flight else "running",
         action="continue",
         reason="worker remains non-terminal with an active liveness lease",
@@ -519,9 +548,6 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--started-at", type=float, required=True)
     parser.add_argument("--last-progress-at", type=float, required=True)
     parser.add_argument("--last-meaningful-progress-at", type=float)
-    parser.add_argument("--checkpoint-requested-at", type=float)
-    parser.add_argument("--checkpoint-received-at", type=float)
-    parser.add_argument("--checkpoint-harvested-at", type=float)
     parser.add_argument("--now", type=float, required=True)
     parser.add_argument("--writable", action="store_true")
     parser.add_argument("--in-flight", action="store_true")
@@ -538,9 +564,7 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Iterable[str] | None = None) -> int:
     ns = build_parser().parse_args(list(argv) if argv is not None else None)
     policy = LifecyclePolicy.from_dict(_load_json_object(ns.policy_json, "policy"))
-    sequence = None if ns.checkpoint_sequence_json is None else _load_checkpoint_sequence(ns.checkpoint_sequence_json)
-    if sequence is not None and any(v is not None for v in (ns.checkpoint_requested_at, ns.checkpoint_received_at, ns.checkpoint_harvested_at)):
-        raise ValueError("legacy checkpoint flags cannot be combined with --checkpoint-sequence-json")
+    sequence = () if ns.checkpoint_sequence_json is None else _load_checkpoint_sequence(ns.checkpoint_sequence_json)
     observation = WorkerObservation(
         scope_id=ns.scope_id,
         stage=ns.stage,
@@ -548,9 +572,6 @@ def main(argv: Iterable[str] | None = None) -> int:
         last_progress_at=ns.last_progress_at,
         now=ns.now,
         last_meaningful_progress_at=ns.last_meaningful_progress_at,
-        checkpoint_requested_at=ns.checkpoint_requested_at,
-        checkpoint_received_at=ns.checkpoint_received_at,
-        checkpoint_harvested_at=ns.checkpoint_harvested_at,
         writable=ns.writable,
         in_flight=ns.in_flight,
         terminal_success=ns.terminal_success,

--- a/scripts/strategies/quality.py
+++ b/scripts/strategies/quality.py
@@ -128,6 +128,7 @@ def implementation_maximum_work_units(task) -> int:
     if (
         task.quality_intent == "strong"
         or task.complexity == "complex"
+        or task.risk == "high"
         or task.scope == "cross-module"
         or task.verification_cost == "high"
     ):

--- a/scripts/strategies/quality.py
+++ b/scripts/strategies/quality.py
@@ -1,7 +1,7 @@
 """Correctness- and verification-first strategy."""
 from __future__ import annotations
 
-from .base import StagePolicy, StrategySpec, WorkerBudget, small_low_risk_is_direct, standard_effort
+from .base import StagePolicy, StrategySpec, TaskBudgetPolicy, WorkerBudget, small_low_risk_is_direct, standard_effort
 
 
 def adaptive_route(task) -> str:
@@ -46,12 +46,7 @@ def independent_review(task) -> bool:
 
 
 def capability(task, role: str) -> str:
-    """Select Parent-class capability only where it adds decision value.
-
-    Strong/absolute intent upgrades implementation and independent review, while
-    ordinary read-only exploration stays on the efficient Worker capability.
-    Explorers upgrade only for genuinely critical technical risk/complexity.
-    """
+    """Select Parent-class capability only where it adds decision value."""
     critical = task.complexity == "critical" or task.risk == "critical"
     if role == "explorer":
         return "parent" if critical else "worker"
@@ -140,6 +135,37 @@ def implementation_maximum_work_units(task) -> int:
     return 1
 
 
+def task_budget(task) -> TaskBudgetPolicy:
+    """Keep correctness-first tasks finite without imposing efficient deadlines."""
+    maximum_work_units = implementation_maximum_work_units(task)
+    if (
+        task.quality_intent == "absolute"
+        or task.complexity == "critical"
+        or task.risk == "critical"
+        or task.scope == "repo-wide"
+        or task.iteration_intensity == "heavy-loop"
+    ):
+        soft_timeout, hard_timeout = 6000, 7200
+    elif (
+        task.quality_intent == "strong"
+        or task.complexity == "complex"
+        or task.scope == "cross-module"
+        or task.risk == "high"
+        or task.verification_cost == "high"
+    ):
+        soft_timeout, hard_timeout = 5400, 6600
+    else:
+        soft_timeout, hard_timeout = 4800, 6000
+    return TaskBudgetPolicy(
+        soft_timeout_seconds=soft_timeout,
+        hard_timeout_seconds=hard_timeout,
+        max_work_units=maximum_work_units,
+        max_implementation_attempts=maximum_work_units + 3,
+        max_replans=3,
+        max_replacements=3,
+    )
+
+
 def lifecycle(task, stage: str) -> StagePolicy:
     if stage == "exploration":
         return StagePolicy("quorum", 2, 300, 2400, True, False, "parent_delta")
@@ -181,4 +207,5 @@ STRATEGY = StrategySpec(
     notes=notes,
     lifecycle=lifecycle,
     allow_parallel_write=True,
+    task_budget=task_budget,
 )

--- a/scripts/strategies/quality.py
+++ b/scripts/strategies/quality.py
@@ -80,11 +80,89 @@ def notes(task) -> tuple[str, ...]:
     return ()
 
 
-def lifecycle(_task, stage: str) -> StagePolicy:
+def implementation_soft_timeout(task) -> int:
+    if task.quality_intent == "absolute" or task.complexity == "critical" or task.risk == "critical":
+        return 2700
+    if (
+        task.quality_intent == "strong"
+        or task.complexity == "complex"
+        or task.scope == "repo-wide"
+        or task.iteration_intensity == "heavy-loop"
+        or task.verification_cost == "high"
+    ):
+        return 2400
+    return 1800
+
+
+def implementation_checkpoint_rearm_seconds(task) -> int:
+    if task.quality_intent == "absolute" or task.complexity == "critical" or task.risk == "critical":
+        return 600
+    if (
+        task.quality_intent == "strong"
+        or task.complexity == "complex"
+        or task.scope in {"cross-module", "repo-wide"}
+        or task.iteration_intensity == "heavy-loop"
+        or task.verification_cost == "high"
+    ):
+        return 480
+    return 360
+
+
+def implementation_repair_attempts(task) -> int:
+    if (
+        task.quality_intent in {"strong", "absolute"}
+        or task.complexity in {"complex", "critical"}
+        or task.risk in {"high", "critical"}
+        or task.scope == "repo-wide"
+        or task.iteration_intensity == "heavy-loop"
+        or task.verification_cost == "high"
+    ):
+        return 3
+    return 2
+
+
+def implementation_maximum_work_units(task) -> int:
+    if (
+        task.quality_intent == "absolute"
+        or task.complexity == "critical"
+        or task.risk == "critical"
+        or task.scope == "repo-wide"
+        or task.iteration_intensity == "heavy-loop"
+    ):
+        return 4
+    if (
+        task.quality_intent == "strong"
+        or task.complexity == "complex"
+        or task.scope == "cross-module"
+        or task.verification_cost == "high"
+    ):
+        return 3
+    return 1
+
+
+def lifecycle(task, stage: str) -> StagePolicy:
     if stage == "exploration":
         return StagePolicy("quorum", 2, 300, 2400, True, False, "parent_delta")
     if stage == "implementation":
-        return StagePolicy("required", 1, 300, 3600, False, False, "replan")
+        maximum_work_units = implementation_maximum_work_units(task)
+        bounded_mode = maximum_work_units > 1
+        return StagePolicy(
+            "required",
+            1,
+            300,
+            3600,
+            False,
+            False,
+            "replan",
+            soft_timeout_seconds=implementation_soft_timeout(task),
+            checkpoint_rearm_seconds=implementation_checkpoint_rearm_seconds(task),
+            max_worker_repair_attempts=implementation_repair_attempts(task),
+            work_unit_mode="bounded" if bounded_mode else "single",
+            minimum_work_units=1,
+            join_between_work_units=bounded_mode,
+            maximum_work_units=maximum_work_units,
+            require_write_paths=bounded_mode,
+        )
     if stage == "review":
         return StagePolicy("required", 2, 300, 3000, False, False, "replan")
     raise ValueError(f"invalid lifecycle stage: {stage}")

--- a/scripts/strategies/quality.py
+++ b/scripts/strategies/quality.py
@@ -46,7 +46,6 @@ def independent_review(task) -> bool:
 
 
 def capability(task, role: str) -> str:
-    """Select Parent-class capability only where it adds decision value."""
     critical = task.complexity == "critical" or task.risk == "critical"
     if role == "explorer":
         return "parent" if critical else "worker"
@@ -140,7 +139,6 @@ def implementation_maximum_work_units(task) -> int:
 
 
 def task_budget(task) -> TaskBudgetPolicy:
-    """Keep correctness-first tasks finite without imposing efficient deadlines."""
     maximum_work_units = implementation_maximum_work_units(task)
     if (
         task.quality_intent == "absolute"
@@ -167,6 +165,8 @@ def task_budget(task) -> TaskBudgetPolicy:
         max_implementation_attempts=maximum_work_units + 3,
         max_replans=3,
         max_replacements=3,
+        max_review_attempts=worker_budget(task).max_reviewers * 2,
+        parent_finalization_seconds=300,
     )
 
 
@@ -177,13 +177,7 @@ def lifecycle(task, stage: str) -> StagePolicy:
         maximum_work_units = implementation_maximum_work_units(task)
         bounded_mode = maximum_work_units > 1
         return StagePolicy(
-            "required",
-            1,
-            300,
-            3600,
-            False,
-            False,
-            "replan",
+            "required", 1, 300, 3600, False, False, "replan",
             soft_timeout_seconds=implementation_soft_timeout(task),
             checkpoint_rearm_seconds=implementation_checkpoint_rearm_seconds(task),
             max_worker_repair_attempts=implementation_repair_attempts(task),
@@ -194,7 +188,7 @@ def lifecycle(task, stage: str) -> StagePolicy:
             require_write_paths=bounded_mode,
         )
     if stage == "review":
-        return StagePolicy("required", 2, 300, 3000, False, False, "replan")
+        return StagePolicy("required", 2, 300, 3000, False, False, "retry_review")
     raise ValueError(f"invalid lifecycle stage: {stage}")
 
 

--- a/scripts/strategies/quality.py
+++ b/scripts/strategies/quality.py
@@ -124,16 +124,19 @@ def implementation_maximum_work_units(task) -> int:
         or task.scope == "repo-wide"
         or task.iteration_intensity == "heavy-loop"
     ):
-        return 4
-    if (
+        semantic_maximum = 4
+    elif (
         task.quality_intent == "strong"
         or task.complexity == "complex"
         or task.risk == "high"
         or task.scope == "cross-module"
         or task.verification_cost == "high"
     ):
-        return 3
-    return 1
+        semantic_maximum = 3
+    else:
+        semantic_maximum = 1
+    topology_floor = min(task.writable_workstreams, worker_budget(task).max_implementers)
+    return max(semantic_maximum, topology_floor)
 
 
 def task_budget(task) -> TaskBudgetPolicy:

--- a/scripts/strategies/speed.py
+++ b/scripts/strategies/speed.py
@@ -16,11 +16,63 @@ def worker_budget(task) -> WorkerBudget:
     return WorkerBudget(3, 8, 1, 8, "high")
 
 
-def lifecycle(_task, stage: str) -> StagePolicy:
+def implementation_soft_timeout(task) -> int:
+    if (
+        task.complexity == "critical"
+        or task.risk == "critical"
+        or task.scope == "repo-wide"
+        or task.iteration_intensity == "heavy-loop"
+    ):
+        return 720
+    if task.complexity == "complex" or task.scope == "cross-module":
+        return 600
+    return 420
+
+
+def implementation_checkpoint_rearm_seconds(_task) -> int:
+    return 180
+
+
+def implementation_repair_attempts(_task) -> int:
+    return 1
+
+
+def implementation_maximum_work_units(task) -> int:
+    if (
+        task.complexity == "critical"
+        or task.risk == "critical"
+        or task.scope == "repo-wide"
+        or task.iteration_intensity == "heavy-loop"
+    ):
+        return 4
+    if task.complexity == "complex" or task.scope == "cross-module":
+        return 3
+    return 1
+
+
+def lifecycle(task, stage: str) -> StagePolicy:
     if stage == "exploration":
         return StagePolicy("opportunistic", 0, 60, 600, True, True, "continue_partial")
     if stage == "implementation":
-        return StagePolicy("required", 1, 120, 1200, False, False, "replan")
+        maximum_work_units = implementation_maximum_work_units(task)
+        bounded_mode = maximum_work_units > 1
+        return StagePolicy(
+            "required",
+            1,
+            120,
+            1200,
+            False,
+            False,
+            "replan",
+            soft_timeout_seconds=implementation_soft_timeout(task),
+            checkpoint_rearm_seconds=implementation_checkpoint_rearm_seconds(task),
+            max_worker_repair_attempts=implementation_repair_attempts(task),
+            work_unit_mode="bounded" if bounded_mode else "single",
+            minimum_work_units=1,
+            join_between_work_units=bounded_mode,
+            maximum_work_units=maximum_work_units,
+            require_write_paths=bounded_mode,
+        )
     if stage == "review":
         return StagePolicy("quorum", 1, 90, 900, True, True, "parent_delta")
     raise ValueError(f"invalid lifecycle stage: {stage}")

--- a/scripts/strategies/speed.py
+++ b/scripts/strategies/speed.py
@@ -1,7 +1,7 @@
 """Wall-clock-latency strategy."""
 from __future__ import annotations
 
-from .base import StagePolicy, StrategySpec, WorkerBudget, never, small_low_risk_is_direct, standard_effort
+from .base import StagePolicy, StrategySpec, TaskBudgetPolicy, WorkerBudget, never, small_low_risk_is_direct, standard_effort
 
 
 def adaptive_route(task) -> str:
@@ -50,6 +50,19 @@ def implementation_maximum_work_units(task) -> int:
     return 1
 
 
+def task_budget(task) -> TaskBudgetPolicy:
+    """Cap total speed-mode execution so replans cannot erase the latency goal."""
+    maximum_work_units = implementation_maximum_work_units(task)
+    return TaskBudgetPolicy(
+        soft_timeout_seconds=1200,
+        hard_timeout_seconds=1800,
+        max_work_units=maximum_work_units,
+        max_implementation_attempts=maximum_work_units + 1,
+        max_replans=1,
+        max_replacements=1,
+    )
+
+
 def lifecycle(task, stage: str) -> StagePolicy:
     if stage == "exploration":
         return StagePolicy("opportunistic", 0, 60, 600, True, True, "continue_partial")
@@ -87,4 +100,5 @@ STRATEGY = StrategySpec(
     independent_review=never,
     lifecycle=lifecycle,
     allow_parallel_write=True,
+    task_budget=task_budget,
 )

--- a/scripts/strategies/speed.py
+++ b/scripts/strategies/speed.py
@@ -44,10 +44,16 @@ def implementation_maximum_work_units(task) -> int:
         or task.scope == "repo-wide"
         or task.iteration_intensity == "heavy-loop"
     ):
-        return 4
-    if task.complexity == "complex" or task.scope == "cross-module":
-        return 3
-    return 1
+        semantic_maximum = 4
+    elif task.complexity == "complex" or task.scope == "cross-module":
+        semantic_maximum = 3
+    else:
+        semantic_maximum = 1
+    # A proven writable workstream is already a natural implementation unit.
+    # Never compile a task budget that authorizes fewer logical units than the
+    # strategy can legitimately schedule as parallel implementers.
+    topology_floor = min(task.writable_workstreams, worker_budget(task).max_implementers)
+    return max(semantic_maximum, topology_floor)
 
 
 def task_budget(task) -> TaskBudgetPolicy:

--- a/scripts/strategies/speed.py
+++ b/scripts/strategies/speed.py
@@ -49,15 +49,11 @@ def implementation_maximum_work_units(task) -> int:
         semantic_maximum = 3
     else:
         semantic_maximum = 1
-    # A proven writable workstream is already a natural implementation unit.
-    # Never compile a task budget that authorizes fewer logical units than the
-    # strategy can legitimately schedule as parallel implementers.
     topology_floor = min(task.writable_workstreams, worker_budget(task).max_implementers)
     return max(semantic_maximum, topology_floor)
 
 
 def task_budget(task) -> TaskBudgetPolicy:
-    """Cap total speed-mode execution so replans cannot erase the latency goal."""
     maximum_work_units = implementation_maximum_work_units(task)
     return TaskBudgetPolicy(
         soft_timeout_seconds=1200,
@@ -66,6 +62,8 @@ def task_budget(task) -> TaskBudgetPolicy:
         max_implementation_attempts=maximum_work_units + 1,
         max_replans=1,
         max_replacements=1,
+        max_review_attempts=2,
+        parent_finalization_seconds=120,
     )
 
 
@@ -93,7 +91,7 @@ def lifecycle(task, stage: str) -> StagePolicy:
             require_write_paths=bounded_mode,
         )
     if stage == "review":
-        return StagePolicy("quorum", 1, 90, 900, True, True, "parent_delta")
+        return StagePolicy("quorum", 1, 90, 900, True, True, "retry_review")
     raise ValueError(f"invalid lifecycle stage: {stage}")
 
 

--- a/scripts/strategies/task_budget_runtime.py
+++ b/scripts/strategies/task_budget_runtime.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Durable task-level budget ledger for FlowPilot.
 
-The strategy compiler supplies an immutable :class:`TaskBudgetPolicy`; this
-helper is the small cross-process decision/ledger boundary that reserves work
-before it starts and reports whether a task should continue, converge, or stop.
-It intentionally does not schedule, cancel, or replace Workers.
+General implementation reservations close at the task soft deadline. Read-only
+`review_attempt` reservations belong to required completion and remain open
+until the absolute hard deadline. All reservations are atomic, idempotent, and
+persisted across processes.
 """
 from __future__ import annotations
 
@@ -23,24 +23,27 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Iterator
 
-try:  # Package import when used by another Python module.
+try:
     from .base import TaskBudgetPolicy
-except ImportError:  # Direct invocation from an installed strategies directory.
+except ImportError:
     from base import TaskBudgetPolicy
 
 
-SCHEMA_VERSION = 1
-RESERVATION_KINDS = (
+SCHEMA_VERSION = 2
+GENERAL_RESERVATION_KINDS = (
     "work_unit",
     "implementation_attempt",
     "replan",
     "replacement",
 )
+REQUIRED_COMPLETION_RESERVATION_KINDS = ("review_attempt",)
+RESERVATION_KINDS = GENERAL_RESERVATION_KINDS + REQUIRED_COMPLETION_RESERVATION_KINDS
 POLICY_LIMIT_FIELDS = {
     "work_unit": "max_work_units",
     "implementation_attempt": "max_implementation_attempts",
     "replan": "max_replans",
     "replacement": "max_replacements",
+    "review_attempt": "max_review_attempts",
 }
 STATE_FIELDS = {
     "schema_version",
@@ -64,7 +67,7 @@ STALE_LOCK_SECONDS = 30.0
 
 
 class LedgerError(ValueError):
-    """Expected user/input/state error rendered without a traceback by the CLI."""
+    pass
 
 
 def _sha256(value: str) -> str:
@@ -83,7 +86,6 @@ def _strict_string(value: Any, label: str) -> str:
 
 
 def _seconds(value: Any, label: str) -> float:
-    """Validate a timestamp/duration as finite, non-negative Unix seconds."""
     if isinstance(value, bool):
         raise LedgerError(f"{label} must be finite seconds")
     try:
@@ -95,9 +97,7 @@ def _seconds(value: Any, label: str) -> float:
     if number < 0:
         raise LedgerError(f"{label} cannot be negative")
     if number > EPOCH_MILLISECONDS_THRESHOLD:
-        raise LedgerError(
-            f"{label} must use Unix seconds, not milliseconds"
-        )
+        raise LedgerError(f"{label} must use Unix seconds, not milliseconds")
     return number
 
 
@@ -107,10 +107,9 @@ def _now(value: Any) -> float:
 
 def _policy(value: Any) -> TaskBudgetPolicy:
     try:
-        policy = TaskBudgetPolicy.from_dict(value)
+        return TaskBudgetPolicy.from_dict(value)
     except (TypeError, ValueError) as exc:
         raise LedgerError(str(exc)) from None
-    return policy
 
 
 def _policy_fingerprint(policy: TaskBudgetPolicy) -> str:
@@ -138,11 +137,7 @@ def _fingerprint_hash(value: Any) -> str:
 def _state_path(value: Any) -> Path:
     raw = _strict_string(value, "state_file")
     path = Path(raw)
-    if not path.is_absolute():
-        # Relative paths are useful for tests and are resolved once so all
-        # lock/temp names refer to the same target during this invocation.
-        path = Path.cwd() / path
-    return path
+    return path if path.is_absolute() else Path.cwd() / path
 
 
 def _reject_symlink(path: Path, label: str) -> None:
@@ -157,12 +152,11 @@ def _reject_symlink(path: Path, label: str) -> None:
 
 
 def _ensure_parent(path: Path) -> None:
-    parent = path.parent
     try:
-        parent.mkdir(parents=True, exist_ok=True)
+        path.parent.mkdir(parents=True, exist_ok=True)
     except OSError as exc:
         raise LedgerError(f"cannot create state parent: {exc}") from None
-    if not parent.is_dir():
+    if not path.parent.is_dir():
         raise LedgerError("state-file parent is not a directory")
 
 
@@ -198,14 +192,11 @@ def _lock_is_stale(path: Path) -> bool:
 
 @contextmanager
 def _ledger_lock(path: Path) -> Iterator[None]:
-    """Acquire an O_EXCL lock with bounded retry and stale recovery."""
     _ensure_parent(path)
     _ensure_regular_state(path)
     lock = _lock_path(path)
-    _reject_symlink(lock, "lock file")
     deadline = time.monotonic() + LOCK_TIMEOUT_SECONDS
-    fd: int | None = None
-    while fd is None:
+    while True:
         _reject_symlink(lock, "lock file")
         try:
             flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
@@ -217,7 +208,6 @@ def _ledger_lock(path: Path) -> Iterator[None]:
                 os.fsync(fd)
             finally:
                 os.close(fd)
-            fd = None
             break
         except FileExistsError:
             if _lock_is_stale(lock):
@@ -232,7 +222,6 @@ def _ledger_lock(path: Path) -> Iterator[None]:
             time.sleep(LOCK_RETRY_SECONDS)
         except OSError as exc:
             raise LedgerError(f"cannot acquire task budget lock: {exc}") from None
-
     try:
         yield
     finally:
@@ -257,7 +246,10 @@ def _atomic_write(path: Path, data: dict[str, Any]) -> None:
         fd = os.open(temporary, flags, 0o600)
         offset = 0
         while offset < len(encoded):
-            offset += os.write(fd, encoded[offset:])
+            written = os.write(fd, encoded[offset:])
+            if written <= 0:
+                raise OSError("short write")
+            offset += written
         os.fsync(fd)
         os.close(fd)
         fd = None
@@ -266,8 +258,6 @@ def _atomic_write(path: Path, data: dict[str, Any]) -> None:
         try:
             os.chmod(path, 0o600)
         except OSError:
-            # Windows ACLs do not map cleanly to POSIX mode bits; the create
-            # mode is still best effort and the file remains private by default.
             pass
         if hasattr(os, "O_DIRECTORY"):
             try:
@@ -298,8 +288,7 @@ def _atomic_write(path: Path, data: dict[str, Any]) -> None:
 def _read_state(path: Path) -> dict[str, Any]:
     _ensure_regular_state(path)
     try:
-        text = path.read_text(encoding="utf-8")
-        value = json.loads(text)
+        value = json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError:
         raise LedgerError("task budget state does not exist; run init first") from None
     except (OSError, UnicodeError, json.JSONDecodeError) as exc:
@@ -318,14 +307,14 @@ def _validate_state(value: Any) -> None:
     if type(value) is not dict:
         raise LedgerError("task budget state must be an object")
     if set(value) != STATE_FIELDS:
-        unknown = sorted(set(value).difference(STATE_FIELDS))
         missing = sorted(STATE_FIELDS.difference(value))
-        detail = []
+        unknown = sorted(set(value).difference(STATE_FIELDS))
+        details = []
         if missing:
-            detail.append(f"missing fields: {missing}")
+            details.append(f"missing fields: {missing}")
         if unknown:
-            detail.append(f"unknown fields: {unknown}")
-        raise LedgerError("invalid task budget state (" + "; ".join(detail) + ")")
+            details.append(f"unknown fields: {unknown}")
+        raise LedgerError("invalid task budget state (" + "; ".join(details) + ")")
     if type(value["schema_version"]) is not int or value["schema_version"] != SCHEMA_VERSION:
         raise LedgerError("unsupported task budget state schema")
     _validate_hash(value["task_id"], "task id hash")
@@ -364,10 +353,10 @@ def _validate_state(value: Any) -> None:
         entries = reservations[kind]
         if type(entries) is not list:
             raise LedgerError(f"reservations.{kind} must be a list")
-        seen: set[str] = set()
-        latest = started
         if len(entries) > limits[kind]:
             raise LedgerError(f"reservations.{kind} exceeds its limit")
+        seen: set[str] = set()
+        latest = started
         for entry in entries:
             if type(entry) is not dict or set(entry) != RESERVATION_FIELDS:
                 raise LedgerError(f"invalid {kind} reservation")
@@ -398,6 +387,10 @@ def _check_now(state: dict[str, Any], now: float) -> None:
 
 
 def _new_state(task_hash: str, policy: TaskBudgetPolicy, now: float) -> dict[str, Any]:
+    limits = {
+        kind: getattr(policy, POLICY_LIMIT_FIELDS[kind])
+        for kind in RESERVATION_KINDS
+    }
     return {
         "schema_version": SCHEMA_VERSION,
         "task_id": task_hash,
@@ -407,14 +400,7 @@ def _new_state(task_hash: str, policy: TaskBudgetPolicy, now: float) -> dict[str
         "hard_deadline": now + policy.hard_timeout_seconds,
         "closed": False,
         "outcome": None,
-        # Keep only the immutable numeric limits needed by later processes;
-        # never persist the original policy/prompt/path/output payload.
-        "limits": {
-            "work_unit": policy.max_work_units,
-            "implementation_attempt": policy.max_implementation_attempts,
-            "replan": policy.max_replans,
-            "replacement": policy.max_replacements,
-        },
+        "limits": limits,
         "reservations": {kind: [] for kind in RESERVATION_KINDS},
     }
 
@@ -434,7 +420,8 @@ def _status(state: dict[str, Any], now: float) -> dict[str, Any]:
         action = "converge"
     else:
         action = "stop"
-    remaining = max(0.0, float(state["hard_deadline"]) - now)
+    remaining_hard = max(0.0, float(state["hard_deadline"]) - now)
+    counters = _counters(state)
     return {
         "schema_version": SCHEMA_VERSION,
         "task_id": state["task_id"],
@@ -445,18 +432,22 @@ def _status(state: dict[str, Any], now: float) -> dict[str, Any]:
         "closed": closed,
         "outcome": state["outcome"],
         "action": action,
-        "remaining_seconds": remaining,
+        "remaining_seconds": remaining_hard,
         "remaining_soft_seconds": max(0.0, float(state["soft_deadline"]) - now),
-        "remaining_hard_seconds": remaining,
-        "counters": _counters(state),
+        "remaining_hard_seconds": remaining_hard,
+        "counters": counters,
         "limits": dict(state["limits"]),
         "permits_new_work": action == "continue",
+        "permits_new_review": (
+            not closed
+            and now < state["hard_deadline"]
+            and counters["review_attempt"] < state["limits"]["review_attempt"]
+        ),
         "cancel_required": action == "stop" and not closed and now >= state["hard_deadline"],
     }
 
 
 def init_ledger(state_file: str | Path, task_id: str, policy: TaskBudgetPolicy, now: Any) -> dict[str, Any]:
-    """Create a ledger, or idempotently validate an existing same-task ledger."""
     path = _state_path(state_file)
     task_hash = _task_hash(task_id)
     policy.validate()
@@ -522,44 +513,37 @@ def reserve(
             if entry["reservation_id"] == reservation_hash:
                 if entry["fingerprint"] != fp_hash:
                     raise LedgerError("reservation id already used with a different fingerprint")
-                # Idempotent replay is not new work, including after a deadline.
                 result = _status(state, current_now)
-                result.update(
-                    {
-                        "kind": kind,
-                        "reservation_id": reservation_hash,
-                        "fingerprint": fp_hash,
-                        "reserved": True,
-                        "idempotent": True,
-                    }
-                )
+                result.update({
+                    "kind": kind,
+                    "reservation_id": reservation_hash,
+                    "fingerprint": fp_hash,
+                    "reserved": True,
+                    "idempotent": True,
+                })
                 return result
         if current_now >= state["hard_deadline"]:
             raise LedgerError("task hard deadline reached; new reservations are not permitted")
-        if current_now >= state["soft_deadline"]:
-            raise LedgerError("task soft deadline reached; new reservations are not permitted")
+        if kind in GENERAL_RESERVATION_KINDS and current_now >= state["soft_deadline"]:
+            raise LedgerError("task soft deadline reached; new general-work reservations are not permitted")
         limit = state["limits"][kind]
         if len(entries) >= limit:
             raise LedgerError(f"{kind} reservation limit reached")
-        entries.append(
-            {
-                "reservation_id": reservation_hash,
-                "fingerprint": fp_hash,
-                "reserved_at": current_now,
-            }
-        )
+        entries.append({
+            "reservation_id": reservation_hash,
+            "fingerprint": fp_hash,
+            "reserved_at": current_now,
+        })
         _validate_state(state)
         _atomic_write(path, state)
         result = _status(state, current_now)
-        result.update(
-            {
-                "kind": kind,
-                "reservation_id": reservation_hash,
-                "fingerprint": fp_hash,
-                "reserved": True,
-                "idempotent": False,
-            }
-        )
+        result.update({
+            "kind": kind,
+            "reservation_id": reservation_hash,
+            "fingerprint": fp_hash,
+            "reserved": True,
+            "idempotent": False,
+        })
         return result
 
 
@@ -599,6 +583,12 @@ def _json_argument(raw: str) -> Any:
         raise LedgerError(f"invalid policy JSON: {exc.msg}") from None
 
 
+def _common_args(command: argparse.ArgumentParser) -> None:
+    command.add_argument("--state-file", required=True)
+    command.add_argument("--task-id", required=True)
+    command.add_argument("--now", required=True)
+
+
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="task_budget_runtime.py",
@@ -606,12 +596,12 @@ def _parser() -> argparse.ArgumentParser:
     )
     commands = parser.add_subparsers(dest="command", required=True)
 
-    init = commands.add_parser("init")
-    _common_args(init)
-    init.add_argument("--policy-json", required=True)
+    init_cmd = commands.add_parser("init")
+    _common_args(init_cmd)
+    init_cmd.add_argument("--policy-json", required=True)
 
-    status = commands.add_parser("status")
-    _common_args(status)
+    status_cmd = commands.add_parser("status")
+    _common_args(status_cmd)
 
     reserve_cmd = commands.add_parser("reserve")
     _common_args(reserve_cmd)
@@ -625,37 +615,19 @@ def _parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _common_args(command: argparse.ArgumentParser) -> None:
-    command.add_argument("--state-file", required=True)
-    command.add_argument("--task-id", required=True)
-    command.add_argument("--now", required=True)
-
-
 def main(argv: list[str] | None = None) -> int:
     parser = _parser()
     ns = parser.parse_args(argv)
     try:
         if ns.command == "init":
-            result = init_ledger(
-                ns.state_file,
-                ns.task_id,
-                _policy(_json_argument(ns.policy_json)),
-                ns.now,
-            )
+            result = init_ledger(ns.state_file, ns.task_id, _policy(_json_argument(ns.policy_json)), ns.now)
         elif ns.command == "status":
             result = ledger_status(ns.state_file, ns.task_id, ns.now)
         elif ns.command == "reserve":
-            result = reserve(
-                ns.state_file,
-                ns.task_id,
-                ns.kind,
-                ns.reservation_id,
-                ns.fingerprint,
-                ns.now,
-            )
+            result = reserve(ns.state_file, ns.task_id, ns.kind, ns.reservation_id, ns.fingerprint, ns.now)
         elif ns.command == "finish":
             result = finish(ns.state_file, ns.task_id, ns.outcome, ns.now)
-        else:  # pragma: no cover - argparse choices make this unreachable.
+        else:  # pragma: no cover
             raise LedgerError(f"unsupported command: {ns.command}")
     except (LedgerError, ValueError, OSError) as exc:
         print(f"task-budget: {exc}", file=sys.stderr)

--- a/scripts/strategies/task_budget_runtime.py
+++ b/scripts/strategies/task_budget_runtime.py
@@ -2,9 +2,9 @@
 """Durable task-level budget ledger for FlowPilot.
 
 General implementation reservations close at the task soft deadline. Read-only
-`review_attempt` reservations belong to required completion and remain open
-until the absolute hard deadline. All reservations are atomic, idempotent, and
-persisted across processes.
+`review_attempt` reservations may use a stricter phase-owned admission deadline.
+All reservation deadline gates run only after exact idempotent replay detection,
+so a committed reservation can always be acknowledged without creating work.
 """
 from __future__ import annotations
 
@@ -27,7 +27,6 @@ try:
     from .base import TaskBudgetPolicy
 except ImportError:
     from base import TaskBudgetPolicy
-
 
 SCHEMA_VERSION = 2
 GENERAL_RESERVATION_KINDS = (
@@ -387,10 +386,7 @@ def _check_now(state: dict[str, Any], now: float) -> None:
 
 
 def _new_state(task_hash: str, policy: TaskBudgetPolicy, now: float) -> dict[str, Any]:
-    limits = {
-        kind: getattr(policy, POLICY_LIMIT_FIELDS[kind])
-        for kind in RESERVATION_KINDS
-    }
+    limits = {kind: getattr(policy, POLICY_LIMIT_FIELDS[kind]) for kind in RESERVATION_KINDS}
     return {
         "schema_version": SCHEMA_VERSION,
         "task_id": task_hash,
@@ -493,10 +489,17 @@ def reserve(
     reservation_id: str,
     fingerprint: str,
     now: Any,
+    *,
+    new_reservation_deadline: Any | None = None,
 ) -> dict[str, Any]:
     path = _state_path(state_file)
     task_hash = _task_hash(task_id)
     current_now = _now(now)
+    admission_deadline = (
+        None
+        if new_reservation_deadline is None
+        else _seconds(new_reservation_deadline, "new_reservation_deadline")
+    )
     if kind not in RESERVATION_KINDS:
         raise LedgerError(f"invalid reservation kind: {kind}")
     reservation_hash = _reservation_hash(reservation_id)
@@ -522,6 +525,11 @@ def reserve(
                     "idempotent": True,
                 })
                 return result
+        if admission_deadline is not None:
+            if admission_deadline > state["hard_deadline"]:
+                raise LedgerError("new reservation deadline cannot exceed task hard deadline")
+            if current_now >= admission_deadline:
+                raise LedgerError("reservation admission deadline reached; new reservation is not permitted")
         if current_now >= state["hard_deadline"]:
             raise LedgerError("task hard deadline reached; new reservations are not permitted")
         if kind in GENERAL_RESERVATION_KINDS and current_now >= state["soft_deadline"]:
@@ -595,20 +603,16 @@ def _parser() -> argparse.ArgumentParser:
         description="durable FlowPilot task budget ledger",
     )
     commands = parser.add_subparsers(dest="command", required=True)
-
     init_cmd = commands.add_parser("init")
     _common_args(init_cmd)
     init_cmd.add_argument("--policy-json", required=True)
-
     status_cmd = commands.add_parser("status")
     _common_args(status_cmd)
-
     reserve_cmd = commands.add_parser("reserve")
     _common_args(reserve_cmd)
     reserve_cmd.add_argument("--kind", choices=RESERVATION_KINDS, required=True)
     reserve_cmd.add_argument("--reservation-id", required=True)
     reserve_cmd.add_argument("--fingerprint", required=True)
-
     finish_cmd = commands.add_parser("finish")
     _common_args(finish_cmd)
     finish_cmd.add_argument("--outcome", default="success")

--- a/scripts/strategies/task_phase_runtime.py
+++ b/scripts/strategies/task_phase_runtime.py
@@ -2,16 +2,22 @@
 """Phase-aware admission on top of the durable task-budget ledger.
 
 The task ledger owns cumulative counters and the absolute task hard deadline.
-This helper adds one missing scheduling invariant: an immutable ExecutionPlan
-that already requires independent review must keep enough tail time for that
-required completion stage.
+This helper adds one missing scheduling invariant: an immutable initial
+ExecutionPlan that already requires independent review must keep enough tail
+time for that required completion stage.
 
-For a new task the helper derives an effective ledger policy from the immutable
-plan. Its soft timeout is clamped to the earlier of the strategy soft timeout
-and ``hard_timeout - review_stage.hard_timeout``. The raw ledger therefore
-keeps its own atomic reservation/idempotency semantics while still enforcing
-that required-completion reserve. Required completion may start after that soft
-boundary and remains permitted until the absolute task hard deadline.
+For a new task the helper derives an effective ledger policy from the initial
+budget plan. Its soft timeout is clamped to the earlier of the strategy soft
+timeout and ``hard_timeout - review_stage.hard_timeout``. The raw ledger
+therefore keeps its own atomic reservation/idempotency semantics while still
+enforcing that required-completion reserve. Required completion may start
+after that soft boundary and remains permitted until the absolute task hard
+deadline.
+
+A ledger created by the pre-phase runtime is grandfathered when its stored
+fingerprint exactly matches the initial plan's original TaskBudgetPolicy. Such
+a running task keeps its historical unclamped soft deadline; upgrades never
+retroactively shorten its execution window or invent a review-tail reservation.
 
 The helper does not schedule Workers. It initializes the ledger, reports
 phase-aware admission, and wraps implementation reservations.
@@ -84,6 +90,13 @@ def _plan(value: Any) -> dict[str, Any]:
     return value
 
 
+def _original_policy(plan: dict[str, Any]) -> TaskBudgetPolicy:
+    try:
+        return TaskBudgetPolicy.from_dict(plan["task_budget"])
+    except (TypeError, ValueError) as exc:
+        raise LedgerError(str(exc)) from None
+
+
 def _review_reserve_seconds(plan: dict[str, Any]) -> int:
     reviewer_workers = _strict_int(plan.get("reviewer_workers"), "reviewer_workers")
     review_stage = plan.get("review_stage")
@@ -96,10 +109,7 @@ def _review_reserve_seconds(plan: dict[str, Any]) -> int:
 
 
 def _effective_policy(plan: dict[str, Any]) -> TaskBudgetPolicy:
-    try:
-        policy = TaskBudgetPolicy.from_dict(plan["task_budget"])
-    except (TypeError, ValueError) as exc:
-        raise LedgerError(str(exc)) from None
+    policy = _original_policy(plan)
     review_reserve = _review_reserve_seconds(plan)
     if review_reserve <= 0:
         return policy
@@ -129,22 +139,33 @@ def _policy_fingerprint(policy: TaskBudgetPolicy) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
+def _policy_mode(plan: dict[str, Any], ledger_value: dict[str, Any]) -> tuple[TaskBudgetPolicy, bool]:
+    """Return the actual ledger policy and whether it is a grandfathered v1 ledger."""
+    original = _original_policy(plan)
+    effective = _effective_policy(plan)
+    stored = ledger_value.get("policy_fingerprint")
+    effective_fp = _policy_fingerprint(effective)
+    original_fp = _policy_fingerprint(original)
+    if stored == effective_fp:
+        return effective, False
+    if effective_fp != original_fp and stored == original_fp:
+        return original, True
+    raise LedgerError("task phase plan/policy mismatch; refusing to use a different budget plan")
+
+
 def phase_decision(
     plan_value: Any,
     ledger_value: Any,
     phase: str,
     now: Any,
 ) -> dict[str, Any]:
-    """Return phase-aware admission from an immutable plan + ledger status."""
+    """Return phase-aware admission from an initial budget plan + ledger status."""
     if phase not in PHASES:
         raise LedgerError(f"invalid task phase: {phase}")
     plan = _plan(plan_value)
-    effective_policy = _effective_policy(plan)
     if type(ledger_value) is not dict:
         raise LedgerError("ledger status must be an object")
-    expected_fingerprint = _policy_fingerprint(effective_policy)
-    if ledger_value.get("policy_fingerprint") != expected_fingerprint:
-        raise LedgerError("task phase plan/policy mismatch; refusing to use a different budget plan")
+    ledger_policy, legacy_unclamped = _policy_mode(plan, ledger_value)
 
     current_now = _strict_number(now, "now")
     started_at = _strict_number(ledger_value.get("started_at"), "started_at")
@@ -152,15 +173,17 @@ def phase_decision(
     hard_deadline = _strict_number(ledger_value.get("hard_deadline"), "hard_deadline")
     if hard_deadline <= soft_deadline:
         raise LedgerError("hard_deadline must be after soft_deadline")
-    if soft_deadline != started_at + effective_policy.soft_timeout_seconds:
-        raise LedgerError("task phase soft deadline does not match the immutable budget plan")
-    if hard_deadline != started_at + effective_policy.hard_timeout_seconds:
-        raise LedgerError("task phase hard deadline does not match the immutable budget plan")
+    if soft_deadline != started_at + ledger_policy.soft_timeout_seconds:
+        raise LedgerError("task phase soft deadline does not match the initial budget plan")
+    if hard_deadline != started_at + ledger_policy.hard_timeout_seconds:
+        raise LedgerError("task phase hard deadline does not match the initial budget plan")
     closed = ledger_value.get("closed")
     if type(closed) is not bool:
         raise LedgerError("ledger closed must be boolean")
 
-    review_reserve = _review_reserve_seconds(plan)
+    # Do not retroactively reserve review tail for a task that was already
+    # running before phase-aware admission existed.
+    review_reserve = 0 if legacy_unclamped else _review_reserve_seconds(plan)
     general_work_deadline = soft_deadline
     hard_open = (not closed) and current_now < hard_deadline
     permits_required_completion = hard_open
@@ -195,6 +218,7 @@ def phase_decision(
         "required_completion_handoff": (
             review_reserve > 0 and hard_open and current_now >= general_work_deadline
         ),
+        "legacy_unclamped": legacy_unclamped,
     }
 
 
@@ -204,9 +228,28 @@ def init(
     plan: dict[str, Any],
     now: Any,
 ) -> dict[str, Any]:
-    """Initialize a new phase-aware ledger from the immutable budget plan."""
-    effective_policy = _effective_policy(_plan(plan))
-    result = init_ledger(state_file, task_id, effective_policy, now)
+    """Initialize a phase-aware ledger, or grandfather an existing pre-phase ledger."""
+    plan = _plan(plan)
+    effective_policy = _effective_policy(plan)
+    try:
+        result = init_ledger(state_file, task_id, effective_policy, now)
+    except LedgerError as init_error:
+        # An already-running task from the pre-phase runtime was initialized
+        # with the original policy. Preserve it rather than shortening its soft
+        # deadline during an update. Any other mismatch still fails closed.
+        try:
+            result = ledger_status(state_file, task_id, now)
+            actual_policy, legacy_unclamped = _policy_mode(plan, result)
+        except LedgerError:
+            raise init_error
+        if not legacy_unclamped:
+            raise init_error
+        result["initialized"] = False
+        result["idempotent"] = True
+        result.update(phase_decision(plan, result, "exploration", now))
+        result["effective_task_budget"] = asdict(actual_policy)
+        return result
+
     result.update(phase_decision(plan, result, "exploration", now))
     result["effective_task_budget"] = asdict(effective_policy)
     return result
@@ -236,9 +279,10 @@ def reserve_implementation(
 ) -> dict[str, Any]:
     if kind not in IMPLEMENTATION_RESERVATION_KINDS:
         raise LedgerError(f"invalid implementation reservation kind: {kind}")
-    # The phase-aware init has already clamped the ledger soft deadline. Calling
-    # the raw atomic reserve preserves its deadline checks and, critically, its
-    # idempotent replay semantics after the deadline.
+    # A phase-aware ledger already has the completion reserve encoded in its
+    # soft deadline. A grandfathered ledger keeps its historical deadline. In
+    # both cases the raw atomic reserve preserves limit/deadline checks and its
+    # deliberate idempotent replay behavior after the deadline.
     result = reserve(
         state_file,
         task_id,

--- a/scripts/strategies/task_phase_runtime.py
+++ b/scripts/strategies/task_phase_runtime.py
@@ -52,6 +52,18 @@ def _strict_number(value: Any, label: str) -> float:
     return number
 
 
+def _cli_now(value: Any) -> float:
+    if isinstance(value, bool):
+        raise LedgerError("now must be finite seconds")
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        raise LedgerError("now must be finite seconds") from None
+    if not math.isfinite(number) or number < 0:
+        raise LedgerError("now must be finite non-negative seconds")
+    return number
+
+
 def _strict_int(value: Any, label: str) -> int:
     if type(value) is not int or value < 0:
         raise LedgerError(f"{label} must be a non-negative integer")
@@ -132,7 +144,7 @@ def phase_decision(
         raise LedgerError("ledger status must be an object")
     expected_fingerprint = _policy_fingerprint(effective_policy)
     if ledger_value.get("policy_fingerprint") != expected_fingerprint:
-        raise LedgerError("task phase plan/policy mismatch; refusing to use a different ExecutionPlan")
+        raise LedgerError("task phase plan/policy mismatch; refusing to use a different budget plan")
 
     current_now = _strict_number(now, "now")
     started_at = _strict_number(ledger_value.get("started_at"), "started_at")
@@ -141,9 +153,9 @@ def phase_decision(
     if hard_deadline <= soft_deadline:
         raise LedgerError("hard_deadline must be after soft_deadline")
     if soft_deadline != started_at + effective_policy.soft_timeout_seconds:
-        raise LedgerError("task phase soft deadline does not match the immutable ExecutionPlan")
+        raise LedgerError("task phase soft deadline does not match the immutable budget plan")
     if hard_deadline != started_at + effective_policy.hard_timeout_seconds:
-        raise LedgerError("task phase hard deadline does not match the immutable ExecutionPlan")
+        raise LedgerError("task phase hard deadline does not match the immutable budget plan")
     closed = ledger_value.get("closed")
     if type(closed) is not bool:
         raise LedgerError("ledger closed must be boolean")
@@ -192,7 +204,7 @@ def init(
     plan: dict[str, Any],
     now: Any,
 ) -> dict[str, Any]:
-    """Initialize a new phase-aware ledger from the immutable plan."""
+    """Initialize a new phase-aware ledger from the immutable budget plan."""
     effective_policy = _effective_policy(_plan(plan))
     result = init_ledger(state_file, task_id, effective_policy, now)
     result.update(phase_decision(plan, result, "exploration", now))
@@ -280,10 +292,11 @@ def main(argv: list[str] | None = None) -> int:
     ns = parser.parse_args(argv)
     try:
         plan = _plan(_json(ns.plan_json, "plan"))
+        current_now = _cli_now(ns.now)
         if ns.command == "init":
-            result = init(ns.state_file, ns.task_id, plan, ns.now)
+            result = init(ns.state_file, ns.task_id, plan, current_now)
         elif ns.command == "status":
-            result = status(ns.state_file, ns.task_id, plan, ns.phase, ns.now)
+            result = status(ns.state_file, ns.task_id, plan, ns.phase, current_now)
         else:
             result = reserve_implementation(
                 ns.state_file,
@@ -292,7 +305,7 @@ def main(argv: list[str] | None = None) -> int:
                 ns.kind,
                 ns.reservation_id,
                 ns.fingerprint,
-                ns.now,
+                current_now,
             )
     except LedgerError as exc:
         print(str(exc), file=sys.stderr)

--- a/scripts/strategies/task_phase_runtime.py
+++ b/scripts/strategies/task_phase_runtime.py
@@ -4,8 +4,14 @@
 The compiler emits one self-consistent task budget. Its soft deadline is the
 end of general writable work. If independent review is planned, its hard
 deadline already includes the review-stage hard window plus an explicit Parent
-finalization reserve. This helper only validates that contract and performs
+finalization reserve. This helper validates that contract and performs
 phase-aware reservations; it never derives a second budget.
+
+Required completion has two admission windows:
+- review may start from the general-work cutoff until ``review_deadline``;
+- Parent finalization retains the remaining tail until the absolute hard stop.
+
+A reviewer retry therefore cannot consume the Parent finalization reserve.
 """
 from __future__ import annotations
 
@@ -98,7 +104,6 @@ def _completion_reserve(plan: dict[str, Any], policy: TaskBudgetPolicy) -> tuple
         if review_stage is not None:
             raise LedgerError("review_stage must be null when reviewer_workers is zero")
         if policy.max_review_attempts != 0:
-            # Parent-only plans must not silently reserve reviewer capacity.
             raise LedgerError("max_review_attempts must be zero when reviewer_workers is zero")
         return 0, 0, 0
     if type(review_stage) is not dict:
@@ -182,11 +187,23 @@ def phase_decision(plan_value: Any, ledger_value: Any, phase: str, now: Any) -> 
     hard_open = (not closed) and current_now < hard_deadline
     permits_general_work = hard_open and current_now < soft_deadline
     permits_required_completion = hard_open and reserve_seconds > 0
+    review_deadline = hard_deadline - parent_finalization if reserve_seconds > 0 else None
+    permits_review_start = (
+        permits_required_completion
+        and review_deadline is not None
+        and current_now < review_deadline
+    )
+    permits_parent_finalization = hard_open
 
     if not hard_open:
         action = "stop"
     elif phase == "required_completion":
-        action = "complete_required" if permits_required_completion else "stop"
+        if not permits_required_completion:
+            action = "stop"
+        elif permits_review_start:
+            action = "complete_required"
+        else:
+            action = "finalize_parent"
     elif permits_general_work:
         action = "continue"
     elif reserve_seconds > 0:
@@ -200,13 +217,17 @@ def phase_decision(plan_value: Any, ledger_value: Any, phase: str, now: Any) -> 
         "permits_phase_start": permits_required_completion if phase == "required_completion" else permits_general_work,
         "permits_general_work": permits_general_work,
         "permits_required_completion": permits_required_completion,
+        "permits_review_start": permits_review_start,
+        "permits_parent_finalization": permits_parent_finalization,
         "reviewer_reserve_seconds": review_hard,
         "parent_finalization_reserve_seconds": parent_finalization,
         "required_completion_reserve_seconds": reserve_seconds,
         "general_work_deadline": soft_deadline,
+        "review_deadline": review_deadline,
         "soft_deadline": soft_deadline,
         "hard_deadline": hard_deadline,
         "remaining_general_work_seconds": max(0.0, soft_deadline - current_now),
+        "remaining_review_seconds": 0.0 if review_deadline is None else max(0.0, review_deadline - current_now),
         "remaining_hard_seconds": max(0.0, hard_deadline - current_now),
         "checkpoint_convergence_required": phase == "implementation" and hard_open and current_now >= soft_deadline,
         "required_completion_handoff": reserve_seconds > 0 and hard_open and current_now >= soft_deadline,
@@ -250,15 +271,19 @@ def reserve_phase(
         raise LedgerError(f"{kind} reservations require phase={expected_phase}")
     if phase == "implementation" and kind not in GENERAL_RESERVATION_KINDS:
         raise LedgerError("implementation phase only accepts general-work reservations")
+
     decision = status(state_file, task_id, plan, phase, now)
-    if not decision["permits_phase_start"]:
+    if kind == "review_attempt":
+        if not decision["permits_review_start"]:
+            raise LedgerError("review admission deadline reached; Parent finalization reserve is protected")
+    elif not decision["permits_phase_start"]:
         raise LedgerError(f"task phase {phase} does not permit a new {kind} reservation")
+
     result = reserve(state_file, task_id, kind, reservation_id, fingerprint, now)
     result.update(phase_decision(plan, result, phase, now))
     return result
 
 
-# Backward-compatible Python name inside this branch; CLI and schema are v11 only.
 def reserve_implementation(state_file: str, task_id: str, plan: dict[str, Any], kind: str, reservation_id: str, fingerprint: str, now: Any) -> dict[str, Any]:
     return reserve_phase(state_file, task_id, plan, "implementation", kind, reservation_id, fingerprint, now)
 

--- a/scripts/strategies/task_phase_runtime.py
+++ b/scripts/strategies/task_phase_runtime.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Phase-aware admission on top of the durable task-budget ledger.
+
+The task ledger owns cumulative counters and the absolute task hard deadline.
+This helper adds one missing scheduling invariant: an immutable ExecutionPlan
+that already requires independent review must keep enough tail time for that
+required completion stage. Exploration/implementation admissions stop at the
+earlier of the task soft deadline and ``hard_deadline - review_stage.hard``;
+required completion may still start until the absolute task hard deadline.
+
+The helper does not schedule Workers. It returns deterministic admission
+signals and wraps implementation reservations so callers cannot bypass the
+reserved review tail by talking directly to the ledger for new implementation
+work.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from typing import Any
+
+try:  # Package import.
+    from .task_budget_runtime import LedgerError, ledger_status, reserve
+except ImportError:  # Direct invocation from installed strategies directory.
+    from task_budget_runtime import LedgerError, ledger_status, reserve
+
+
+PHASES = ("exploration", "implementation", "required_completion")
+IMPLEMENTATION_RESERVATION_KINDS = (
+    "work_unit",
+    "implementation_attempt",
+    "replan",
+    "replacement",
+)
+
+
+def _strict_number(value: Any, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise LedgerError(f"{label} must be a finite number")
+    number = float(value)
+    if not math.isfinite(number) or number < 0:
+        raise LedgerError(f"{label} must be a finite non-negative number")
+    return number
+
+
+def _strict_int(value: Any, label: str) -> int:
+    if type(value) is not int or value < 0:
+        raise LedgerError(f"{label} must be a non-negative integer")
+    return value
+
+
+def _plan(value: Any) -> dict[str, Any]:
+    if type(value) is not dict:
+        raise LedgerError("ExecutionPlan must be an object")
+    if value.get("task_budget") is None:
+        raise LedgerError("ExecutionPlan has no task_budget")
+    if type(value.get("task_budget")) is not dict:
+        raise LedgerError("ExecutionPlan task_budget must be an object")
+    _strict_int(value.get("reviewer_workers"), "reviewer_workers")
+    review_stage = value.get("review_stage")
+    if review_stage is not None and type(review_stage) is not dict:
+        raise LedgerError("review_stage must be an object or null")
+    return value
+
+
+def _review_reserve_seconds(plan: dict[str, Any]) -> float:
+    reviewer_workers = _strict_int(plan.get("reviewer_workers"), "reviewer_workers")
+    review_stage = plan.get("review_stage")
+    if reviewer_workers <= 0 or review_stage is None:
+        return 0.0
+    hard = _strict_number(review_stage.get("hard_timeout_seconds"), "review_stage.hard_timeout_seconds")
+    if hard <= 0:
+        raise LedgerError("required review hard timeout must be positive")
+    return hard
+
+
+def phase_decision(
+    plan_value: Any,
+    ledger_value: Any,
+    phase: str,
+    now: Any,
+) -> dict[str, Any]:
+    """Return phase-aware admission from an immutable plan + ledger status."""
+    if phase not in PHASES:
+        raise LedgerError(f"invalid task phase: {phase}")
+    plan = _plan(plan_value)
+    if type(ledger_value) is not dict:
+        raise LedgerError("ledger status must be an object")
+    current_now = _strict_number(now, "now")
+    soft_deadline = _strict_number(ledger_value.get("soft_deadline"), "soft_deadline")
+    hard_deadline = _strict_number(ledger_value.get("hard_deadline"), "hard_deadline")
+    if hard_deadline <= soft_deadline:
+        raise LedgerError("hard_deadline must be after soft_deadline")
+    closed = ledger_value.get("closed")
+    if type(closed) is not bool:
+        raise LedgerError("ledger closed must be boolean")
+
+    review_reserve = _review_reserve_seconds(plan)
+    completion_cutoff = hard_deadline - review_reserve
+    if review_reserve > 0 and completion_cutoff <= _strict_number(ledger_value.get("started_at"), "started_at"):
+        raise LedgerError("task hard budget is too small to reserve the required review stage")
+    general_work_deadline = min(soft_deadline, completion_cutoff) if review_reserve > 0 else soft_deadline
+
+    hard_open = (not closed) and current_now < hard_deadline
+    permits_required_completion = hard_open
+    permits_general_work = hard_open and current_now < general_work_deadline
+
+    if not hard_open:
+        action = "stop"
+    elif phase == "required_completion":
+        action = "complete_required"
+    elif permits_general_work:
+        action = "continue"
+    elif review_reserve > 0:
+        action = "converge_for_required_completion"
+    else:
+        action = "converge"
+
+    return {
+        "phase": phase,
+        "action": action,
+        "permits_phase_start": permits_required_completion if phase == "required_completion" else permits_general_work,
+        "permits_general_work": permits_general_work,
+        "permits_required_completion": permits_required_completion,
+        "required_completion_reserve_seconds": review_reserve,
+        "general_work_deadline": general_work_deadline,
+        "soft_deadline": soft_deadline,
+        "hard_deadline": hard_deadline,
+        "remaining_general_work_seconds": max(0.0, general_work_deadline - current_now),
+        "remaining_hard_seconds": max(0.0, hard_deadline - current_now),
+        "checkpoint_convergence_required": (
+            phase == "implementation" and hard_open and current_now >= general_work_deadline
+        ),
+        "required_completion_handoff": (
+            review_reserve > 0 and hard_open and current_now >= general_work_deadline
+        ),
+    }
+
+
+def status(
+    state_file: str,
+    task_id: str,
+    plan: dict[str, Any],
+    phase: str,
+    now: Any,
+) -> dict[str, Any]:
+    ledger = ledger_status(state_file, task_id, now)
+    result = dict(ledger)
+    result.update(phase_decision(plan, ledger, phase, now))
+    return result
+
+
+def reserve_implementation(
+    state_file: str,
+    task_id: str,
+    plan: dict[str, Any],
+    kind: str,
+    reservation_id: str,
+    fingerprint: str,
+    now: Any,
+) -> dict[str, Any]:
+    if kind not in IMPLEMENTATION_RESERVATION_KINDS:
+        raise LedgerError(f"invalid implementation reservation kind: {kind}")
+    decision = status(state_file, task_id, plan, "implementation", now)
+    if not decision["permits_phase_start"]:
+        if decision["action"] == "stop":
+            raise LedgerError("task hard deadline reached; implementation reservation is not permitted")
+        raise LedgerError(
+            "required-completion reserve reached; new implementation/replan/replacement work is not permitted"
+        )
+    result = reserve(
+        state_file,
+        task_id,
+        kind,
+        reservation_id,
+        fingerprint,
+        now,
+    )
+    result.update(phase_decision(plan, result, "implementation", now))
+    return result
+
+
+def _json(raw: str, label: str) -> Any:
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise LedgerError(f"invalid {label} JSON: {exc.msg}") from None
+
+
+def _common(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--state-file", required=True)
+    parser.add_argument("--task-id", required=True)
+    parser.add_argument("--plan-json", required=True)
+    parser.add_argument("--now", required=True)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="task_phase_runtime.py",
+        description="phase-aware admission for FlowPilot task budgets",
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    status_cmd = commands.add_parser("status")
+    _common(status_cmd)
+    status_cmd.add_argument("--phase", choices=PHASES, required=True)
+
+    reserve_cmd = commands.add_parser("reserve")
+    _common(reserve_cmd)
+    reserve_cmd.add_argument("--kind", choices=IMPLEMENTATION_RESERVATION_KINDS, required=True)
+    reserve_cmd.add_argument("--reservation-id", required=True)
+    reserve_cmd.add_argument("--fingerprint", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _parser()
+    ns = parser.parse_args(argv)
+    try:
+        plan = _plan(_json(ns.plan_json, "plan"))
+        if ns.command == "status":
+            result = status(ns.state_file, ns.task_id, plan, ns.phase, ns.now)
+        else:
+            result = reserve_implementation(
+                ns.state_file,
+                ns.task_id,
+                plan,
+                ns.kind,
+                ns.reservation_id,
+                ns.fingerprint,
+                ns.now,
+            )
+    except LedgerError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/strategies/task_phase_runtime.py
+++ b/scripts/strategies/task_phase_runtime.py
@@ -272,14 +272,20 @@ def reserve_phase(
     if phase == "implementation" and kind not in GENERAL_RESERVATION_KINDS:
         raise LedgerError("implementation phase only accepts general-work reservations")
 
-    decision = status(state_file, task_id, plan, phase, now)
     if kind == "review_attempt":
+        # Review admission has a stricter boundary than the raw ledger hard
+        # deadline because the final tail belongs exclusively to Parent
+        # finalization. No new reviewer may start at/after review_deadline.
+        decision = status(state_file, task_id, plan, phase, now)
         if not decision["permits_review_start"]:
             raise LedgerError("review admission deadline reached; Parent finalization reserve is protected")
-    elif not decision["permits_phase_start"]:
-        raise LedgerError(f"task phase {phase} does not permit a new {kind} reservation")
+        result = reserve(state_file, task_id, kind, reservation_id, fingerprint, now)
+    else:
+        # The durable ledger checks idempotency before its soft/hard deadline
+        # gates. Let it remain authoritative so an exact replay is still safe
+        # after convergence starts, while genuinely new general work is rejected.
+        result = reserve(state_file, task_id, kind, reservation_id, fingerprint, now)
 
-    result = reserve(state_file, task_id, kind, reservation_id, fingerprint, now)
     result.update(phase_decision(plan, result, phase, now))
     return result
 

--- a/scripts/strategies/task_phase_runtime.py
+++ b/scripts/strategies/task_phase_runtime.py
@@ -42,7 +42,6 @@ except ImportError:
         reserve,
     )
 
-
 PHASES = ("exploration", "implementation", "required_completion")
 RESERVATION_PHASE = {
     "work_unit": "implementation",
@@ -88,12 +87,7 @@ def _task_policy(plan: dict[str, Any]) -> TaskBudgetPolicy:
 
 
 def _policy_fingerprint(policy: TaskBudgetPolicy) -> str:
-    encoded = json.dumps(
-        asdict(policy),
-        ensure_ascii=False,
-        sort_keys=True,
-        separators=(",", ":"),
-    ).encode("utf-8")
+    encoded = json.dumps(asdict(policy), ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
 
 
@@ -110,10 +104,7 @@ def _completion_reserve(plan: dict[str, Any], policy: TaskBudgetPolicy) -> tuple
         raise LedgerError("review_stage is required when reviewer_workers is positive")
     if policy.max_review_attempts < reviewer_workers:
         raise LedgerError("review topology exceeds task budget max_review_attempts")
-    review_hard = _strict_int(
-        review_stage.get("hard_timeout_seconds"),
-        "review_stage.hard_timeout_seconds",
-    )
+    review_hard = _strict_int(review_stage.get("hard_timeout_seconds"), "review_stage.hard_timeout_seconds")
     if review_hard < 1:
         raise LedgerError("review_stage.hard_timeout_seconds must be positive")
     parent_finalization = policy.parent_finalization_seconds
@@ -143,10 +134,10 @@ def _plan(value: Any) -> dict[str, Any]:
         if implementation_workers > policy.max_implementation_attempts:
             raise LedgerError("implementation topology exceeds task budget max_implementation_attempts")
         implementation_soft = implementation_stage.get("soft_timeout_seconds")
-        if implementation_soft is not None:
-            implementation_soft = _strict_int(implementation_soft, "implementation_stage.soft_timeout_seconds")
-            if policy.soft_timeout_seconds < implementation_soft:
-                raise LedgerError("task soft timeout cannot precede implementation soft checkpoint budget")
+        if type(implementation_soft) is not int or implementation_soft < 1:
+            raise LedgerError("implementation_stage.soft_timeout_seconds must be a positive integer")
+        if policy.soft_timeout_seconds < implementation_soft:
+            raise LedgerError("task soft timeout cannot precede implementation soft checkpoint budget")
     elif implementation_stage is not None:
         raise LedgerError("implementation_stage must be null when implementation_workers is zero")
 
@@ -170,7 +161,6 @@ def phase_decision(plan_value: Any, ledger_value: Any, phase: str, now: Any) -> 
     if type(ledger_value) is not dict:
         raise LedgerError("ledger status must be an object")
     policy = _validate_ledger_identity(plan, ledger_value)
-
     current_now = _strict_number(now, "now")
     started_at = _strict_number(ledger_value.get("started_at"), "started_at")
     soft_deadline = _strict_number(ledger_value.get("soft_deadline"), "soft_deadline")
@@ -188,11 +178,7 @@ def phase_decision(plan_value: Any, ledger_value: Any, phase: str, now: Any) -> 
     permits_general_work = hard_open and current_now < soft_deadline
     permits_required_completion = hard_open and reserve_seconds > 0
     review_deadline = hard_deadline - parent_finalization if reserve_seconds > 0 else None
-    permits_review_start = (
-        permits_required_completion
-        and review_deadline is not None
-        and current_now < review_deadline
-    )
+    permits_review_start = permits_required_completion and review_deadline is not None and current_now < review_deadline
     permits_parent_finalization = hard_open
 
     if not hard_open:
@@ -273,25 +259,14 @@ def reserve_phase(
         raise LedgerError("implementation phase only accepts general-work reservations")
 
     if kind == "review_attempt":
-        # Review admission has a stricter boundary than the raw ledger hard
-        # deadline because the final tail belongs exclusively to Parent
-        # finalization. No new reviewer may start at/after review_deadline.
         decision = status(state_file, task_id, plan, phase, now)
         if not decision["permits_review_start"]:
             raise LedgerError("review admission deadline reached; Parent finalization reserve is protected")
         result = reserve(state_file, task_id, kind, reservation_id, fingerprint, now)
     else:
-        # The durable ledger checks idempotency before its soft/hard deadline
-        # gates. Let it remain authoritative so an exact replay is still safe
-        # after convergence starts, while genuinely new general work is rejected.
         result = reserve(state_file, task_id, kind, reservation_id, fingerprint, now)
-
     result.update(phase_decision(plan, result, phase, now))
     return result
-
-
-def reserve_implementation(state_file: str, task_id: str, plan: dict[str, Any], kind: str, reservation_id: str, fingerprint: str, now: Any) -> dict[str, Any]:
-    return reserve_phase(state_file, task_id, plan, "implementation", kind, reservation_id, fingerprint, now)
 
 
 def _json(raw: str, label: str) -> Any:
@@ -311,14 +286,11 @@ def _common(parser: argparse.ArgumentParser) -> None:
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="task_phase_runtime.py", description="phase-aware admission for FlowPilot task budgets")
     commands = parser.add_subparsers(dest="command", required=True)
-
     init_cmd = commands.add_parser("init")
     _common(init_cmd)
-
     status_cmd = commands.add_parser("status")
     _common(status_cmd)
     status_cmd.add_argument("--phase", choices=PHASES, required=True)
-
     reserve_cmd = commands.add_parser("reserve")
     _common(reserve_cmd)
     reserve_cmd.add_argument("--phase", choices=PHASES, required=True)

--- a/scripts/strategies/task_phase_runtime.py
+++ b/scripts/strategies/task_phase_runtime.py
@@ -1,15 +1,11 @@
 #!/usr/bin/env python3
-"""Phase-aware admission on top of the durable task-budget ledger.
+"""Phase-aware admission for the canonical ExecutionPlan task budget.
 
-The strategy ExecutionPlan owns the general-work soft boundary.  When the same
-immutable plan requires independent review, this helper deterministically
-extends only the effective task hard boundary so required read-only review and
-Parent finalization have a real completion tail.  It never shortens the
-strategy's general-work window.
-
-There is intentionally no legacy-ledger migration path: this runtime has not
-shipped with persisted task ledgers, so incompatible/mismatched state fails
-closed instead of preserving obsolete semantics.
+The compiler emits one self-consistent task budget. Its soft deadline is the
+end of general writable work. If independent review is planned, its hard
+deadline already includes the review-stage hard window plus an explicit Parent
+finalization reserve. This helper only validates that contract and performs
+phase-aware reservations; it never derives a second budget.
 """
 from __future__ import annotations
 
@@ -21,22 +17,34 @@ import sys
 from dataclasses import asdict
 from typing import Any
 
-try:  # Package import.
+try:
     from .base import TaskBudgetPolicy
-    from .task_budget_runtime import LedgerError, init_ledger, ledger_status, reserve
-except ImportError:  # Direct invocation from installed strategies directory.
+    from .task_budget_runtime import (
+        GENERAL_RESERVATION_KINDS,
+        LedgerError,
+        init_ledger,
+        ledger_status,
+        reserve,
+    )
+except ImportError:
     from base import TaskBudgetPolicy
-    from task_budget_runtime import LedgerError, init_ledger, ledger_status, reserve
+    from task_budget_runtime import (
+        GENERAL_RESERVATION_KINDS,
+        LedgerError,
+        init_ledger,
+        ledger_status,
+        reserve,
+    )
 
 
 PHASES = ("exploration", "implementation", "required_completion")
-IMPLEMENTATION_RESERVATION_KINDS = (
-    "work_unit",
-    "implementation_attempt",
-    "replan",
-    "replacement",
-)
-PARENT_FINALIZATION_MIN_SECONDS = 120
+RESERVATION_PHASE = {
+    "work_unit": "implementation",
+    "implementation_attempt": "implementation",
+    "replan": "implementation",
+    "replacement": "implementation",
+    "review_attempt": "required_completion",
+}
 
 
 def _strict_number(value: Any, label: str) -> float:
@@ -73,95 +81,6 @@ def _task_policy(plan: dict[str, Any]) -> TaskBudgetPolicy:
         raise LedgerError(str(exc)) from None
 
 
-def _review_reserve(plan: dict[str, Any]) -> tuple[int, int, int]:
-    reviewer_workers = _strict_int(plan.get("reviewer_workers"), "reviewer_workers")
-    review_stage = plan.get("review_stage")
-    if reviewer_workers <= 0:
-        if review_stage is not None:
-            raise LedgerError("review_stage must be null when reviewer_workers is zero")
-        return 0, 0, 0
-    if type(review_stage) is not dict:
-        raise LedgerError("review_stage is required when reviewer_workers is positive")
-    review_hard = _strict_int(
-        review_stage.get("hard_timeout_seconds"),
-        "review_stage.hard_timeout_seconds",
-    )
-    review_idle = _strict_int(
-        review_stage.get("idle_timeout_seconds"),
-        "review_stage.idle_timeout_seconds",
-    )
-    if review_hard <= 0:
-        raise LedgerError("required review hard timeout must be positive")
-    if review_idle <= 0 or review_idle > review_hard:
-        raise LedgerError("required review idle timeout must be positive and <= review hard timeout")
-    parent_finalization = max(PARENT_FINALIZATION_MIN_SECONDS, review_idle)
-    return review_hard, parent_finalization, review_hard + parent_finalization
-
-
-def _plan(value: Any) -> dict[str, Any]:
-    if type(value) is not dict:
-        raise LedgerError("ExecutionPlan must be an object")
-    if type(value.get("task_budget")) is not dict:
-        raise LedgerError("ExecutionPlan task_budget must be an object")
-    policy = _task_policy(value)
-    implementation_workers = _strict_int(
-        value.get("implementation_workers"),
-        "implementation_workers",
-    )
-    _strict_int(value.get("reviewer_workers"), "reviewer_workers")
-    implementation_stage = value.get("implementation_stage")
-    if implementation_workers > 0:
-        if type(implementation_stage) is not dict:
-            raise LedgerError("implementation_stage is required when implementation_workers is positive")
-        maximum_work_units = implementation_stage.get("maximum_work_units")
-        if type(maximum_work_units) is not int or maximum_work_units < 1:
-            raise LedgerError("implementation_stage.maximum_work_units must be a positive integer")
-        if maximum_work_units != policy.max_work_units:
-            raise LedgerError("task budget max_work_units must match implementation_stage maximum_work_units")
-        if implementation_workers > maximum_work_units:
-            raise LedgerError("implementation topology exceeds task budget max_work_units")
-        if implementation_workers > policy.max_implementation_attempts:
-            raise LedgerError("implementation topology exceeds task budget max_implementation_attempts")
-        implementation_soft = implementation_stage.get("soft_timeout_seconds")
-        if implementation_soft is not None:
-            implementation_soft = _strict_int(
-                implementation_soft,
-                "implementation_stage.soft_timeout_seconds",
-            )
-            if policy.soft_timeout_seconds < implementation_soft:
-                raise LedgerError(
-                    "task soft timeout cannot be earlier than implementation soft checkpoint budget"
-                )
-    elif implementation_stage is not None:
-        raise LedgerError("implementation_stage must be null when implementation_workers is zero")
-    _review_reserve(value)
-    return value
-
-
-def _effective_policy(plan: dict[str, Any]) -> TaskBudgetPolicy:
-    policy = _task_policy(plan)
-    _review_hard, _parent_finalization, completion_reserve = _review_reserve(plan)
-    if completion_reserve <= 0:
-        return policy
-    # Preserve the strategy's general-work soft target. Required completion is
-    # additive: an explicit/strategy-required review may make the task longer,
-    # but must never steal the implementation window it is meant to verify.
-    effective_hard = max(
-        policy.hard_timeout_seconds,
-        policy.soft_timeout_seconds + completion_reserve,
-    )
-    effective = TaskBudgetPolicy(
-        soft_timeout_seconds=policy.soft_timeout_seconds,
-        hard_timeout_seconds=effective_hard,
-        max_work_units=policy.max_work_units,
-        max_implementation_attempts=policy.max_implementation_attempts,
-        max_replans=policy.max_replans,
-        max_replacements=policy.max_replacements,
-    )
-    effective.validate()
-    return effective
-
-
 def _policy_fingerprint(policy: TaskBudgetPolicy) -> str:
     encoded = json.dumps(
         asdict(policy),
@@ -172,58 +91,109 @@ def _policy_fingerprint(policy: TaskBudgetPolicy) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
-def _validate_ledger_identity(plan: dict[str, Any], ledger_value: dict[str, Any]) -> TaskBudgetPolicy:
-    effective = _effective_policy(plan)
-    if ledger_value.get("policy_fingerprint") != _policy_fingerprint(effective):
+def _completion_reserve(plan: dict[str, Any], policy: TaskBudgetPolicy) -> tuple[int, int, int]:
+    reviewer_workers = _strict_int(plan.get("reviewer_workers"), "reviewer_workers")
+    review_stage = plan.get("review_stage")
+    if reviewer_workers == 0:
+        if review_stage is not None:
+            raise LedgerError("review_stage must be null when reviewer_workers is zero")
+        if policy.max_review_attempts != 0:
+            # Parent-only plans must not silently reserve reviewer capacity.
+            raise LedgerError("max_review_attempts must be zero when reviewer_workers is zero")
+        return 0, 0, 0
+    if type(review_stage) is not dict:
+        raise LedgerError("review_stage is required when reviewer_workers is positive")
+    if policy.max_review_attempts < reviewer_workers:
+        raise LedgerError("review topology exceeds task budget max_review_attempts")
+    review_hard = _strict_int(
+        review_stage.get("hard_timeout_seconds"),
+        "review_stage.hard_timeout_seconds",
+    )
+    if review_hard < 1:
+        raise LedgerError("review_stage.hard_timeout_seconds must be positive")
+    parent_finalization = policy.parent_finalization_seconds
+    return review_hard, parent_finalization, review_hard + parent_finalization
+
+
+def _plan(value: Any) -> dict[str, Any]:
+    if type(value) is not dict:
+        raise LedgerError("ExecutionPlan must be an object")
+    if value.get("schema_version") != 11:
+        raise LedgerError("task phase runtime requires ExecutionPlan schema v11")
+    if type(value.get("task_budget")) is not dict:
+        raise LedgerError("ExecutionPlan task_budget must be an object")
+    policy = _task_policy(value)
+    implementation_workers = _strict_int(value.get("implementation_workers"), "implementation_workers")
+    implementation_stage = value.get("implementation_stage")
+    if implementation_workers > 0:
+        if type(implementation_stage) is not dict:
+            raise LedgerError("implementation_stage is required when implementation_workers is positive")
+        maximum_work_units = implementation_stage.get("maximum_work_units")
+        if type(maximum_work_units) is not int or maximum_work_units < 1:
+            raise LedgerError("implementation_stage.maximum_work_units must be a positive integer")
+        if maximum_work_units != policy.max_work_units:
+            raise LedgerError("task budget max_work_units must match implementation_stage maximum_work_units")
+        if implementation_workers > policy.max_work_units:
+            raise LedgerError("implementation topology exceeds task budget max_work_units")
+        if implementation_workers > policy.max_implementation_attempts:
+            raise LedgerError("implementation topology exceeds task budget max_implementation_attempts")
+        implementation_soft = implementation_stage.get("soft_timeout_seconds")
+        if implementation_soft is not None:
+            implementation_soft = _strict_int(implementation_soft, "implementation_stage.soft_timeout_seconds")
+            if policy.soft_timeout_seconds < implementation_soft:
+                raise LedgerError("task soft timeout cannot precede implementation soft checkpoint budget")
+    elif implementation_stage is not None:
+        raise LedgerError("implementation_stage must be null when implementation_workers is zero")
+
+    _review_hard, _parent_finalization, reserve_seconds = _completion_reserve(value, policy)
+    if reserve_seconds > 0 and policy.hard_timeout_seconds - policy.soft_timeout_seconds < reserve_seconds:
+        raise LedgerError("task budget does not reserve the full required-completion tail")
+    return value
+
+
+def _validate_ledger_identity(plan: dict[str, Any], ledger: dict[str, Any]) -> TaskBudgetPolicy:
+    policy = _task_policy(plan)
+    if ledger.get("policy_fingerprint") != _policy_fingerprint(policy):
         raise LedgerError("task phase plan/policy mismatch; refusing to use a different budget plan")
-    return effective
+    return policy
 
 
-def phase_decision(
-    plan_value: Any,
-    ledger_value: Any,
-    phase: str,
-    now: Any,
-) -> dict[str, Any]:
+def phase_decision(plan_value: Any, ledger_value: Any, phase: str, now: Any) -> dict[str, Any]:
     if phase not in PHASES:
         raise LedgerError(f"invalid task phase: {phase}")
     plan = _plan(plan_value)
     if type(ledger_value) is not dict:
         raise LedgerError("ledger status must be an object")
-    effective = _validate_ledger_identity(plan, ledger_value)
+    policy = _validate_ledger_identity(plan, ledger_value)
 
     current_now = _strict_number(now, "now")
     started_at = _strict_number(ledger_value.get("started_at"), "started_at")
     soft_deadline = _strict_number(ledger_value.get("soft_deadline"), "soft_deadline")
     hard_deadline = _strict_number(ledger_value.get("hard_deadline"), "hard_deadline")
-    if soft_deadline != started_at + effective.soft_timeout_seconds:
-        raise LedgerError("task phase soft deadline does not match effective task budget")
-    if hard_deadline != started_at + effective.hard_timeout_seconds:
-        raise LedgerError("task phase hard deadline does not match effective task budget")
+    if soft_deadline != started_at + policy.soft_timeout_seconds:
+        raise LedgerError("task phase soft deadline does not match ExecutionPlan task budget")
+    if hard_deadline != started_at + policy.hard_timeout_seconds:
+        raise LedgerError("task phase hard deadline does not match ExecutionPlan task budget")
     closed = ledger_value.get("closed")
     if type(closed) is not bool:
         raise LedgerError("ledger closed must be boolean")
 
-    review_hard, parent_finalization, completion_reserve = _review_reserve(plan)
-    if completion_reserve > 0 and hard_deadline - soft_deadline < completion_reserve:
-        raise LedgerError("effective task budget does not reserve required completion tail")
-
+    review_hard, parent_finalization, reserve_seconds = _completion_reserve(plan, policy)
     hard_open = (not closed) and current_now < hard_deadline
     permits_general_work = hard_open and current_now < soft_deadline
-    permits_required_completion = hard_open
+    permits_required_completion = hard_open and reserve_seconds > 0
 
     if not hard_open:
         action = "stop"
     elif phase == "required_completion":
-        action = "complete_required"
+        action = "complete_required" if permits_required_completion else "stop"
     elif permits_general_work:
         action = "continue"
-    elif completion_reserve > 0:
+    elif reserve_seconds > 0:
         action = "converge_for_required_completion"
     else:
         action = "converge"
 
-    base_policy = _task_policy(plan)
     return {
         "phase": phase,
         "action": action,
@@ -232,44 +202,27 @@ def phase_decision(
         "permits_required_completion": permits_required_completion,
         "reviewer_reserve_seconds": review_hard,
         "parent_finalization_reserve_seconds": parent_finalization,
-        "required_completion_reserve_seconds": completion_reserve,
+        "required_completion_reserve_seconds": reserve_seconds,
         "general_work_deadline": soft_deadline,
         "soft_deadline": soft_deadline,
         "hard_deadline": hard_deadline,
         "remaining_general_work_seconds": max(0.0, soft_deadline - current_now),
         "remaining_hard_seconds": max(0.0, hard_deadline - current_now),
-        "checkpoint_convergence_required": (
-            phase == "implementation" and hard_open and current_now >= soft_deadline
-        ),
-        "required_completion_handoff": (
-            completion_reserve > 0 and hard_open and current_now >= soft_deadline
-        ),
-        "hard_deadline_extended": effective.hard_timeout_seconds > base_policy.hard_timeout_seconds,
-        "base_task_budget": asdict(base_policy),
-        "effective_task_budget": asdict(effective),
+        "checkpoint_convergence_required": phase == "implementation" and hard_open and current_now >= soft_deadline,
+        "required_completion_handoff": reserve_seconds > 0 and hard_open and current_now >= soft_deadline,
+        "task_budget": asdict(policy),
     }
 
 
-def init(
-    state_file: str,
-    task_id: str,
-    plan: dict[str, Any],
-    now: Any,
-) -> dict[str, Any]:
+def init(state_file: str, task_id: str, plan: dict[str, Any], now: Any) -> dict[str, Any]:
     plan = _plan(plan)
-    effective = _effective_policy(plan)
-    result = init_ledger(state_file, task_id, effective, now)
+    policy = _task_policy(plan)
+    result = init_ledger(state_file, task_id, policy, now)
     result.update(phase_decision(plan, result, "exploration", now))
     return result
 
 
-def status(
-    state_file: str,
-    task_id: str,
-    plan: dict[str, Any],
-    phase: str,
-    now: Any,
-) -> dict[str, Any]:
+def status(state_file: str, task_id: str, plan: dict[str, Any], phase: str, now: Any) -> dict[str, Any]:
     plan = _plan(plan)
     ledger = ledger_status(state_file, task_id, now)
     result = dict(ledger)
@@ -277,31 +230,37 @@ def status(
     return result
 
 
-def reserve_implementation(
+def reserve_phase(
     state_file: str,
     task_id: str,
     plan: dict[str, Any],
+    phase: str,
     kind: str,
     reservation_id: str,
     fingerprint: str,
     now: Any,
 ) -> dict[str, Any]:
     plan = _plan(plan)
-    if kind not in IMPLEMENTATION_RESERVATION_KINDS:
-        raise LedgerError(f"invalid implementation reservation kind: {kind}")
-    # The raw ledger's soft deadline is exactly the general-work cutoff, so its
-    # atomic reserve path remains authoritative for implementation admission and
-    # idempotent replay.
-    result = reserve(
-        state_file,
-        task_id,
-        kind,
-        reservation_id,
-        fingerprint,
-        now,
-    )
-    result.update(phase_decision(plan, result, "implementation", now))
+    if phase not in PHASES:
+        raise LedgerError(f"invalid task phase: {phase}")
+    expected_phase = RESERVATION_PHASE.get(kind)
+    if expected_phase is None:
+        raise LedgerError(f"unsupported task phase reservation kind: {kind}")
+    if phase != expected_phase:
+        raise LedgerError(f"{kind} reservations require phase={expected_phase}")
+    if phase == "implementation" and kind not in GENERAL_RESERVATION_KINDS:
+        raise LedgerError("implementation phase only accepts general-work reservations")
+    decision = status(state_file, task_id, plan, phase, now)
+    if not decision["permits_phase_start"]:
+        raise LedgerError(f"task phase {phase} does not permit a new {kind} reservation")
+    result = reserve(state_file, task_id, kind, reservation_id, fingerprint, now)
+    result.update(phase_decision(plan, result, phase, now))
     return result
+
+
+# Backward-compatible Python name inside this branch; CLI and schema are v11 only.
+def reserve_implementation(state_file: str, task_id: str, plan: dict[str, Any], kind: str, reservation_id: str, fingerprint: str, now: Any) -> dict[str, Any]:
+    return reserve_phase(state_file, task_id, plan, "implementation", kind, reservation_id, fingerprint, now)
 
 
 def _json(raw: str, label: str) -> Any:
@@ -319,10 +278,7 @@ def _common(parser: argparse.ArgumentParser) -> None:
 
 
 def _parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="task_phase_runtime.py",
-        description="phase-aware admission for FlowPilot task budgets",
-    )
+    parser = argparse.ArgumentParser(prog="task_phase_runtime.py", description="phase-aware admission for FlowPilot task budgets")
     commands = parser.add_subparsers(dest="command", required=True)
 
     init_cmd = commands.add_parser("init")
@@ -334,7 +290,8 @@ def _parser() -> argparse.ArgumentParser:
 
     reserve_cmd = commands.add_parser("reserve")
     _common(reserve_cmd)
-    reserve_cmd.add_argument("--kind", choices=IMPLEMENTATION_RESERVATION_KINDS, required=True)
+    reserve_cmd.add_argument("--phase", choices=PHASES, required=True)
+    reserve_cmd.add_argument("--kind", choices=tuple(RESERVATION_PHASE), required=True)
     reserve_cmd.add_argument("--reservation-id", required=True)
     reserve_cmd.add_argument("--fingerprint", required=True)
     return parser
@@ -351,10 +308,11 @@ def main(argv: list[str] | None = None) -> int:
         elif ns.command == "status":
             result = status(ns.state_file, ns.task_id, plan, ns.phase, current_now)
         else:
-            result = reserve_implementation(
+            result = reserve_phase(
                 ns.state_file,
                 ns.task_id,
                 plan,
+                ns.phase,
                 ns.kind,
                 ns.reservation_id,
                 ns.fingerprint,

--- a/scripts/strategies/task_phase_runtime.py
+++ b/scripts/strategies/task_phase_runtime.py
@@ -260,9 +260,18 @@ def reserve_phase(
 
     if kind == "review_attempt":
         decision = status(state_file, task_id, plan, phase, now)
-        if not decision["permits_review_start"]:
-            raise LedgerError("review admission deadline reached; Parent finalization reserve is protected")
-        result = reserve(state_file, task_id, kind, reservation_id, fingerprint, now)
+        review_deadline = decision["review_deadline"]
+        if review_deadline is None:
+            raise LedgerError("review_attempt requires a planned review deadline")
+        result = reserve(
+            state_file,
+            task_id,
+            kind,
+            reservation_id,
+            fingerprint,
+            now,
+            new_reservation_deadline=review_deadline,
+        )
     else:
         result = reserve(state_file, task_id, kind, reservation_id, fingerprint, now)
     result.update(phase_decision(plan, result, phase, now))

--- a/scripts/strategies/task_phase_runtime.py
+++ b/scripts/strategies/task_phase_runtime.py
@@ -4,27 +4,34 @@
 The task ledger owns cumulative counters and the absolute task hard deadline.
 This helper adds one missing scheduling invariant: an immutable ExecutionPlan
 that already requires independent review must keep enough tail time for that
-required completion stage. Exploration/implementation admissions stop at the
-earlier of the task soft deadline and ``hard_deadline - review_stage.hard``;
-required completion may still start until the absolute task hard deadline.
+required completion stage.
 
-The helper does not schedule Workers. It returns deterministic admission
-signals and wraps implementation reservations so callers cannot bypass the
-reserved review tail by talking directly to the ledger for new implementation
-work.
+For a new task the helper derives an effective ledger policy from the immutable
+plan. Its soft timeout is clamped to the earlier of the strategy soft timeout
+and ``hard_timeout - review_stage.hard_timeout``. The raw ledger therefore
+keeps its own atomic reservation/idempotency semantics while still enforcing
+that required-completion reserve. Required completion may start after that soft
+boundary and remains permitted until the absolute task hard deadline.
+
+The helper does not schedule Workers. It initializes the ledger, reports
+phase-aware admission, and wraps implementation reservations.
 """
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import math
 import sys
+from dataclasses import asdict
 from typing import Any
 
 try:  # Package import.
-    from .task_budget_runtime import LedgerError, ledger_status, reserve
+    from .base import TaskBudgetPolicy
+    from .task_budget_runtime import LedgerError, init_ledger, ledger_status, reserve
 except ImportError:  # Direct invocation from installed strategies directory.
-    from task_budget_runtime import LedgerError, ledger_status, reserve
+    from base import TaskBudgetPolicy
+    from task_budget_runtime import LedgerError, init_ledger, ledger_status, reserve
 
 
 PHASES = ("exploration", "implementation", "required_completion")
@@ -65,15 +72,49 @@ def _plan(value: Any) -> dict[str, Any]:
     return value
 
 
-def _review_reserve_seconds(plan: dict[str, Any]) -> float:
+def _review_reserve_seconds(plan: dict[str, Any]) -> int:
     reviewer_workers = _strict_int(plan.get("reviewer_workers"), "reviewer_workers")
     review_stage = plan.get("review_stage")
     if reviewer_workers <= 0 or review_stage is None:
-        return 0.0
-    hard = _strict_number(review_stage.get("hard_timeout_seconds"), "review_stage.hard_timeout_seconds")
+        return 0
+    hard = _strict_int(review_stage.get("hard_timeout_seconds"), "review_stage.hard_timeout_seconds")
     if hard <= 0:
         raise LedgerError("required review hard timeout must be positive")
     return hard
+
+
+def _effective_policy(plan: dict[str, Any]) -> TaskBudgetPolicy:
+    try:
+        policy = TaskBudgetPolicy.from_dict(plan["task_budget"])
+    except (TypeError, ValueError) as exc:
+        raise LedgerError(str(exc)) from None
+    review_reserve = _review_reserve_seconds(plan)
+    if review_reserve <= 0:
+        return policy
+    latest_general_work = policy.hard_timeout_seconds - review_reserve
+    if latest_general_work < 1:
+        raise LedgerError("task hard budget is too small to reserve the required review stage")
+    effective_soft = min(policy.soft_timeout_seconds, latest_general_work)
+    effective = TaskBudgetPolicy(
+        soft_timeout_seconds=effective_soft,
+        hard_timeout_seconds=policy.hard_timeout_seconds,
+        max_work_units=policy.max_work_units,
+        max_implementation_attempts=policy.max_implementation_attempts,
+        max_replans=policy.max_replans,
+        max_replacements=policy.max_replacements,
+    )
+    effective.validate()
+    return effective
+
+
+def _policy_fingerprint(policy: TaskBudgetPolicy) -> str:
+    encoded = json.dumps(
+        asdict(policy),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
 
 
 def phase_decision(
@@ -86,23 +127,29 @@ def phase_decision(
     if phase not in PHASES:
         raise LedgerError(f"invalid task phase: {phase}")
     plan = _plan(plan_value)
+    effective_policy = _effective_policy(plan)
     if type(ledger_value) is not dict:
         raise LedgerError("ledger status must be an object")
+    expected_fingerprint = _policy_fingerprint(effective_policy)
+    if ledger_value.get("policy_fingerprint") != expected_fingerprint:
+        raise LedgerError("task phase plan/policy mismatch; refusing to use a different ExecutionPlan")
+
     current_now = _strict_number(now, "now")
+    started_at = _strict_number(ledger_value.get("started_at"), "started_at")
     soft_deadline = _strict_number(ledger_value.get("soft_deadline"), "soft_deadline")
     hard_deadline = _strict_number(ledger_value.get("hard_deadline"), "hard_deadline")
     if hard_deadline <= soft_deadline:
         raise LedgerError("hard_deadline must be after soft_deadline")
+    if soft_deadline != started_at + effective_policy.soft_timeout_seconds:
+        raise LedgerError("task phase soft deadline does not match the immutable ExecutionPlan")
+    if hard_deadline != started_at + effective_policy.hard_timeout_seconds:
+        raise LedgerError("task phase hard deadline does not match the immutable ExecutionPlan")
     closed = ledger_value.get("closed")
     if type(closed) is not bool:
         raise LedgerError("ledger closed must be boolean")
 
     review_reserve = _review_reserve_seconds(plan)
-    completion_cutoff = hard_deadline - review_reserve
-    if review_reserve > 0 and completion_cutoff <= _strict_number(ledger_value.get("started_at"), "started_at"):
-        raise LedgerError("task hard budget is too small to reserve the required review stage")
-    general_work_deadline = min(soft_deadline, completion_cutoff) if review_reserve > 0 else soft_deadline
-
+    general_work_deadline = soft_deadline
     hard_open = (not closed) and current_now < hard_deadline
     permits_required_completion = hard_open
     permits_general_work = hard_open and current_now < general_work_deadline
@@ -139,6 +186,20 @@ def phase_decision(
     }
 
 
+def init(
+    state_file: str,
+    task_id: str,
+    plan: dict[str, Any],
+    now: Any,
+) -> dict[str, Any]:
+    """Initialize a new phase-aware ledger from the immutable plan."""
+    effective_policy = _effective_policy(_plan(plan))
+    result = init_ledger(state_file, task_id, effective_policy, now)
+    result.update(phase_decision(plan, result, "exploration", now))
+    result["effective_task_budget"] = asdict(effective_policy)
+    return result
+
+
 def status(
     state_file: str,
     task_id: str,
@@ -163,13 +224,9 @@ def reserve_implementation(
 ) -> dict[str, Any]:
     if kind not in IMPLEMENTATION_RESERVATION_KINDS:
         raise LedgerError(f"invalid implementation reservation kind: {kind}")
-    decision = status(state_file, task_id, plan, "implementation", now)
-    if not decision["permits_phase_start"]:
-        if decision["action"] == "stop":
-            raise LedgerError("task hard deadline reached; implementation reservation is not permitted")
-        raise LedgerError(
-            "required-completion reserve reached; new implementation/replan/replacement work is not permitted"
-        )
+    # The phase-aware init has already clamped the ledger soft deadline. Calling
+    # the raw atomic reserve preserves its deadline checks and, critically, its
+    # idempotent replay semantics after the deadline.
     result = reserve(
         state_file,
         task_id,
@@ -203,6 +260,9 @@ def _parser() -> argparse.ArgumentParser:
     )
     commands = parser.add_subparsers(dest="command", required=True)
 
+    init_cmd = commands.add_parser("init")
+    _common(init_cmd)
+
     status_cmd = commands.add_parser("status")
     _common(status_cmd)
     status_cmd.add_argument("--phase", choices=PHASES, required=True)
@@ -220,7 +280,9 @@ def main(argv: list[str] | None = None) -> int:
     ns = parser.parse_args(argv)
     try:
         plan = _plan(_json(ns.plan_json, "plan"))
-        if ns.command == "status":
+        if ns.command == "init":
+            result = init(ns.state_file, ns.task_id, plan, ns.now)
+        elif ns.command == "status":
             result = status(ns.state_file, ns.task_id, plan, ns.phase, ns.now)
         else:
             result = reserve_implementation(

--- a/scripts/strategies/task_phase_runtime.py
+++ b/scripts/strategies/task_phase_runtime.py
@@ -1,26 +1,15 @@
 #!/usr/bin/env python3
 """Phase-aware admission on top of the durable task-budget ledger.
 
-The task ledger owns cumulative counters and the absolute task hard deadline.
-This helper adds one missing scheduling invariant: an immutable initial
-ExecutionPlan that already requires independent review must keep enough tail
-time for that required completion stage.
+The strategy ExecutionPlan owns the general-work soft boundary.  When the same
+immutable plan requires independent review, this helper deterministically
+extends only the effective task hard boundary so required read-only review and
+Parent finalization have a real completion tail.  It never shortens the
+strategy's general-work window.
 
-For a new task the helper derives an effective ledger policy from the initial
-budget plan. Its soft timeout is clamped to the earlier of the strategy soft
-timeout and ``hard_timeout - review_stage.hard_timeout``. The raw ledger
-therefore keeps its own atomic reservation/idempotency semantics while still
-enforcing that required-completion reserve. Required completion may start
-after that soft boundary and remains permitted until the absolute task hard
-deadline.
-
-A ledger created by the pre-phase runtime is grandfathered when its stored
-fingerprint exactly matches the initial plan's original TaskBudgetPolicy. Such
-a running task keeps its historical unclamped soft deadline; upgrades never
-retroactively shorten its execution window or invent a review-tail reservation.
-
-The helper does not schedule Workers. It initializes the ledger, reports
-phase-aware admission, and wraps implementation reservations.
+There is intentionally no legacy-ledger migration path: this runtime has not
+shipped with persisted task ledgers, so incompatible/mismatched state fails
+closed instead of preserving obsolete semantics.
 """
 from __future__ import annotations
 
@@ -47,6 +36,7 @@ IMPLEMENTATION_RESERVATION_KINDS = (
     "replan",
     "replacement",
 )
+PARENT_FINALIZATION_MIN_SECONDS = 120
 
 
 def _strict_number(value: Any, label: str) -> float:
@@ -76,50 +66,93 @@ def _strict_int(value: Any, label: str) -> int:
     return value
 
 
-def _plan(value: Any) -> dict[str, Any]:
-    if type(value) is not dict:
-        raise LedgerError("ExecutionPlan must be an object")
-    if value.get("task_budget") is None:
-        raise LedgerError("ExecutionPlan has no task_budget")
-    if type(value.get("task_budget")) is not dict:
-        raise LedgerError("ExecutionPlan task_budget must be an object")
-    _strict_int(value.get("reviewer_workers"), "reviewer_workers")
-    review_stage = value.get("review_stage")
-    if review_stage is not None and type(review_stage) is not dict:
-        raise LedgerError("review_stage must be an object or null")
-    return value
-
-
-def _original_policy(plan: dict[str, Any]) -> TaskBudgetPolicy:
+def _task_policy(plan: dict[str, Any]) -> TaskBudgetPolicy:
     try:
         return TaskBudgetPolicy.from_dict(plan["task_budget"])
     except (TypeError, ValueError) as exc:
         raise LedgerError(str(exc)) from None
 
 
-def _review_reserve_seconds(plan: dict[str, Any]) -> int:
+def _review_reserve(plan: dict[str, Any]) -> tuple[int, int, int]:
     reviewer_workers = _strict_int(plan.get("reviewer_workers"), "reviewer_workers")
     review_stage = plan.get("review_stage")
-    if reviewer_workers <= 0 or review_stage is None:
-        return 0
-    hard = _strict_int(review_stage.get("hard_timeout_seconds"), "review_stage.hard_timeout_seconds")
-    if hard <= 0:
+    if reviewer_workers <= 0:
+        if review_stage is not None:
+            raise LedgerError("review_stage must be null when reviewer_workers is zero")
+        return 0, 0, 0
+    if type(review_stage) is not dict:
+        raise LedgerError("review_stage is required when reviewer_workers is positive")
+    review_hard = _strict_int(
+        review_stage.get("hard_timeout_seconds"),
+        "review_stage.hard_timeout_seconds",
+    )
+    review_idle = _strict_int(
+        review_stage.get("idle_timeout_seconds"),
+        "review_stage.idle_timeout_seconds",
+    )
+    if review_hard <= 0:
         raise LedgerError("required review hard timeout must be positive")
-    return hard
+    if review_idle <= 0 or review_idle > review_hard:
+        raise LedgerError("required review idle timeout must be positive and <= review hard timeout")
+    parent_finalization = max(PARENT_FINALIZATION_MIN_SECONDS, review_idle)
+    return review_hard, parent_finalization, review_hard + parent_finalization
+
+
+def _plan(value: Any) -> dict[str, Any]:
+    if type(value) is not dict:
+        raise LedgerError("ExecutionPlan must be an object")
+    if type(value.get("task_budget")) is not dict:
+        raise LedgerError("ExecutionPlan task_budget must be an object")
+    policy = _task_policy(value)
+    implementation_workers = _strict_int(
+        value.get("implementation_workers"),
+        "implementation_workers",
+    )
+    _strict_int(value.get("reviewer_workers"), "reviewer_workers")
+    implementation_stage = value.get("implementation_stage")
+    if implementation_workers > 0:
+        if type(implementation_stage) is not dict:
+            raise LedgerError("implementation_stage is required when implementation_workers is positive")
+        maximum_work_units = implementation_stage.get("maximum_work_units")
+        if type(maximum_work_units) is not int or maximum_work_units < 1:
+            raise LedgerError("implementation_stage.maximum_work_units must be a positive integer")
+        if maximum_work_units != policy.max_work_units:
+            raise LedgerError("task budget max_work_units must match implementation_stage maximum_work_units")
+        if implementation_workers > maximum_work_units:
+            raise LedgerError("implementation topology exceeds task budget max_work_units")
+        if implementation_workers > policy.max_implementation_attempts:
+            raise LedgerError("implementation topology exceeds task budget max_implementation_attempts")
+        implementation_soft = implementation_stage.get("soft_timeout_seconds")
+        if implementation_soft is not None:
+            implementation_soft = _strict_int(
+                implementation_soft,
+                "implementation_stage.soft_timeout_seconds",
+            )
+            if policy.soft_timeout_seconds < implementation_soft:
+                raise LedgerError(
+                    "task soft timeout cannot be earlier than implementation soft checkpoint budget"
+                )
+    elif implementation_stage is not None:
+        raise LedgerError("implementation_stage must be null when implementation_workers is zero")
+    _review_reserve(value)
+    return value
 
 
 def _effective_policy(plan: dict[str, Any]) -> TaskBudgetPolicy:
-    policy = _original_policy(plan)
-    review_reserve = _review_reserve_seconds(plan)
-    if review_reserve <= 0:
+    policy = _task_policy(plan)
+    _review_hard, _parent_finalization, completion_reserve = _review_reserve(plan)
+    if completion_reserve <= 0:
         return policy
-    latest_general_work = policy.hard_timeout_seconds - review_reserve
-    if latest_general_work < 1:
-        raise LedgerError("task hard budget is too small to reserve the required review stage")
-    effective_soft = min(policy.soft_timeout_seconds, latest_general_work)
+    # Preserve the strategy's general-work soft target. Required completion is
+    # additive: an explicit/strategy-required review may make the task longer,
+    # but must never steal the implementation window it is meant to verify.
+    effective_hard = max(
+        policy.hard_timeout_seconds,
+        policy.soft_timeout_seconds + completion_reserve,
+    )
     effective = TaskBudgetPolicy(
-        soft_timeout_seconds=effective_soft,
-        hard_timeout_seconds=policy.hard_timeout_seconds,
+        soft_timeout_seconds=policy.soft_timeout_seconds,
+        hard_timeout_seconds=effective_hard,
         max_work_units=policy.max_work_units,
         max_implementation_attempts=policy.max_implementation_attempts,
         max_replans=policy.max_replans,
@@ -139,18 +172,11 @@ def _policy_fingerprint(policy: TaskBudgetPolicy) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
-def _policy_mode(plan: dict[str, Any], ledger_value: dict[str, Any]) -> tuple[TaskBudgetPolicy, bool]:
-    """Return the actual ledger policy and whether it is a grandfathered v1 ledger."""
-    original = _original_policy(plan)
+def _validate_ledger_identity(plan: dict[str, Any], ledger_value: dict[str, Any]) -> TaskBudgetPolicy:
     effective = _effective_policy(plan)
-    stored = ledger_value.get("policy_fingerprint")
-    effective_fp = _policy_fingerprint(effective)
-    original_fp = _policy_fingerprint(original)
-    if stored == effective_fp:
-        return effective, False
-    if effective_fp != original_fp and stored == original_fp:
-        return original, True
-    raise LedgerError("task phase plan/policy mismatch; refusing to use a different budget plan")
+    if ledger_value.get("policy_fingerprint") != _policy_fingerprint(effective):
+        raise LedgerError("task phase plan/policy mismatch; refusing to use a different budget plan")
+    return effective
 
 
 def phase_decision(
@@ -159,35 +185,32 @@ def phase_decision(
     phase: str,
     now: Any,
 ) -> dict[str, Any]:
-    """Return phase-aware admission from an initial budget plan + ledger status."""
     if phase not in PHASES:
         raise LedgerError(f"invalid task phase: {phase}")
     plan = _plan(plan_value)
     if type(ledger_value) is not dict:
         raise LedgerError("ledger status must be an object")
-    ledger_policy, legacy_unclamped = _policy_mode(plan, ledger_value)
+    effective = _validate_ledger_identity(plan, ledger_value)
 
     current_now = _strict_number(now, "now")
     started_at = _strict_number(ledger_value.get("started_at"), "started_at")
     soft_deadline = _strict_number(ledger_value.get("soft_deadline"), "soft_deadline")
     hard_deadline = _strict_number(ledger_value.get("hard_deadline"), "hard_deadline")
-    if hard_deadline <= soft_deadline:
-        raise LedgerError("hard_deadline must be after soft_deadline")
-    if soft_deadline != started_at + ledger_policy.soft_timeout_seconds:
-        raise LedgerError("task phase soft deadline does not match the initial budget plan")
-    if hard_deadline != started_at + ledger_policy.hard_timeout_seconds:
-        raise LedgerError("task phase hard deadline does not match the initial budget plan")
+    if soft_deadline != started_at + effective.soft_timeout_seconds:
+        raise LedgerError("task phase soft deadline does not match effective task budget")
+    if hard_deadline != started_at + effective.hard_timeout_seconds:
+        raise LedgerError("task phase hard deadline does not match effective task budget")
     closed = ledger_value.get("closed")
     if type(closed) is not bool:
         raise LedgerError("ledger closed must be boolean")
 
-    # Do not retroactively reserve review tail for a task that was already
-    # running before phase-aware admission existed.
-    review_reserve = 0 if legacy_unclamped else _review_reserve_seconds(plan)
-    general_work_deadline = soft_deadline
+    review_hard, parent_finalization, completion_reserve = _review_reserve(plan)
+    if completion_reserve > 0 and hard_deadline - soft_deadline < completion_reserve:
+        raise LedgerError("effective task budget does not reserve required completion tail")
+
     hard_open = (not closed) and current_now < hard_deadline
+    permits_general_work = hard_open and current_now < soft_deadline
     permits_required_completion = hard_open
-    permits_general_work = hard_open and current_now < general_work_deadline
 
     if not hard_open:
         action = "stop"
@@ -195,30 +218,35 @@ def phase_decision(
         action = "complete_required"
     elif permits_general_work:
         action = "continue"
-    elif review_reserve > 0:
+    elif completion_reserve > 0:
         action = "converge_for_required_completion"
     else:
         action = "converge"
 
+    base_policy = _task_policy(plan)
     return {
         "phase": phase,
         "action": action,
         "permits_phase_start": permits_required_completion if phase == "required_completion" else permits_general_work,
         "permits_general_work": permits_general_work,
         "permits_required_completion": permits_required_completion,
-        "required_completion_reserve_seconds": review_reserve,
-        "general_work_deadline": general_work_deadline,
+        "reviewer_reserve_seconds": review_hard,
+        "parent_finalization_reserve_seconds": parent_finalization,
+        "required_completion_reserve_seconds": completion_reserve,
+        "general_work_deadline": soft_deadline,
         "soft_deadline": soft_deadline,
         "hard_deadline": hard_deadline,
-        "remaining_general_work_seconds": max(0.0, general_work_deadline - current_now),
+        "remaining_general_work_seconds": max(0.0, soft_deadline - current_now),
         "remaining_hard_seconds": max(0.0, hard_deadline - current_now),
         "checkpoint_convergence_required": (
-            phase == "implementation" and hard_open and current_now >= general_work_deadline
+            phase == "implementation" and hard_open and current_now >= soft_deadline
         ),
         "required_completion_handoff": (
-            review_reserve > 0 and hard_open and current_now >= general_work_deadline
+            completion_reserve > 0 and hard_open and current_now >= soft_deadline
         ),
-        "legacy_unclamped": legacy_unclamped,
+        "hard_deadline_extended": effective.hard_timeout_seconds > base_policy.hard_timeout_seconds,
+        "base_task_budget": asdict(base_policy),
+        "effective_task_budget": asdict(effective),
     }
 
 
@@ -228,30 +256,10 @@ def init(
     plan: dict[str, Any],
     now: Any,
 ) -> dict[str, Any]:
-    """Initialize a phase-aware ledger, or grandfather an existing pre-phase ledger."""
     plan = _plan(plan)
-    effective_policy = _effective_policy(plan)
-    try:
-        result = init_ledger(state_file, task_id, effective_policy, now)
-    except LedgerError as init_error:
-        # An already-running task from the pre-phase runtime was initialized
-        # with the original policy. Preserve it rather than shortening its soft
-        # deadline during an update. Any other mismatch still fails closed.
-        try:
-            result = ledger_status(state_file, task_id, now)
-            actual_policy, legacy_unclamped = _policy_mode(plan, result)
-        except LedgerError:
-            raise init_error
-        if not legacy_unclamped:
-            raise init_error
-        result["initialized"] = False
-        result["idempotent"] = True
-        result.update(phase_decision(plan, result, "exploration", now))
-        result["effective_task_budget"] = asdict(actual_policy)
-        return result
-
+    effective = _effective_policy(plan)
+    result = init_ledger(state_file, task_id, effective, now)
     result.update(phase_decision(plan, result, "exploration", now))
-    result["effective_task_budget"] = asdict(effective_policy)
     return result
 
 
@@ -262,6 +270,7 @@ def status(
     phase: str,
     now: Any,
 ) -> dict[str, Any]:
+    plan = _plan(plan)
     ledger = ledger_status(state_file, task_id, now)
     result = dict(ledger)
     result.update(phase_decision(plan, ledger, phase, now))
@@ -277,12 +286,12 @@ def reserve_implementation(
     fingerprint: str,
     now: Any,
 ) -> dict[str, Any]:
+    plan = _plan(plan)
     if kind not in IMPLEMENTATION_RESERVATION_KINDS:
         raise LedgerError(f"invalid implementation reservation kind: {kind}")
-    # A phase-aware ledger already has the completion reserve encoded in its
-    # soft deadline. A grandfathered ledger keeps its historical deadline. In
-    # both cases the raw atomic reserve preserves limit/deadline checks and its
-    # deliberate idempotent replay behavior after the deadline.
+    # The raw ledger's soft deadline is exactly the general-work cutoff, so its
+    # atomic reserve path remains authoritative for implementation admission and
+    # idempotent replay.
     result = reserve(
         state_file,
         task_id,

--- a/scripts/strategies/work_unit_runtime.py
+++ b/scripts/strategies/work_unit_runtime.py
@@ -1,12 +1,5 @@
 #!/usr/bin/env python3
-"""Deterministic validator for bounded implementation work-unit manifests.
-
-FlowPilot partitions a strategy-owned bounded implementation stage into logical
-units before spawning implementers. This helper validates the manifest against
-ExecutionPlan StagePolicy and the already-resolved implementation concurrency so
-unit boundaries, dependency ordering, and writable parallelism are explicit
-rather than improvised by Parent.
-"""
+"""Deterministic validator for implementation work-unit manifests."""
 from __future__ import annotations
 
 import argparse
@@ -19,10 +12,16 @@ from dataclasses import dataclass
 from typing import Any, Iterable
 
 WORK_UNIT_MODES = {"single", "bounded"}
+POLICY_FIELDS = {
+    "work_unit_mode",
+    "minimum_work_units",
+    "join_between_work_units",
+    "maximum_work_units",
+    "require_write_paths",
+}
 
 
 def _strict_string(value: Any, label: str) -> str:
-    """Return a manifest string without coercing other JSON scalar types."""
     if type(value) is not str:
         raise ValueError(f"{label} must be a string")
     result = value.strip()
@@ -32,7 +31,6 @@ def _strict_string(value: Any, label: str) -> str:
 
 
 def _strict_int(value: Any, label: str, *, minimum: int | None = None) -> int:
-    """Validate JSON integers explicitly; bool is an int subclass in Python."""
     if type(value) is not int:
         raise ValueError(f"{label} must be an integer")
     if minimum is not None and value < minimum:
@@ -41,12 +39,6 @@ def _strict_int(value: Any, label: str, *, minimum: int | None = None) -> int:
 
 
 def _normalize_repo_path(value: Any, label: str) -> str:
-    """Validate and return one normalized, repo-relative POSIX path.
-
-    This is deliberately lexical preflight only. It does not resolve symlinks or
-    provide an operating-system lock, so the caller must still retain normal
-    writable-scope/fencing safeguards.
-    """
     path = _strict_string(value, label)
     if "\x00" in path:
         raise ValueError(f"{label} must not contain NUL")
@@ -58,11 +50,9 @@ def _normalize_repo_path(value: Any, label: str) -> str:
         raise ValueError(f"{label} must not use a Windows drive path")
     if any(char in path for char in "*?[]{}"):
         raise ValueError(f"{label} must not contain glob metacharacters")
-
     components = path.split("/")
     if any(component in {"", ".", ".."} for component in components):
         raise ValueError(f"{label} must be a normalized path without empty, '.' or '..' components")
-
     normalized = posixpath.normpath(path)
     if normalized in {"", ".", ".."} or normalized != path or normalized.startswith("../"):
         raise ValueError(f"{label} must be a normalized repo-relative POSIX path")
@@ -78,72 +68,57 @@ class WorkUnit:
     validation: tuple[str, ...]
     depends_on: tuple[str, ...]
     parallel_group: str | None = None
-    generation: int = 0
+    generation: int | None = None
     write_paths: tuple[str, ...] = ()
 
     @classmethod
     def from_dict(cls, value: dict[str, Any]) -> "WorkUnit":
+        if type(value) is not dict:
+            raise ValueError("work unit must be an object")
         required = ("unit_id", "scope_id", "acceptance_delta", "write_scope_id", "validation")
         missing = [key for key in required if key not in value]
         if missing:
             raise ValueError(f"work unit missing fields: {missing}")
+        allowed = set(required) | {"depends_on", "parallel_group", "generation", "write_paths"}
+        unknown = sorted(set(value).difference(allowed))
+        if unknown:
+            raise ValueError(f"work unit has unknown fields: {unknown}")
 
         unit_id = _strict_string(value["unit_id"], "unit_id")
         scope_id = _strict_string(value["scope_id"], f"work unit {unit_id}: scope_id")
-        acceptance_delta = _strict_string(
-            value["acceptance_delta"], f"work unit {unit_id}: acceptance_delta"
-        )
-        write_scope_id = _strict_string(
-            value["write_scope_id"], f"work unit {unit_id}: write_scope_id"
-        )
+        acceptance_delta = _strict_string(value["acceptance_delta"], f"work unit {unit_id}: acceptance_delta")
+        write_scope_id = _strict_string(value["write_scope_id"], f"work unit {unit_id}: write_scope_id")
 
         raw_validation = value["validation"]
         if type(raw_validation) is not list or not raw_validation:
             raise ValueError(f"work unit {unit_id}: validation must be a non-empty list")
-        validation = tuple(
-            _strict_string(item, f"work unit {unit_id}: validation entry") for item in raw_validation
-        )
+        validation = tuple(_strict_string(item, f"work unit {unit_id}: validation entry") for item in raw_validation)
 
-        if "depends_on" in value:
-            raw_dependencies = value["depends_on"]
-        else:
-            raw_dependencies = []
+        raw_dependencies = value.get("depends_on", [])
         if type(raw_dependencies) is not list:
             raise ValueError(f"work unit {unit_id}: depends_on must be a list")
-        depends_on = tuple(
-            _strict_string(item, f"work unit {unit_id}: depends_on entry") for item in raw_dependencies
-        )
+        depends_on = tuple(_strict_string(item, f"work unit {unit_id}: depends_on entry") for item in raw_dependencies)
         if len(set(depends_on)) != len(depends_on):
             raise ValueError(f"work unit {unit_id}: depends_on entries must be unique")
         if unit_id in depends_on:
             raise ValueError(f"work unit {unit_id}: unit cannot depend on itself")
 
+        parallel_group = None
         if value.get("parallel_group") is not None:
-            parallel_group = _strict_string(
-                value["parallel_group"], f"work unit {unit_id}: parallel_group"
-            )
-        else:
-            parallel_group = None
+            parallel_group = _strict_string(value["parallel_group"], f"work unit {unit_id}: parallel_group")
 
+        generation = None
         if "generation" in value:
-            generation = _strict_int(
-                value["generation"], f"work unit {unit_id}: generation", minimum=0
-            )
-        else:
-            generation = 0
+            generation = _strict_int(value["generation"], f"work unit {unit_id}: generation", minimum=0)
 
+        write_paths: tuple[str, ...] = ()
         if "write_paths" in value:
             raw_write_paths = value["write_paths"]
             if type(raw_write_paths) is not list or not raw_write_paths:
                 raise ValueError(f"work unit {unit_id}: write_paths must be a non-empty list")
-            write_paths = tuple(
-                _normalize_repo_path(item, f"work unit {unit_id}: write_paths entry")
-                for item in raw_write_paths
-            )
+            write_paths = tuple(_normalize_repo_path(item, f"work unit {unit_id}: write_paths entry") for item in raw_write_paths)
             if len(set(write_paths)) != len(write_paths):
                 raise ValueError(f"work unit {unit_id}: write_paths entries must be unique")
-        else:
-            write_paths = ()
 
         return cls(
             unit_id=unit_id,
@@ -173,64 +148,50 @@ def _positive_int(value: Any, label: str) -> int:
     return value
 
 
-def _policy_contract(value: dict[str, Any]) -> tuple[str, int, bool, int | None, bool, bool]:
+def _policy_contract(value: dict[str, Any]) -> tuple[str, int, bool, int, bool]:
     if type(value) is not dict:
         raise ValueError("policy must be an object")
+    missing = sorted(POLICY_FIELDS.difference(value))
+    if missing:
+        raise ValueError(f"implementation work-unit policy missing fields: {missing}")
 
-    mode = value.get("work_unit_mode", "single")
-    if type(mode) is not str:
-        raise ValueError("work_unit_mode must be a string")
-    minimum = _strict_int(
-        value["minimum_work_units"] if "minimum_work_units" in value else 1,
-        "minimum_work_units",
-        minimum=1,
-    )
-    join_between = value.get("join_between_work_units", False)
+    mode = value["work_unit_mode"]
+    if type(mode) is not str or mode not in WORK_UNIT_MODES:
+        raise ValueError(f"invalid work_unit_mode: {mode}")
+    minimum = _strict_int(value["minimum_work_units"], "minimum_work_units", minimum=1)
+    maximum = _strict_int(value["maximum_work_units"], "maximum_work_units", minimum=1)
+    join_between = value["join_between_work_units"]
+    require_write_paths = value["require_write_paths"]
     if type(join_between) is not bool:
         raise ValueError("join_between_work_units must be boolean")
-
-    maximum = value.get("maximum_work_units") if "maximum_work_units" in value else None
-    # StagePolicy serializes an omitted Optional field as null. Treat that as
-    # legacy absence; any concrete value must be an integer and is enforced.
-    if maximum is not None:
-        maximum = _strict_int(maximum, "maximum_work_units", minimum=1)
-
-    require_write_paths = value.get("require_write_paths", False)
     if type(require_write_paths) is not bool:
         raise ValueError("require_write_paths must be boolean")
 
-    if mode not in WORK_UNIT_MODES:
-        raise ValueError(f"invalid work_unit_mode: {mode}")
     if mode == "single":
-        if minimum != 1:
-            raise ValueError("single work-unit mode requires minimum_work_units=1")
+        if minimum != 1 or maximum != 1:
+            raise ValueError("single work-unit mode requires minimum_work_units=maximum_work_units=1")
         if join_between:
             raise ValueError("single work-unit mode cannot join between work units")
-        if maximum is not None and maximum != 1:
-            raise ValueError("single work-unit mode requires maximum_work_units=1")
+        if require_write_paths:
+            raise ValueError("single work-unit mode must not require write_paths")
     else:
         if not join_between:
             raise ValueError("bounded work-unit mode requires Parent joins between work units")
-        if maximum is not None and maximum < minimum:
+        if maximum < minimum:
             raise ValueError("bounded work-unit mode requires maximum_work_units >= minimum_work_units")
-
-    # New bounded plans opt into generation/path lineage through either a
-    # concrete maximum or require_write_paths. Older bounded policies omit both
-    # fields and continue to support serial manifests without write_paths.
-    new_bounded = mode == "bounded" and (maximum is not None or require_write_paths)
-    return mode, minimum, join_between, maximum, require_write_paths, new_bounded
+        if not require_write_paths:
+            raise ValueError("bounded work-unit mode requires write_paths")
+    return mode, minimum, join_between, maximum, require_write_paths
 
 
 def _check_dependencies(units: tuple[WorkUnit, ...]) -> dict[str, WorkUnit]:
     by_id = {unit.unit_id: unit for unit in units}
     if len(by_id) != len(units):
         raise ValueError("work-unit ids must be unique")
-
     for unit in units:
         unknown = [dependency for dependency in unit.depends_on if dependency not in by_id]
         if unknown:
             raise ValueError(f"work unit {unit.unit_id}: unknown dependencies: {unknown}")
-
     visiting: set[str] = set()
     visited: set[str] = set()
 
@@ -250,11 +211,7 @@ def _check_dependencies(units: tuple[WorkUnit, ...]) -> dict[str, WorkUnit]:
     return by_id
 
 
-def _depends_on_transitively(
-    by_id: dict[str, WorkUnit],
-    unit_id: str,
-    dependency_id: str,
-) -> bool:
+def _depends_on_transitively(by_id: dict[str, WorkUnit], unit_id: str, dependency_id: str) -> bool:
     stack = list(by_id[unit_id].depends_on)
     seen: set[str] = set()
     while stack:
@@ -277,19 +234,11 @@ def _check_acceptance_deltas(units: tuple[WorkUnit, ...]) -> None:
     for unit in units:
         previous = seen.get(unit.acceptance_delta)
         if previous is not None:
-            raise ValueError(
-                f"work units {previous!r} and {unit.unit_id!r}: acceptance_delta must be unique"
-            )
+            raise ValueError(f"work units {previous!r} and {unit.unit_id!r}: acceptance_delta must be unique")
         seen[unit.acceptance_delta] = unit.unit_id
 
 
 def _check_write_path_order(units: tuple[WorkUnit, ...], by_id: dict[str, WorkUnit]) -> None:
-    """Require dependency ordering for every known path overlap.
-
-    Legacy manifests may omit paths, so an unknown path is not treated as an
-    overlap here. Parallel groups independently reject missing paths, which keeps
-    legacy serial execution compatible without claiming unproven isolation.
-    """
     for index, left in enumerate(units):
         if not left.write_paths:
             continue
@@ -304,9 +253,7 @@ def _check_write_path_order(units: tuple[WorkUnit, ...], by_id: dict[str, WorkUn
             ]
             if not overlaps:
                 continue
-            linked = _depends_on_transitively(by_id, left.unit_id, right.unit_id) or _depends_on_transitively(
-                by_id, right.unit_id, left.unit_id
-            )
+            linked = _depends_on_transitively(by_id, left.unit_id, right.unit_id) or _depends_on_transitively(by_id, right.unit_id, left.unit_id)
             if not linked:
                 left_path, right_path = overlaps[0]
                 raise ValueError(
@@ -327,12 +274,7 @@ def _check_shared_writable_scope_order(units: tuple[WorkUnit, ...]) -> None:
         previous_by_scope[unit.write_scope_id] = unit
 
 
-def _check_parallel_groups(
-    units: tuple[WorkUnit, ...],
-    by_id: dict[str, WorkUnit],
-    *,
-    max_parallel_units: int,
-) -> None:
+def _check_parallel_groups(units: tuple[WorkUnit, ...], by_id: dict[str, WorkUnit], *, max_parallel_units: int) -> None:
     groups: dict[str, list[WorkUnit]] = defaultdict(list)
     for unit in units:
         if unit.parallel_group is not None:
@@ -346,33 +288,20 @@ def _check_parallel_groups(
         seen_scopes: set[str] = set()
         for member in members:
             if not member.write_paths:
-                raise ValueError(
-                    f"parallel group {group!r} requires write_paths for every member; "
-                    f"work unit {member.unit_id!r} is missing them"
-                )
+                raise ValueError(f"parallel group {group!r} requires write_paths for every member")
             if member.write_scope_id in seen_scopes:
-                raise ValueError(
-                    f"parallel group {group!r} contains overlapping write scope {member.write_scope_id!r}"
-                )
+                raise ValueError(f"parallel group {group!r} contains overlapping write scope {member.write_scope_id!r}")
             seen_scopes.add(member.write_scope_id)
-
         for index, left in enumerate(members):
             for right in members[index + 1 :]:
-                if any(
-                    _paths_overlap(left_path, right_path)
-                    for left_path in left.write_paths
-                    for right_path in right.write_paths
-                ):
+                if any(_paths_overlap(lp, rp) for lp in left.write_paths for rp in right.write_paths):
                     raise ValueError(
                         f"parallel group {group!r} contains overlapping write paths between "
                         f"{left.unit_id!r} and {right.unit_id!r}"
                     )
-                if _depends_on_transitively(by_id, left.unit_id, right.unit_id) or _depends_on_transitively(
-                    by_id, right.unit_id, left.unit_id
-                ):
+                if _depends_on_transitively(by_id, left.unit_id, right.unit_id) or _depends_on_transitively(by_id, right.unit_id, left.unit_id):
                     raise ValueError(
-                        f"parallel group {group!r} contains transitively dependency-linked units; "
-                        "dependent units must run in later waves"
+                        f"parallel group {group!r} contains transitively dependency-linked units; dependent units must run in later waves"
                     )
 
 
@@ -399,50 +328,37 @@ def validate_manifest(
     implementation_workers: int = 1,
     max_concurrent_threads: int = 1,
 ) -> dict[str, Any]:
-    if type(policy) is not dict:
-        raise ValueError("policy must be an object")
     if type(manifest) is not dict:
         raise ValueError("manifest must be an object")
     implementation_workers = _positive_int(implementation_workers, "implementation_workers")
     max_concurrent_threads = _positive_int(max_concurrent_threads, "max_concurrent_threads")
     max_parallel_units = min(implementation_workers, max_concurrent_threads)
+    mode, minimum, join_between, maximum, require_write_paths = _policy_contract(policy)
 
-    mode, minimum, join_between, maximum, require_write_paths, new_bounded = _policy_contract(policy)
     raw_units = manifest.get("units")
     if type(raw_units) is not list or not raw_units:
         raise ValueError("manifest.units must be a non-empty list")
-    units = tuple(WorkUnit.from_dict(value) for value in raw_units if type(value) is dict)
-    if len(units) != len(raw_units):
-        raise ValueError("every manifest unit must be an object")
+    units = tuple(WorkUnit.from_dict(value) for value in raw_units)
 
     if mode == "single" and len(units) != 1:
         raise ValueError("single work-unit mode requires exactly one manifest unit")
     if mode == "bounded" and len(units) < minimum:
-        raise ValueError(
-            f"bounded implementation requires at least {minimum} work units; got {len(units)}"
-        )
-    if maximum is not None and len(units) > maximum:
-        raise ValueError(
-            f"manifest contains {len(units)} work units but policy maximum_work_units is {maximum}"
-        )
+        raise ValueError(f"bounded implementation requires at least {minimum} work units; got {len(units)}")
+    if len(units) > maximum:
+        raise ValueError(f"manifest contains {len(units)} work units but policy maximum_work_units is {maximum}")
 
-    if new_bounded:
+    if mode == "bounded":
         missing_generation = [unit.unit_id for raw, unit in zip(raw_units, units) if "generation" not in raw]
-        if missing_generation:
-            raise ValueError(
-                f"new bounded policy requires generation for every work unit; missing: {missing_generation}"
-            )
-    if require_write_paths:
         missing_paths = [unit.unit_id for raw, unit in zip(raw_units, units) if "write_paths" not in raw]
+        if missing_generation:
+            raise ValueError(f"bounded policy requires generation for every work unit; missing: {missing_generation}")
         if missing_paths:
-            raise ValueError(
-                f"policy requires write_paths for every work unit; missing: {missing_paths}"
-            )
+            raise ValueError(f"bounded policy requires write_paths for every work unit; missing: {missing_paths}")
+        if any(unit.generation is None for unit in units):
+            raise AssertionError("bounded generation validation failed")
         empty_paths = [unit.unit_id for unit in units if not unit.write_paths]
         if empty_paths:
-            raise ValueError(
-                f"policy requires non-empty write_paths for every work unit; empty: {empty_paths}"
-            )
+            raise ValueError(f"bounded policy requires non-empty write_paths for every work unit; empty: {empty_paths}")
 
     by_id = _check_dependencies(units)
     _check_acceptance_deltas(units)
@@ -452,9 +368,7 @@ def validate_manifest(
 
     parallel_groups = sorted({unit.parallel_group for unit in units if unit.parallel_group is not None})
     fingerprints = {unit.unit_id: _unit_fingerprint(unit) for unit in units}
-    logical_fingerprints = {
-        unit.unit_id: _unit_fingerprint(unit, include_generation=False) for unit in units
-    }
+    logical_fingerprints = {unit.unit_id: _unit_fingerprint(unit, include_generation=False) for unit in units}
     return {
         "valid": True,
         "work_unit_mode": mode,
@@ -474,7 +388,7 @@ def validate_manifest(
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="work-unit-runtime")
     parser.add_argument("--policy-json", required=True, help="implementation_stage JSON object")
-    parser.add_argument("--manifest-json", required=True, help="bounded work-unit manifest JSON object")
+    parser.add_argument("--manifest-json", required=True, help="work-unit manifest JSON object")
     parser.add_argument("--implementation-workers", required=True, type=int)
     parser.add_argument("--max-concurrent-threads", required=True, type=int)
     return parser

--- a/scripts/strategy_runtime.py
+++ b/scripts/strategy_runtime.py
@@ -31,7 +31,7 @@ from strategies.base import (
 
 try:
     from telemetry_core.app_server import quota_windows as app_server_quota_windows
-except ImportError:  # pragma: no cover - standalone installs always bundle it
+except ImportError:  # pragma: no cover
     app_server_quota_windows = None
 
 CODEX_HOME = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
@@ -51,10 +51,6 @@ QUALITY_INTENTS = ("normal", "strong", "absolute")
 REVIEW_MODES = ("auto", "standard", "strict")
 FANOUT_MODES = ("auto", "conservative", "aggressive")
 EFFORT_RANK = {name: idx for idx, name in enumerate(EFFORTS)}
-
-# Lifecycle preferences belong to strategies, but no strategy may wait forever.
-# These hard ceilings are deliberately not user-tunable in v1; later telemetry can
-# inform configurable/predictive limits without weakening the safety boundary.
 RUNTIME_MAX_WORKER_IDLE_SECONDS = 600
 RUNTIME_MAX_WORKER_WALL_SECONDS = 3600
 
@@ -239,10 +235,7 @@ class ExecutionPlan:
 
 
 def _section_body(text: str, section: str) -> re.Match[str] | None:
-    return re.search(
-        rf"(?ms)^\[{re.escape(section)}\]\s*\n(.*?)(?=^\[[^\n]+\]\s*$|\Z)",
-        text,
-    )
+    return re.search(rf"(?ms)^\[{re.escape(section)}\]\s*\n(.*?)(?=^\[[^\n]+\]\s*$|\Z)", text)
 
 
 def policy_value(path: Path | None, section: str, key: str, default: str = "") -> str:
@@ -312,7 +305,6 @@ def _release_bool(section: str, key: str, fallback: bool) -> bool:
 
 
 def _release_reasoning_rollout() -> ReasoningRolloutPolicy:
-    """Load optional rollout defaults while preserving old installations."""
     rollout = ReasoningRolloutPolicy(
         mode=_release_value("reasoning.rollout", "mode", "shadow"),
         minimum=_release_value("reasoning.rollout", "minimum", "high"),
@@ -343,7 +335,7 @@ def set_policy_value(path: Path, section: str, key: str, value: str, *, quote: b
             if body and not body.endswith("\n"):
                 body += "\n"
             body += line + "\n"
-        text = text[: match.start(1)] + body + text[match.end(1) :]
+        text = text[: match.start(1)] + body + text[match.end(1):]
     else:
         if text and not text.endswith("\n"):
             text += "\n"
@@ -456,9 +448,6 @@ def _raise_capability_floors(base: PolicySnapshot, repo: Path | None) -> PolicyS
         worker_routine_reasoning=repo_effort("worker", "routine_effort", base.worker_routine_reasoning),
         worker_complex_reasoning=repo_effort("worker", "complex_effort", base.worker_complex_reasoning),
         worker_critical_reasoning=repo_effort("worker", "critical_effort", base.worker_critical_reasoning),
-        # Repository policy may raise rollout effort floors, but it cannot
-        # change the user's rollout mode (in particular, it cannot silently
-        # opt a legacy/shadow user into adaptive execution).
         reasoning_rollout=ReasoningRolloutPolicy(
             mode=base.reasoning_rollout.mode,
             minimum=repo_effort("reasoning.rollout", "minimum", base.reasoning_rollout.minimum),
@@ -472,22 +461,14 @@ def _raise_capability_floors(base: PolicySnapshot, repo: Path | None) -> PolicyS
 
 
 def resolve_policy(user_policy: Path, repo_policy: Path | None = None) -> ResolvedPolicy:
-    """Resolve release + user + already-selected repository policy."""
     repo = repo_policy
-    enabled = _policy_bool(
-        user_policy,
-        "strategy",
-        "enabled",
-        _release_bool("strategy", "enabled", True),
-        strict=True,
-    )
+    enabled = _policy_bool(user_policy, "strategy", "enabled", _release_bool("strategy", "enabled", True), strict=True)
     strategy = policy_value(user_policy, "strategy", "profile", _release_value("strategy", "profile"))
     routing = policy_value(user_policy, "routing", "mode", _release_value("routing", "mode"))
     review = policy_value(user_policy, "modifiers", "review", _release_value("modifiers", "review"))
     fanout = policy_value(user_policy, "modifiers", "fanout", _release_value("modifiers", "fanout"))
     max_threads = _policy_int(user_policy, "runtime", "max_concurrent_threads", _release_int("runtime", "max_concurrent_threads", 4))
     max_repairs = _policy_int(user_policy, "runtime", "max_repair_cycles", _release_int("runtime", "max_repair_cycles", 2))
-
     if repo is not None:
         strategy = policy_value(repo, "strategy", "profile", strategy)
         routing = policy_value(repo, "routing", "mode", routing)
@@ -505,7 +486,6 @@ def resolve_policy(user_policy: Path, repo_policy: Path | None = None) -> Resolv
                 max_repairs = min(max_repairs, int(repo_repairs))
             except ValueError:
                 pass
-
     resolved = ResolvedPolicy(
         enabled=enabled,
         strategy=strategy,
@@ -536,10 +516,7 @@ def _configured_effort(task: TaskProfile, policy: PolicySnapshot, role: str) -> 
     return _effort_max(floor, target)
 
 
-def _rollout_policy_with_override(
-    policy: ReasoningRolloutPolicy,
-    mode: str | None,
-) -> ReasoningRolloutPolicy:
+def _rollout_policy_with_override(policy: ReasoningRolloutPolicy, mode: str | None) -> ReasoningRolloutPolicy:
     if mode is None:
         policy.validate()
         return policy
@@ -629,12 +606,7 @@ def _reviewer_demand(task: TaskProfile, review_mode: str, bonus: int = 0) -> int
     return demand
 
 
-def _fit_total_worker_budget(
-    exploration_workers: int,
-    implementation_workers: int,
-    reviewer_workers: int,
-    budget: WorkerBudget,
-) -> tuple[int, int, int]:
+def _fit_total_worker_budget(exploration_workers: int, implementation_workers: int, reviewer_workers: int, budget: WorkerBudget) -> tuple[int, int, int]:
     while exploration_workers + implementation_workers + reviewer_workers > budget.max_total_workers:
         if exploration_workers > 0:
             exploration_workers -= 1
@@ -647,37 +619,15 @@ def _fit_total_worker_budget(
     return exploration_workers, implementation_workers, reviewer_workers
 
 
-def _bounded_stage_policy(
-    spec,
-    task: TaskProfile,
-    stage: str,
-    worker_count: int,
-    modifiers: Modifiers,
-) -> StagePolicy | None:
-    """Normalize one strategy lifecycle policy against actual topology and Runtime ceilings."""
+def _bounded_stage_policy(spec, task: TaskProfile, stage: str, worker_count: int, modifiers: Modifiers) -> StagePolicy | None:
     if worker_count <= 0:
         return None
-
     policy = spec.lifecycle(task, stage)
     policy.validate()
-
     hard_timeout = min(policy.hard_timeout_seconds, RUNTIME_MAX_WORKER_WALL_SECONDS)
     idle_timeout = min(policy.idle_timeout_seconds, RUNTIME_MAX_WORKER_IDLE_SECONDS, hard_timeout)
-    if policy.join_policy == "opportunistic":
-        minimum = 0
-    else:
-        minimum = max(1, min(worker_count, policy.min_successful_workers))
-
-    bounded = replace(
-        policy,
-        min_successful_workers=minimum,
-        idle_timeout_seconds=idle_timeout,
-        hard_timeout_seconds=hard_timeout,
-    )
-
-    # strict is a generic modifier contract: requested independent review must
-    # actually reach a terminal result instead of being silently replaced by
-    # Parent review or quorum-based straggler cancellation.
+    minimum = 0 if policy.join_policy == "opportunistic" else max(1, min(worker_count, policy.min_successful_workers))
+    bounded = replace(policy, min_successful_workers=minimum, idle_timeout_seconds=idle_timeout, hard_timeout_seconds=hard_timeout)
     if stage == "review" and modifiers.review == "strict":
         bounded = replace(
             bounded,
@@ -685,11 +635,46 @@ def _bounded_stage_policy(
             min_successful_workers=worker_count,
             cancel_if_superseded=False,
             cancel_stragglers_after_quorum=False,
-            fallback_policy="replan",
+            fallback_policy="retry_review",
         )
-
     bounded.validate()
     return bounded
+
+
+def _canonical_task_budget(
+    raw: TaskBudgetPolicy,
+    *,
+    implementation_workers: int,
+    reviewer_workers: int,
+    implementation_stage: StagePolicy | None,
+    review_stage: StagePolicy | None,
+) -> TaskBudgetPolicy:
+    raw.validate()
+    if implementation_stage is None:
+        raise ValueError("delegated task budget requires implementation_stage")
+    if implementation_stage.maximum_work_units is None:
+        raise ValueError("delegated task budget requires maximum_work_units")
+    if raw.max_work_units != implementation_stage.maximum_work_units:
+        raise ValueError("task budget max_work_units must match implementation_stage maximum_work_units")
+    if implementation_workers > raw.max_work_units:
+        raise ValueError("implementation topology exceeds task budget max_work_units")
+    if implementation_workers > raw.max_implementation_attempts:
+        raise ValueError("implementation topology exceeds task budget max_implementation_attempts")
+    if implementation_stage.soft_timeout_seconds is not None and raw.soft_timeout_seconds < implementation_stage.soft_timeout_seconds:
+        raise ValueError("task soft timeout cannot precede implementation soft checkpoint budget")
+
+    if reviewer_workers <= 0:
+        if review_stage is not None:
+            raise ValueError("review_stage must be absent when reviewer_workers is zero")
+        return replace(raw, max_review_attempts=0)
+
+    if review_stage is None:
+        raise ValueError("review_stage is required when reviewer_workers is positive")
+    if raw.max_review_attempts < reviewer_workers:
+        raise ValueError("review topology exceeds task budget max_review_attempts")
+    completion_tail = review_stage.hard_timeout_seconds + raw.parent_finalization_seconds
+    canonical_hard = max(raw.hard_timeout_seconds, raw.soft_timeout_seconds + completion_tail)
+    return replace(raw, hard_timeout_seconds=canonical_hard)
 
 
 def compile_plan(
@@ -722,16 +707,9 @@ def compile_plan(
 
     route = spec.adaptive_route(task) if routing_mode == "adaptive" else routing_mode
     delegated = route == "delegate"
-    parent_effort = _effort_max(
-        _configured_effort(task, policy, "parent"),
-        spec.effort(task, "parent"),
-    )
+    parent_effort = _effort_max(_configured_effort(task, policy, "parent"), spec.effort(task, "parent"))
     legacy_role_efforts = {
-        role: _effort_max(
-            _configured_effort(task, policy, "worker"),
-            spec.effort(task, role),
-            _effort_next(parent_effort),
-        )
+        role: _effort_max(_configured_effort(task, policy, "worker"), spec.effort(task, role), _effort_next(parent_effort))
         for role in ("explorer", "implementer", "reviewer")
     }
     role_efforts = dict(legacy_role_efforts)
@@ -749,37 +727,17 @@ def compile_plan(
 
     if delegated:
         implementation_workers = 1
-        exploration_workers = min(
-            _exploration_demand(task, spec.exploration_bonus(task)),
-            budget.max_explorers,
-            runtime.max_concurrent_threads,
-        )
-
-        proven_writable = min(
-            task.writable_workstreams,
-            runtime.max_concurrent_threads,
-            budget.max_implementers,
-        )
-        allow_parallel_write = (
-            task.parallelism == "high"
-            and task.write_conflict == "low"
-            and proven_writable >= 2
-        )
+        exploration_workers = min(_exploration_demand(task, spec.exploration_bonus(task)), budget.max_explorers, runtime.max_concurrent_threads)
+        proven_writable = min(task.writable_workstreams, runtime.max_concurrent_threads, budget.max_implementers)
+        allow_parallel_write = task.parallelism == "high" and task.write_conflict == "low" and proven_writable >= 2
         if allow_parallel_write and (spec.allow_parallel_write or modifiers.fanout == "aggressive"):
             implementation_workers = proven_writable
-            notes.append(
-                f"parallel writable execution authorized across {implementation_workers} proven isolated workstreams"
-            )
-
+            notes.append(f"parallel writable execution authorized across {implementation_workers} proven isolated workstreams")
         if modifiers.fanout == "conservative":
             exploration_workers = min(exploration_workers, 1)
             implementation_workers = 1
         elif modifiers.fanout == "aggressive" and task.parallelism == "high":
-            exploration_workers = min(
-                budget.max_explorers,
-                runtime.max_concurrent_threads,
-                max(exploration_workers, 2),
-            )
+            exploration_workers = min(budget.max_explorers, runtime.max_concurrent_threads, max(exploration_workers, 2))
 
         if modifiers.review == "strict":
             review_mode = "independent+parent"
@@ -787,28 +745,16 @@ def compile_plan(
             review_mode = "parent"
         elif spec.independent_review(task):
             review_mode = "independent+parent"
-
-        reviewer_workers = min(
-            _reviewer_demand(task, review_mode, spec.reviewer_bonus(task)),
-            budget.max_reviewers,
-            runtime.max_concurrent_threads,
-        )
+        reviewer_workers = min(_reviewer_demand(task, review_mode, spec.reviewer_bonus(task)), budget.max_reviewers, runtime.max_concurrent_threads)
 
         if task.parallelism == "none":
             exploration_workers = 0
             implementation_workers = 1
             reviewer_workers = min(reviewer_workers, 1)
-
         exploration_workers, implementation_workers, reviewer_workers = _fit_total_worker_budget(
-            exploration_workers,
-            implementation_workers,
-            reviewer_workers,
-            budget,
+            exploration_workers, implementation_workers, reviewer_workers, budget
         )
-        concurrency = min(
-            runtime.max_concurrent_threads,
-            max(1, exploration_workers, implementation_workers, reviewer_workers),
-        )
+        concurrency = min(runtime.max_concurrent_threads, max(1, exploration_workers, implementation_workers, reviewer_workers))
 
     if runtime.quota_pressure in {"high", "critical"}:
         notes.append("quota pressure is high; speculative fan-out and repair budget are constrained before quality floors")
@@ -824,13 +770,7 @@ def compile_plan(
 
     if delegated and spec.reasoning_rollout is not None:
         decisions = {
-            role: spec.reasoning_rollout(
-                task,
-                role,
-                rollout_policy,
-                parent_effort,
-                legacy_role_efforts[role],
-            )
+            role: spec.reasoning_rollout(task, role, rollout_policy, parent_effort, legacy_role_efforts[role])
             for role in ("explorer", "implementer", "reviewer")
         }
         selected = {decision.selected_worker_reasoning for decision in decisions.values()}
@@ -838,35 +778,20 @@ def compile_plan(
             raise ValueError("strategy reasoning rollout must select one Worker effort across roles")
         reasoning_rollout = next(iter(decisions.values()))
         reasoning_rollout.validate()
-        role_efforts = {
-            role: decisions[role].selected_worker_reasoning
-            for role in decisions
-        }
+        role_efforts = {role: decisions[role].selected_worker_reasoning for role in decisions}
         if reasoning_rollout.mode == "shadow":
-            notes.append(
-                "efficient reasoning rollout is shadow; proposed Worker effort is reported, legacy effort is selected"
-            )
+            notes.append("efficient reasoning rollout is shadow; proposed Worker effort is reported, legacy effort is selected")
         elif reasoning_rollout.mode == "adaptive":
-            notes.append(
-                "efficient reasoning rollout is adaptive; proposed Worker effort is selected and may equal Parent"
-            )
+            notes.append("efficient reasoning rollout is adaptive; proposed Worker effort is selected and may equal Parent")
         else:
             notes.append("efficient reasoning rollout is legacy; current Worker effort is selected")
 
     if route == "direct":
-        exploration_workers = 0
-        implementation_workers = 0
-        reviewer_workers = 0
+        exploration_workers = implementation_workers = reviewer_workers = 0
         concurrency = 1
-        explorer_capability_policy: str | None = None
-        explorer_model: str | None = None
-        explorer_reasoning: str | None = None
-        implementer_capability_policy: str | None = None
-        implementer_model: str | None = None
-        implementer_reasoning: str | None = None
-        reviewer_capability_policy: str | None = None
-        reviewer_model: str | None = None
-        reviewer_reasoning: str | None = None
+        explorer_capability_policy = explorer_model = explorer_reasoning = None
+        implementer_capability_policy = implementer_model = implementer_reasoning = None
+        reviewer_capability_policy = reviewer_model = reviewer_reasoning = None
         review_mode = "parent"
     else:
         if exploration_workers > 0:
@@ -875,51 +800,46 @@ def compile_plan(
             if explorer_capability_policy != policy.worker_capability_policy:
                 notes.append("explorer role requests parent-class capability; use runtime override when supported")
         else:
-            explorer_capability_policy = None
-            explorer_model = None
-            explorer_reasoning = None
-
+            explorer_capability_policy = explorer_model = explorer_reasoning = None
         implementer_capability_policy, implementer_model = _desired_role_capability(task, spec, policy, "implementer")
         implementer_reasoning = role_efforts["implementer"]
         if implementer_capability_policy != policy.worker_capability_policy:
             notes.append("implementer role requests parent-class capability; use runtime override when supported")
-
         if reviewer_workers > 0:
             reviewer_capability_policy, reviewer_model = _desired_role_capability(task, spec, policy, "reviewer")
             reviewer_reasoning = role_efforts["reviewer"]
             if reviewer_capability_policy != policy.worker_capability_policy:
                 notes.append("reviewer role requests parent-class capability; use runtime override when supported")
         else:
-            reviewer_capability_policy = None
-            reviewer_model = None
-            reviewer_reasoning = None
+            reviewer_capability_policy = reviewer_model = reviewer_reasoning = None
 
     exploration_stage = _bounded_stage_policy(spec, task, "exploration", exploration_workers, modifiers)
     implementation_stage = _bounded_stage_policy(spec, task, "implementation", implementation_workers, modifiers)
     review_stage = _bounded_stage_policy(spec, task, "review", reviewer_workers, modifiers)
 
-    # Task budgets are strategy-owned and only meaningful for delegated work.
-    # Keep the compiler generic: a strategy may opt into the hook, while legacy
-    # strategies and direct plans continue to emit no task ledger contract.
     task_budget: TaskBudgetPolicy | None = None
     if delegated and spec.task_budget is not None:
-        task_budget = spec.task_budget(task)
-        if task_budget is not None:
-            if not isinstance(task_budget, TaskBudgetPolicy):
+        raw_budget = spec.task_budget(task)
+        if raw_budget is not None:
+            if not isinstance(raw_budget, TaskBudgetPolicy):
                 raise ValueError("strategy task_budget hook must return TaskBudgetPolicy or None")
+            task_budget = _canonical_task_budget(
+                raw_budget,
+                implementation_workers=implementation_workers,
+                reviewer_workers=reviewer_workers,
+                implementation_stage=implementation_stage,
+                review_stage=review_stage,
+            )
             task_budget.validate()
-            if (
-                implementation_stage is not None
-                and implementation_stage.maximum_work_units is not None
-                and implementation_stage.maximum_work_units != task_budget.max_work_units
-            ):
-                raise ValueError(
-                    "task budget max_work_units must match implementation_stage maximum_work_units"
+            if task_budget.hard_timeout_seconds != raw_budget.hard_timeout_seconds:
+                notes.append(
+                    f"required completion extends task hard deadline to {task_budget.hard_timeout_seconds}s "
+                    f"without shortening the {task_budget.soft_timeout_seconds}s general-work window"
                 )
 
     planned_worker_count = exploration_workers + implementation_workers + reviewer_workers
     return ExecutionPlan(
-        schema_version=10,
+        schema_version=11,
         strategy=strategy,
         routing=route,
         review_modifier=modifiers.review,
@@ -957,13 +877,11 @@ def compile_plan(
     )
 
 
-
 def _temporary_bypass_path() -> Path:
     return CODEX_HOME / "codex-flow" / TEMPORARY_BYPASS_NAME
 
 
 def arm_temporary_bypass() -> None:
-    """Arm a one-shot strategy bypass without mutating persistent policy."""
     path = _temporary_bypass_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
@@ -982,7 +900,6 @@ def temporary_bypass_pending() -> bool:
 
 
 def consume_temporary_bypass() -> bool:
-    """Atomically consume the token. At most one concurrent task can succeed."""
     path = _temporary_bypass_path()
     claim = path.with_name(f".{path.name}.{os.getpid()}.claim")
     try:
@@ -997,14 +914,9 @@ def consume_temporary_bypass() -> bool:
         except FileNotFoundError:
             pass
 
+
 def configured_strategy_enabled(path: Path) -> bool:
-    return _policy_bool(
-        path,
-        "strategy",
-        "enabled",
-        _release_bool("strategy", "enabled", True),
-        strict=True,
-    )
+    return _policy_bool(path, "strategy", "enabled", _release_bool("strategy", "enabled", True), strict=True)
 
 
 def configured_strategy(path: Path) -> str:
@@ -1048,13 +960,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="codex-flow strategy")
     parser.add_argument("--policy", type=Path, default=DEFAULT_POLICY)
     sub = parser.add_subparsers(dest="command")
-
     sub.add_parser("profiles")
     show = sub.add_parser("show")
     show.add_argument("--json", action="store_true")
     show.add_argument("--effective", action="store_true")
     show.add_argument("--repo-policy", default="auto")
-
     sub.add_parser("enabled")
     sub.add_parser("enable")
     sub.add_parser("disable")
@@ -1063,10 +973,8 @@ def build_parser() -> argparse.ArgumentParser:
     sub.add_parser("consume-bypass")
     set_cmd = sub.add_parser("set")
     set_cmd.add_argument("profile", choices=STRATEGIES)
-
     routing = sub.add_parser("routing")
     routing.add_argument("mode", nargs="?", choices=ROUTING_MODES)
-
     plan = sub.add_parser("plan")
     plan.add_argument("--profile", choices=STRATEGIES)
     plan.add_argument("--routing", choices=ROUTING_MODES)
@@ -1084,16 +992,8 @@ def build_parser() -> argparse.ArgumentParser:
     plan.add_argument("--iteration-intensity", choices=ITERATION, default="iterative")
     plan.add_argument("--writable-workstreams", type=int, default=1)
     plan.add_argument("--quality-intent", choices=QUALITY_INTENTS, default="normal")
-    plan.add_argument(
-        "--efficient-reasoning",
-        choices=REASONING_ROLLOUT_MODES,
-        help="current-task efficient Worker reasoning rollout mode",
-    )
-    plan.add_argument(
-        "--quota-pressure",
-        choices=("auto", "unknown", "low", "medium", "high", "critical"),
-        default="auto",
-    )
+    plan.add_argument("--efficient-reasoning", choices=REASONING_ROLLOUT_MODES)
+    plan.add_argument("--quota-pressure", choices=("auto", "unknown", "low", "medium", "high", "critical"), default="auto")
     plan.add_argument("--max-threads", type=int)
     plan.add_argument("--max-repairs", type=int)
     return parser
@@ -1103,10 +1003,8 @@ def main(argv: Iterable[str] | None = None) -> int:
     parser = build_parser()
     ns = parser.parse_args(list(argv) if argv is not None else None)
     command = ns.command or "show"
-
     if command == "profiles":
-        _print_profiles()
-        return 0
+        _print_profiles(); return 0
     if command == "show":
         if getattr(ns, "effective", False):
             repo, _disabled = _repo_arg(getattr(ns, "repo_policy", "auto"))
@@ -1118,38 +1016,19 @@ def main(argv: Iterable[str] | None = None) -> int:
                 else:
                     print(str(exc), file=sys.stderr)
                 return 2
-            result = {
-                "enabled": resolved.enabled,
-                "strategy": resolved.strategy,
-                "routing": resolved.routing,
-                "review": resolved.modifiers.review,
-                "fanout": resolved.modifiers.fanout,
-                "repo_policy": resolved.repo_policy,
-                "valid": True,
-            }
-            if getattr(ns, "json", False):
-                print(json.dumps(result, ensure_ascii=False, indent=2))
-            else:
-                print(
-                    f"strategy={resolved.strategy} routing={resolved.routing} "
-                    f"review={resolved.modifiers.review} fanout={resolved.modifiers.fanout}"
-                )
+            result = {"enabled": resolved.enabled, "strategy": resolved.strategy, "routing": resolved.routing, "review": resolved.modifiers.review, "fanout": resolved.modifiers.fanout, "repo_policy": resolved.repo_policy, "valid": True}
+            print(json.dumps(result, ensure_ascii=False, indent=2) if getattr(ns, "json", False) else f"strategy={resolved.strategy} routing={resolved.routing} review={resolved.modifiers.review} fanout={resolved.modifiers.fanout}")
             return 0
         strategy = configured_strategy(ns.policy)
         routing_mode = configured_routing(ns.policy)
         try:
-            enabled = configured_strategy_enabled(ns.policy)
-            enabled_valid = True
-            enabled_error = None
+            enabled = configured_strategy_enabled(ns.policy); enabled_error = None
         except ValueError as exc:
-            enabled = False
-            enabled_valid = False
-            enabled_error = str(exc)
-        valid = enabled_valid and strategy in STRATEGIES and routing_mode in ROUTING_MODES
+            enabled = False; enabled_error = str(exc)
+        valid = enabled_error is None and strategy in STRATEGIES and routing_mode in ROUTING_MODES
         if getattr(ns, "json", False):
             result = {"enabled": enabled, "strategy": strategy, "routing": routing_mode, "valid": valid}
-            if enabled_error is not None:
-                result["error"] = enabled_error
+            if enabled_error is not None: result["error"] = enabled_error
             print(json.dumps(result, ensure_ascii=False, indent=2))
         elif enabled_error is not None:
             print(enabled_error, file=sys.stderr)
@@ -1157,89 +1036,53 @@ def main(argv: Iterable[str] | None = None) -> int:
             print(f"enabled={'true' if enabled else 'false'} strategy={strategy} routing={routing_mode}")
         return 0 if valid else 2
     if command == "enabled":
-        try:
-            enabled = configured_strategy_enabled(ns.policy)
+        try: enabled = configured_strategy_enabled(ns.policy)
         except ValueError as exc:
-            print(str(exc), file=sys.stderr)
-            return 2
-        print("true" if enabled else "false")
-        return 0
+            print(str(exc), file=sys.stderr); return 2
+        print("true" if enabled else "false"); return 0
     if command == "bypass-once":
-        try:
-            enabled = configured_strategy_enabled(ns.policy)
+        try: enabled = configured_strategy_enabled(ns.policy)
         except ValueError as exc:
-            print(str(exc), file=sys.stderr)
-            return 2
+            print(str(exc), file=sys.stderr); return 2
         if not enabled:
-            print("strategy dispatch is globally disabled; temporary bypass is unnecessary", file=sys.stderr)
-            return 3
-        arm_temporary_bypass()
-        print("armed=true")
-        return 0
+            print("strategy dispatch is globally disabled; temporary bypass is unnecessary", file=sys.stderr); return 3
+        arm_temporary_bypass(); print("armed=true"); return 0
     if command == "bypass-pending":
-        print("true" if temporary_bypass_pending() else "false")
-        return 0
+        print("true" if temporary_bypass_pending() else "false"); return 0
     if command == "consume-bypass":
-        print("true" if consume_temporary_bypass() else "false")
-        return 0
+        print("true" if consume_temporary_bypass() else "false"); return 0
     if command in {"enable", "disable"}:
         enabled = command == "enable"
         set_policy_value(ns.policy, "strategy", "enabled", "true" if enabled else "false", quote=False)
-        print(f"enabled={'true' if enabled else 'false'}")
-        return 0
+        print(f"enabled={'true' if enabled else 'false'}"); return 0
     if command == "set":
-        set_policy_value(ns.policy, "strategy", "profile", ns.profile)
-        print(f"strategy={ns.profile}")
-        return 0
+        set_policy_value(ns.policy, "strategy", "profile", ns.profile); print(f"strategy={ns.profile}"); return 0
     if command == "routing":
         if ns.mode is None:
-            print(configured_routing(ns.policy))
-            return 0
-        set_policy_value(ns.policy, "routing", "mode", ns.mode)
-        print(f"routing={ns.mode}")
-        return 0
+            print(configured_routing(ns.policy)); return 0
+        set_policy_value(ns.policy, "routing", "mode", ns.mode); print(f"routing={ns.mode}"); return 0
     if command == "plan":
         repo, _disabled = _repo_arg(ns.repo_policy)
-        try:
-            resolved = resolve_policy(ns.policy, repo)
+        try: resolved = resolve_policy(ns.policy, repo)
         except ValueError as exc:
-            print(str(exc), file=sys.stderr)
-            return 3
+            print(str(exc), file=sys.stderr); return 3
         if not resolved.enabled:
-            print(
-                "codex-flow strategy dispatch is disabled; run `codex-flow strategy enable` to re-enable it.",
-                file=sys.stderr,
-            )
-            return 3
-        strategy = ns.profile or resolved.strategy
-        routing_mode = ns.routing or resolved.routing
-        modifiers = Modifiers(
-            review=ns.review or resolved.modifiers.review,
-            fanout=ns.fanout or resolved.modifiers.fanout,
-        )
-        max_threads = resolved.max_concurrent_threads
-        if ns.max_threads is not None:
-            max_threads = min(max_threads, ns.max_threads)
-        max_repairs = resolved.max_repair_cycles
-        if ns.max_repairs is not None:
-            max_repairs = min(max_repairs, ns.max_repairs)
+            print("codex-flow strategy dispatch is disabled; run `codex-flow strategy enable` to re-enable it.", file=sys.stderr); return 3
+        modifiers = Modifiers(review=ns.review or resolved.modifiers.review, fanout=ns.fanout or resolved.modifiers.fanout)
+        max_threads = resolved.max_concurrent_threads if ns.max_threads is None else min(resolved.max_concurrent_threads, ns.max_threads)
+        max_repairs = resolved.max_repair_cycles if ns.max_repairs is None else min(resolved.max_repair_cycles, ns.max_repairs)
         quota_pressure = detect_quota_pressure() if ns.quota_pressure == "auto" else ns.quota_pressure
         plan_obj = compile_plan(
             _task_from_args(ns),
-            strategy=strategy,
-            routing_mode=routing_mode,
+            strategy=ns.profile or resolved.strategy,
+            routing_mode=ns.routing or resolved.routing,
             modifiers=modifiers,
             policy=resolved.capability,
-            runtime=RuntimeState(
-                quota_pressure=quota_pressure,
-                max_concurrent_threads=max_threads,
-                max_repair_cycles=max_repairs,
-            ),
+            runtime=RuntimeState(quota_pressure=quota_pressure, max_concurrent_threads=max_threads, max_repair_cycles=max_repairs),
             repo_policy=resolved.repo_policy,
             efficient_reasoning=ns.efficient_reasoning,
         )
-        print(json.dumps(plan_obj.to_dict(), ensure_ascii=False, indent=2))
-        return 0
+        print(json.dumps(plan_obj.to_dict(), ensure_ascii=False, indent=2)); return 0
     parser.error(f"unsupported command: {command}")
     return 2
 

--- a/templates/skills/flow-pilot/SKILL.md
+++ b/templates/skills/flow-pilot/SKILL.md
@@ -250,7 +250,28 @@ quality     4800..6000 / 6000..7200 1..4          units + 3                 3 / 
 
 The exact values come only from the current immutable ExecutionPlan. Never infer them from the strategy name and never substitute efficient's numbers for another strategy. When both are present, `task_budget.max_work_units` must equal `implementation_stage.maximum_work_units`.
 
-Immediately after the first plan is compiled, initialize `task_budget_runtime.py` with the plan's exact `task_budget`, task id, and runtime-owned state path. After that, **do not use the raw ledger `permits_new_work` flag as the Worker-spawn gate**. Every delegated phase must go through `task_phase_runtime.py`, because a plan that already requires independent review needs a reserved completion tail.
+Immediately after the first plan is compiled, initialize the durable ledger **through the phase helper**, not through `task_budget_runtime.py init` directly:
+
+```bash
+python3 ~/.codex/codex-flow/strategies/task_phase_runtime.py init \
+  --state-file <task-ledger-path> \
+  --task-id <task-id> \
+  --plan-json '<immutable ExecutionPlan JSON>' \
+  --now <unix-seconds>
+```
+
+For a plan with reviewer Workers, phase-aware init deterministically derives an effective ledger policy whose soft timeout is:
+
+```text
+min(
+  ExecutionPlan.task_budget.soft_timeout_seconds,
+  ExecutionPlan.task_budget.hard_timeout_seconds - review_stage.hard_timeout_seconds
+)
+```
+
+All counters and the absolute hard timeout remain unchanged. This derived soft timeout is the actual general-work admission boundary stored by the ledger, so the raw ledger preserves its own atomic limit checks and deadline-after-idempotent-replay semantics. `task_phase_runtime.py` also binds later status/reserve calls to that same effective policy fingerprint and refuses a different ExecutionPlan.
+
+After initialization, **do not use the raw ledger `permits_new_work` flag as a Worker-spawn gate**. Every delegated phase must go through `task_phase_runtime.py`.
 
 Before exploration or implementation admission:
 
@@ -276,20 +297,9 @@ python3 ~/.codex/codex-flow/strategies/task_phase_runtime.py reserve \
   --fingerprint <stable-fingerprint>
 ```
 
-For a bounded manifest, reserve `work_unit` with the validator's stable `logical_unit_fingerprints[unit_id]`, which excludes generation. Reserve `implementation_attempt` with the generation-aware `unit_fingerprints[unit_id]` and an identity derived from `(scope_id, unit_id, generation)`. A replacement therefore consumes a new implementation attempt/replacement reservation without double-counting the same logical work unit; changing acceptance/scope/path/validation under the same logical unit still fails closed.
+For a bounded manifest, reserve `work_unit` with the validator's stable `logical_unit_fingerprints[unit_id]`, which excludes generation. Reserve `implementation_attempt` with the generation-aware `unit_fingerprints[unit_id]` and an identity derived from `(scope_id, unit_id, generation)`. A replacement therefore consumes a new implementation attempt/replacement reservation without double-counting the same logical work unit; changing acceptance/scope/path/validation under the same logical unit still fails closed. Exact idempotent replay remains valid even after the general-work deadline; a genuinely new reservation is rejected.
 
-The phase helper computes the general-work deadline as:
-
-```text
-min(
-  ledger.soft_deadline,
-  ledger.hard_deadline - review_stage.hard_timeout_seconds
-)
-```
-
-when `reviewer_workers > 0` and `review_stage` exists. With no reviewer Worker, the general-work deadline remains the ordinary task soft deadline. This does not change the immutable strategy budget or ledger fingerprint; it is a deterministic admission reserve derived from that plan's already-required completion stage.
-
-At the general-work deadline, do not open new exploration/implementation work or create implementation/replan/replacement reservations. Existing implementation must checkpoint/converge and return control. If a writable Worker cannot return before it consumes the required-review tail, harvest its latest checkpoint first, then apply the existing lifecycle/writer-fence rules and review only a terminal or immutable harvested snapshot. Never let a moving writable workspace consume a tail already reserved for required review.
+At the effective general-work soft deadline, do not open new exploration/implementation work or create implementation/replan/replacement reservations. Existing implementation must checkpoint/converge and return control. If a writable Worker cannot return before it consumes the required-review tail, harvest its latest checkpoint first, then apply the existing lifecycle/writer-fence rules and review only a terminal or immutable harvested snapshot. Never let a moving writable workspace consume a tail already reserved for required review.
 
 Required completion is a separate phase consisting of the immutable plan's already-required read-only independent review plus Parent final verification. Before starting a reviewer Worker, query:
 
@@ -302,9 +312,9 @@ python3 ~/.codex/codex-flow/strategies/task_phase_runtime.py status \
   --now <unix-seconds>
 ```
 
-`required_completion` may start after the task soft/general-work deadline and remains permitted until the absolute task hard deadline. Soft convergence must therefore **never** silently skip an `independent+parent` or `strict` review that the immutable ExecutionPlan already requires. At the hard deadline, first harvest any received checkpoint, then apply lifecycle fencing/cancellation; no new reviewer, replacement Worker, or Parent writer may start. Parent may still report already-collected evidence, but the task hard deadline is the absolute execution stop.
+`required_completion` may start after the effective task soft/general-work deadline and remains permitted until the absolute task hard deadline. Soft convergence must therefore **never** silently skip an `independent+parent` or `strict` review that the immutable ExecutionPlan already requires. At the hard deadline, first harvest any received checkpoint, then apply lifecycle fencing/cancellation; no new reviewer, replacement Worker, or Parent writer may start. Parent may still report already-collected evidence, but the task hard deadline is the absolute execution stop.
 
-Exploration/review Workers consume wall time but do not consume implementation counters. After every join or wait, re-query the phase gate for the phase you intend to continue. At task completion, call the raw ledger `finish`. A replan reuses the original ledger/state path and remaining counters, never a fresh budget.
+Exploration/review Workers consume wall time but do not consume implementation counters. After every join or wait, re-query the phase gate for the phase you intend to continue. At task completion, call the raw ledger `finish`. A replan reuses the original ledger/state path and remaining counters, never a fresh budget or a newly initialized phase ledger.
 
 The task-budget helper is a durable ledger/decision boundary and the task-phase helper is an admission boundary; neither schedules Workers. FlowPilot/runtime performs checkpointing, harvesting, fencing, cancellation, spawning, and joins from their deterministic results. The lifecycle helper remains authoritative for Worker-level safety decisions.
 
@@ -556,7 +566,7 @@ Logical work-unit boundaries do not enlarge WorkerBudget. Reuse the same planned
 
 Do not send all bounded units to one Worker in a single “complete everything” handoff. That recreates the long transaction this policy is designed to avoid.
 
-Before every implementation spawn/replan/replacement, query `task_phase_runtime.py` with `phase=implementation` and perform the corresponding reservation through its `reserve` subcommand. `permits_phase_start=false` is binding even if the raw task ledger has not yet reached its ordinary soft deadline; the difference is the required-completion tail reserved by the immutable plan.
+Before every implementation spawn/replan/replacement, query `task_phase_runtime.py` with `phase=implementation` and perform the corresponding reservation through its `reserve` subcommand. `permits_phase_start=false` is binding; the effective ledger soft deadline already includes any required-completion tail reserved by phase-aware init.
 
 ## 8. Compact implementation handoff
 

--- a/templates/skills/flow-pilot/SKILL.md
+++ b/templates/skills/flow-pilot/SKILL.md
@@ -250,26 +250,28 @@ quality     4800..6000 / 6000..7200 1..4          units + 3                 3 / 
 
 The exact values come only from the current immutable ExecutionPlan. Never infer them from the strategy name and never substitute efficient's numbers for another strategy. When both are present, `task_budget.max_work_units` must equal `implementation_stage.maximum_work_units`.
 
-Immediately after the first plan is compiled, initialize the durable ledger **through the phase helper**, not through `task_budget_runtime.py init` directly:
+Immediately after the first plan is compiled, persist that exact plan JSON as the task's **initial budget plan** and initialize the durable ledger **through the phase helper**, not through `task_budget_runtime.py init` directly:
 
 ```bash
 python3 ~/.codex/codex-flow/strategies/task_phase_runtime.py init \
   --state-file <task-ledger-path> \
   --task-id <task-id> \
-  --plan-json '<immutable ExecutionPlan JSON>' \
+  --plan-json '<initial budget plan JSON>' \
   --now <unix-seconds>
 ```
 
-For a plan with reviewer Workers, phase-aware init deterministically derives an effective ledger policy whose soft timeout is:
+The initial budget plan is immutable for task-budget purposes. Every later `task_phase_runtime.py status` and `reserve` call for this task MUST keep passing that same initial budget plan JSON, including after a semantic re-profile/replan compiles a newer ExecutionPlan. The newer plan controls current topology, role resources, lifecycle, validation, and remaining-delta execution, but it never replaces, extends, or reinitializes the durable task budget. If the newer plan needs work outside the remaining original admission envelope, converge/fail closed rather than substituting the newer plan into the phase helper.
+
+For an initial budget plan with reviewer Workers, phase-aware init deterministically derives an effective ledger policy whose soft timeout is:
 
 ```text
 min(
-  ExecutionPlan.task_budget.soft_timeout_seconds,
-  ExecutionPlan.task_budget.hard_timeout_seconds - review_stage.hard_timeout_seconds
+  initial_budget_plan.task_budget.soft_timeout_seconds,
+  initial_budget_plan.task_budget.hard_timeout_seconds - initial_budget_plan.review_stage.hard_timeout_seconds
 )
 ```
 
-All counters and the absolute hard timeout remain unchanged. This derived soft timeout is the actual general-work admission boundary stored by the ledger, so the raw ledger preserves its own atomic limit checks and deadline-after-idempotent-replay semantics. `task_phase_runtime.py` also binds later status/reserve calls to that same effective policy fingerprint and refuses a different ExecutionPlan.
+All counters and the absolute hard timeout remain unchanged. This derived soft timeout is the actual general-work admission boundary stored by the ledger, so the raw ledger preserves its own atomic limit checks and deadline-after-idempotent-replay semantics. `task_phase_runtime.py` binds later status/reserve calls to that budget-policy identity and refuses a different budget plan. A running pre-phase ledger with the original policy fingerprint is grandfathered instead of being shortened retroactively.
 
 After initialization, **do not use the raw ledger `permits_new_work` flag as a Worker-spawn gate**. Every delegated phase must go through `task_phase_runtime.py`.
 
@@ -279,7 +281,7 @@ Before exploration or implementation admission:
 python3 ~/.codex/codex-flow/strategies/task_phase_runtime.py status \
   --state-file <task-ledger-path> \
   --task-id <task-id> \
-  --plan-json '<immutable ExecutionPlan JSON>' \
+  --plan-json '<initial budget plan JSON>' \
   --phase exploration|implementation \
   --now <unix-seconds>
 ```
@@ -290,7 +292,7 @@ Before each logical work-unit start, implementation attempt, replan, or replacem
 python3 ~/.codex/codex-flow/strategies/task_phase_runtime.py reserve \
   --state-file <task-ledger-path> \
   --task-id <task-id> \
-  --plan-json '<immutable ExecutionPlan JSON>' \
+  --plan-json '<initial budget plan JSON>' \
   --now <unix-seconds> \
   --kind work_unit|implementation_attempt|replan|replacement \
   --reservation-id <stable-id> \
@@ -301,20 +303,20 @@ For a bounded manifest, reserve `work_unit` with the validator's stable `logical
 
 At the effective general-work soft deadline, do not open new exploration/implementation work or create implementation/replan/replacement reservations. Existing implementation must checkpoint/converge and return control. If a writable Worker cannot return before it consumes the required-review tail, harvest its latest checkpoint first, then apply the existing lifecycle/writer-fence rules and review only a terminal or immutable harvested snapshot. Never let a moving writable workspace consume a tail already reserved for required review.
 
-Required completion is a separate phase consisting of the immutable plan's already-required read-only independent review plus Parent final verification. Before starting a reviewer Worker, query:
+Required completion is a separate phase consisting of the initial budget plan's already-required read-only independent review plus Parent final verification. Before starting a reviewer Worker, query:
 
 ```bash
 python3 ~/.codex/codex-flow/strategies/task_phase_runtime.py status \
   --state-file <task-ledger-path> \
   --task-id <task-id> \
-  --plan-json '<immutable ExecutionPlan JSON>' \
+  --plan-json '<initial budget plan JSON>' \
   --phase required_completion \
   --now <unix-seconds>
 ```
 
-`required_completion` may start after the effective task soft/general-work deadline and remains permitted until the absolute task hard deadline. Soft convergence must therefore **never** silently skip an `independent+parent` or `strict` review that the immutable ExecutionPlan already requires. At the hard deadline, first harvest any received checkpoint, then apply lifecycle fencing/cancellation; no new reviewer, replacement Worker, or Parent writer may start. Parent may still report already-collected evidence, but the task hard deadline is the absolute execution stop.
+`required_completion` may start after the effective task soft/general-work deadline and remains permitted until the absolute task hard deadline. Soft convergence must therefore **never** silently skip an `independent+parent` or `strict` review that the initial budget plan already requires. Parent should perform non-conflicting final verification while read-only reviewers run when possible, then reconcile their results before the hard boundary. At the hard deadline, first harvest any received checkpoint, then apply lifecycle fencing/cancellation; no new reviewer, replacement Worker, or Parent writer may start. Parent may still report already-collected evidence, but the task hard deadline is the absolute execution stop.
 
-Exploration/review Workers consume wall time but do not consume implementation counters. After every join or wait, re-query the phase gate for the phase you intend to continue. At task completion, call the raw ledger `finish`. A replan reuses the original ledger/state path and remaining counters, never a fresh budget or a newly initialized phase ledger.
+Exploration/review Workers consume wall time but do not consume implementation counters. After every join or wait, re-query the phase gate for the phase you intend to continue, always with the initial budget plan. At task completion, call the raw ledger `finish`. A replan reuses the original ledger/state path and remaining counters, never a fresh budget or a newly initialized phase ledger.
 
 The task-budget helper is a durable ledger/decision boundary and the task-phase helper is an admission boundary; neither schedules Workers. FlowPilot/runtime performs checkpointing, harvesting, fencing, cancellation, spawning, and joins from their deterministic results. The lifecycle helper remains authoritative for Worker-level safety decisions.
 
@@ -406,7 +408,7 @@ Meaningful-progress quality is observational and non-destructive. `activity_only
 
 `idle_timeout_seconds` is a renewable liveness lease. `soft_timeout_seconds` is an advisory checkpoint/convergence budget. `hard_timeout_seconds` is the absolute Worker wall-clock ceiling.
 
-The lifecycle helper is a deterministic evaluator, not a durable scheduler or checkpoint store. The separate task-budget helper is the durable cross-process ledger for task-level reservations; the task-phase helper derives phase admission and completion-tail reservation from the immutable plan. These helpers report decisions/requirements; the runtime must enforce cancellation, checkpoint harvest, writer fencing, and Worker scheduling.
+The lifecycle helper is a deterministic evaluator, not a durable scheduler or checkpoint store. The separate task-budget helper is the durable cross-process ledger for task-level reservations; the task-phase helper derives phase admission and completion-tail reservation from the immutable initial budget plan. These helpers report decisions/requirements; the runtime must enforce cancellation, checkpoint harvest, writer fencing, and Worker scheduling.
 
 **A `wait()` timeout is never a Worker timeout.** Repeated Parent waits without terminal output do not by themselves justify stalled/failed/cancelled.
 
@@ -508,7 +510,7 @@ Parent execution is fork/join, not fork/block: spawn planned Workers, continue n
 
 If `exploration_workers=0`, Parent performs targeted discovery and `exploration_stage` is none.
 
-Otherwise query the task-phase gate with `phase=exploration` before each planned spawn, then delegate exactly the permitted planned count to distinct bounded read-only questions, each with a unique `scope_id`. Respect `max_concurrent_threads` and role capability/model/reasoning. Do not collapse multiple planned explorers merely out of habit, and do not open a new explorer after general-work admission has closed.
+Otherwise query the task-phase gate with `phase=exploration` before each planned spawn, using the initial budget plan JSON, then delegate exactly the permitted planned count to distinct bounded read-only questions, each with a unique `scope_id`. Respect `max_concurrent_threads` and role capability/model/reasoning. Do not collapse multiple planned explorers merely out of habit, and do not open a new explorer after general-work admission has closed.
 
 Execute exploration join/cancellation/fallback only from `exploration_stage`. In particular, do not kill a Luna `xhigh/max` Explorer merely because it has taken multiple Parent wait intervals while continuing to read files, run commands, or produce other observable progress.
 
@@ -566,7 +568,7 @@ Logical work-unit boundaries do not enlarge WorkerBudget. Reuse the same planned
 
 Do not send all bounded units to one Worker in a single “complete everything” handoff. That recreates the long transaction this policy is designed to avoid.
 
-Before every implementation spawn/replan/replacement, query `task_phase_runtime.py` with `phase=implementation` and perform the corresponding reservation through its `reserve` subcommand. `permits_phase_start=false` is binding; the effective ledger soft deadline already includes any required-completion tail reserved by phase-aware init.
+Before every implementation spawn/replan/replacement, query `task_phase_runtime.py` with `phase=implementation` and perform the corresponding reservation through its `reserve` subcommand, always passing the initial budget plan rather than a later recompiled plan. `permits_phase_start=false` is binding; the effective ledger soft deadline already includes any required-completion tail reserved by phase-aware init.
 
 ## 8. Compact implementation handoff
 
@@ -635,7 +637,7 @@ Parent always reviews relevant diff, affected call sites, validation evidence, a
 - `review_mode=parent`: no reviewer Workers;
 - `review_mode=independent+parent`: spawn exactly `reviewer_workers` bounded independent reviewers, execute `review_stage`, then Parent final verification.
 
-Before any independent reviewer spawn, query the phase helper with `phase=required_completion`. A task soft/general-work deadline is **not** permission to skip the planned review; only the absolute task hard deadline closes required completion. Review a terminal workspace or immutable harvested snapshot, never a concurrently mutating writable scope. If the implementation phase reaches its completion handoff boundary with a non-terminal writer, harvest first and apply writer fencing/cancellation according to lifecycle before consuming the reserved review tail.
+Before any independent reviewer spawn, query the phase helper with `phase=required_completion`, passing the initial budget plan. A task soft/general-work deadline is **not** permission to skip the planned review; only the absolute task hard deadline closes required completion. Review a terminal workspace or immutable harvested snapshot, never a concurrently mutating writable scope. If the implementation phase reaches its completion handoff boundary with a non-terminal writer, harvest first and apply writer fencing/cancellation according to lifecycle before consuming the reserved review tail.
 
 Multiple reviewers get complementary scopes, not duplicated prompts. Reviewers are read-only and must not silently implement.
 
@@ -649,7 +651,7 @@ On implementation defect returned to Parent, send the smallest repair delta: exa
 
 Never exceed top-level `max_repair_cycles`. These cycles begin only after Implementer returned control and are separate from local Worker repair attempts.
 
-If repair fails or evidence materially changes the task, update TaskProfile and compile a new ExecutionPlan. Do not mutate old plan ad hoc.
+If repair fails or evidence materially changes the task, update TaskProfile and compile a new ExecutionPlan. Do not mutate old plan ad hoc. Keep the original initial budget plan and ledger for all task-phase admission/reservations; the new ExecutionPlan must fit inside their remaining envelope.
 
 Worker stall/failure/supersession, checkpoint handling, timeout fallback, unit joins, and remaining-delta replan do not themselves consume Parent repair cycles.
 
@@ -692,7 +694,7 @@ Re-profile and invoke planner again when:
 - Parent repair cycles fail;
 - reliable quota/runtime state materially changes.
 
-Replan from evaluator-provided scope, never original task by default. For `checkpoint_remaining_delta`, harvested checkpoint is authoritative boundary. For `uncovered_scope`, derive smallest still-uncovered scope. A new plan never overrides old writable-worker fencing or the existing durable task ledger.
+Replan from evaluator-provided scope, never original task by default. For `checkpoint_remaining_delta`, harvested checkpoint is authoritative boundary. For `uncovered_scope`, derive smallest still-uncovered scope. A new plan never overrides old writable-worker fencing or the existing durable task ledger. It also never replaces the initial budget plan passed to `task_phase_runtime.py`; all phase admission and cumulative reservations remain bound to the initial budget plan for this task.
 
 Completed bounded units remain prior evidence across replan unless concrete new evidence invalidates them. Do not restart already accepted units merely because a later unit failed.
 
@@ -708,4 +710,4 @@ fanout = auto
 quality_intent = normal
 ```
 
-Persistent policy remains schema v4. ExecutionPlan schema v10 adds optional task-level cumulative budget and reasoning-rollout decision fields alongside StagePolicy convergence/repair/work-unit/checkpoint-rearm fields. Older plans without `task_budget`, `reasoning_rollout`, `soft_timeout_seconds`, meaningful-progress/checkpoint state, `checkpoint_rearm_seconds`, `max_worker_repair_attempts`, or work-unit fields retain historical behavior for that run. In particular, missing checkpoint-rearm policy is safe one-shot behavior and absent task-budget/work-unit/rollout fields resolve to the legacy path; updates must not retroactively split, cancel, change reasoning, reserve completion tail, or reset already-running Workers.
+Persistent policy remains schema v4. ExecutionPlan schema v10 adds optional task-level cumulative budget and reasoning-rollout decision fields alongside StagePolicy convergence/repair/work-unit/checkpoint-rearm fields. Older plans without `task_budget`, `reasoning_rollout`, `soft_timeout_seconds`, meaningful-progress/checkpoint state, `checkpoint_rearm_seconds`, `max_worker_repair_attempts`, or work-unit fields retain historical behavior for that run. In particular, missing checkpoint-rearm policy is safe one-shot behavior and absent task-budget/work-unit/rollout fields resolve to the legacy path; updates must not retroactively split, cancel, change reasoning, reserve completion tail, or reset already-running Workers. Existing pre-phase ledgers with the initial plan's original task-budget fingerprint remain `legacy_unclamped` rather than being rewritten to the new effective soft deadline.

--- a/templates/skills/flow-pilot/SKILL.md
+++ b/templates/skills/flow-pilot/SKILL.md
@@ -1,25 +1,21 @@
 ---
 name: flow-pilot
-description: Profile non-trivial technical work, compile a deterministic ExecutionPlan through the codex-flow strategy runtime, then execute parent/worker/review/repair and asynchronous worker lifecycle exactly from that plan while honoring current-task and repository policy.
+description: Profile non-trivial technical work, compile a deterministic ExecutionPlan through codex-flow, and execute its worker, lifecycle, task-budget, review, and validation contracts exactly.
 ---
 
 # FlowPilot Strategy Runtime
 
 FlowPilot is the semantic profiler and execution runtime for codex-flow. It is **not** a second strategy engine.
 
-The invariant is:
-
 > **FlowPilot profiles. `strategy_runtime.py` + the strategy registry decide. FlowPilot executes the returned plan.**
 
-Do not independently re-implement strategy topology, capability selection, reasoning selection, quota policy, worker counts, review mode, fan-out, lifecycle/join policy, cancellation policy, fallback policy, local repair budget, task budget, task-phase admission, or implementation work-unit policy in this skill. The installed planner and built-in strategy registry are the single source of truth for those decisions. Hard Worker lifecycle safety invariants are evaluated by the installed deterministic lifecycle helper; bounded implementation manifests are validated by the installed deterministic work-unit helper; cumulative task counters live in the task-budget ledger; phase-aware admission is evaluated by the installed task-phase helper.
+Do not independently re-implement strategy topology, capability selection, reasoning selection, quota policy, Worker counts, review mode, fan-out, lifecycle policy, local repair budget, task budget, phase admission, or implementation work-unit policy. The installed planner and deterministic runtime helpers are authoritative.
 
-Default compatibility remains `strategy = efficient` plus `routing = adaptive`.
+Default policy remains `strategy=efficient` with `routing=adaptive`.
 
-## 0. Policy precedence and current-task intent
+## 0. Strategy gate and precedence
 
-### Global strategy master switch
-
-Before TaskProfile construction or any automatic Worker delegation, read the installed global strategy state:
+Before automatic FlowPilot delegation, read the installed strategy state:
 
 ```bash
 python3 ~/.codex/codex-flow/strategy_runtime.py \
@@ -27,7 +23,7 @@ python3 ~/.codex/codex-flow/strategy_runtime.py \
   show --json
 ```
 
-If the returned `enabled` field is `true`, consume any armed one-shot bypass before TaskProfile construction:
+If enabled, atomically consume any one-shot bypass:
 
 ```bash
 python3 ~/.codex/codex-flow/strategy_runtime.py \
@@ -35,99 +31,60 @@ python3 ~/.codex/codex-flow/strategy_runtime.py \
   consume-bypass
 ```
 
-If that command prints `true`, **stop FlowPilot strategy processing for this task only** and continue with ordinary Codex execution. The token is consumed atomically; concurrent tasks cannot both claim the same temporary bypass. The persistent global master switch remains enabled and the following task returns to normal strategy processing.
+If that prints `true`, bypass FlowPilot for this task only. If `enabled=false`, do not build a FlowPilot TaskProfile or compile an ExecutionPlan; continue with ordinary Codex execution. Repository policy and task overrides cannot re-enable a disabled global switch.
 
-If `enabled=false`, stop FlowPilot strategy processing for this task:
-
-- do not build a FlowPilot TaskProfile;
-- do not compile an ExecutionPlan;
-- do not apply codex-flow strategy, routing, modifier, WorkerBudget, lifecycle, repair, or role-capability decisions;
-- do not automatically spawn/delegate Workers on behalf of FlowPilot;
-- continue with ordinary Codex execution using the active Codex runtime/configuration.
-
-The switch disables codex-flow automatic distribution, not Codex's native Agent capability. Explicit user requests to use native subagents outside FlowPilot may still be honored when appropriate.
-
-`[strategy].enabled` is a global master gate. Repository policy and current-task overrides cannot re-enable it. Missing `enabled` in an older policy resolves to `true` for compatibility.
-
-When enabled, planner precedence is:
+Policy precedence is:
 
 ```text
 hard runtime / safety ceilings
   > explicit current-task overrides
   > repository .codex-flow.toml
   > ~/.codex/codex-flow.toml
-  > codex-flow release defaults
+  > release defaults
 ```
-
-Repository policy may choose strategy/routing/modifiers, tighten runtime ceilings, and raise reasoning floors. It must not silently lower user reasoning floors.
 
 Persistent dimensions are independent:
 
-- `[strategy].profile`: `efficient`, `balanced`, `quality`, `speed`;
-- `[routing].mode`: `adaptive`, `direct`, `delegate`;
-- `[modifiers].review`: `auto`, `standard`, `strict`;
-- `[modifiers].fanout`: `auto`, `conservative`, `aggressive`.
+- strategy: `efficient | balanced | quality | speed`
+- routing: `adaptive | direct | delegate`
+- review: `auto | standard | strict`
+- fanout: `auto | conservative | aggressive`
 
-Explicit current-task intent overrides those dimensions for that task only and must not mutate persistent policy.
+`direct` — do not spawn or delegate to subagents for this task.
 
-Routing:
+`delegate` — use subagent delegation for execution when the runtime supports it and safe scoping is possible.
 
-- `direct` — do not spawn or delegate to subagents for this task.
-- `delegate` — use subagent delegation for execution when the runtime supports it and safe scoping is possible.
-- `adaptive` — let the deterministic planner choose direct or delegated execution from the TaskProfile.
+`adaptive` — let the deterministic planner choose from the TaskProfile.
 
-Strategies:
-
-- `efficient`: minimize expensive Parent use and total waste while moving deep execution loops to efficient Workers;
-- `balanced`: balance quality, quota, and wall-clock latency;
-- `quality`: prioritize correctness, deeper verification, and higher-value capability where explicit quality intent warrants it;
-- `speed`: minimize wall-clock latency by saturating proven-safe concurrency.
-
-Strategy and routing are orthogonal. Modifiers do not create new strategy names.
+Strategy and routing are orthogonal.
 
 ## 1. Build only the semantic TaskProfile
 
-Before broad execution classify:
+Profile the task before broad execution:
 
 ```text
-TaskProfile
-  complexity: small | routine | complex | critical
-  uncertainty: low | medium | high
-  risk: low | medium | high | critical
-  scope: local | module | cross-module | repo-wide
-  parallelism: none | limited | high
-  write_conflict: low | high
-  exploration_need: low | medium | high
-  verification_cost: low | medium | high
-  iteration_intensity: one-shot | iterative | heavy-loop
-  writable_workstreams: positive integer
-  quality_intent: normal | strong | absolute
+complexity: small | routine | complex | critical
+uncertainty: low | medium | high
+risk: low | medium | high | critical
+scope: local | module | cross-module | repo-wide
+parallelism: none | limited | high
+write_conflict: low | high
+exploration_need: low | medium | high
+verification_cost: low | medium | high
+iteration_intensity: one-shot | iterative | heavy-loop
+writable_workstreams: positive integer
+quality_intent: normal | strong | absolute
 ```
 
-`writable_workstreams` is the count of **already proven isolated, non-overlapping writable scopes/worktrees**. Default to `1`; never claim `2+` merely because parallel writes would be faster.
+`writable_workstreams` counts already-proven isolated writable scopes/worktrees. Default to `1`; never invent extra writable streams merely to gain concurrency.
 
-`quality_intent` is current-task intent, independent of technical risk:
+`quality_intent` is user intent, not risk. `strong` and `absolute` require explicit preference for correctness/quality over ordinary quota or latency.
 
-- `normal`: ordinary expectations;
-- `strong`: explicit quality/correctness preference over ordinary cost efficiency;
-- `absolute`: explicit highest-practical-quality intent with materially higher cost/latency accepted.
+Re-profile only when material evidence changes scope, risk, uncertainty, isolation, iteration intensity, or explicit quality intent.
 
-Do not infer strong/absolute from generic wording such as “careful” or “good”. Do not convert quality intent into critical risk.
+## 2. Compile the authoritative plan
 
-Guidance:
-
-- `small`: obvious localized low-risk work;
-- `routine`: clear implementation path and ordinary validation;
-- `complex`: architecture/debugging/refactor/migration/cross-system uncertainty;
-- `critical`: security, destructive/data-integrity, production-critical, or repeated-failure work;
-- `parallelism=none`: no planner-created parallel Workers;
-- `write_conflict=high`: writable work is not safe to fan out.
-
-Re-profile only when material evidence changes risk, scope, uncertainty, parallelism, workstream isolation, iteration intensity, or explicit quality intent.
-
-## 2. Compile the authoritative ExecutionPlan
-
-Invoke the installed deterministic planner before broad execution:
+Invoke:
 
 ```bash
 python3 ~/.codex/codex-flow/strategy_runtime.py \
@@ -146,7 +103,7 @@ python3 ~/.codex/codex-flow/strategy_runtime.py \
   --quality-intent normal|strong|absolute
 ```
 
-For explicit current-task overrides append only requested dimensions:
+Task-only overrides may append:
 
 ```text
 --profile efficient|balanced|quality|speed
@@ -156,17 +113,15 @@ For explicit current-task overrides append only requested dimensions:
 --efficient-reasoning legacy|shadow|adaptive
 ```
 
-The planner merges release/user/repository policy, loads the selected strategy, resolves WorkerBudget, computes topology, resolves StagePolicy and task budget, chooses per-role capability/reasoning, applies runtime ceilings and writable-isolation checks, reads reliable quota state when available, and emits one ExecutionPlan without extra LLM calls.
+If the planner/registry is unavailable, treat that as an installation/runtime failure. Do not reconstruct its policy from this skill.
 
-If planner/registry is unavailable, treat it as installation/runtime failure. Do not reconstruct strategy logic from this file.
+## 3. ExecutionPlan is the hard boundary
 
-## 3. ExecutionPlan is the hard strategy/runtime boundary
-
-Current contract (schema v10):
+Current contract (schema v11):
 
 ```text
 ExecutionPlan
-  schema_version
+  schema_version = 11
   strategy
   routing
   review_modifier
@@ -176,20 +131,14 @@ ExecutionPlan
   parent_model_floor
   parent_reasoning
   reasoning_rollout | none
-    mode: legacy | shadow | adaptive
+    mode
     legacy_worker_reasoning
     proposed_worker_reasoning
     selected_worker_reasoning
     applied
-  explorer_capability_policy | none
-  explorer_model | none
-  explorer_reasoning | none
-  implementer_capability_policy | none
-  implementer_model | none
-  implementer_reasoning | none
-  reviewer_capability_policy | none
-  reviewer_model | none
-  reviewer_reasoning | none
+  explorer_capability_policy/model/reasoning | none
+  implementer_capability_policy/model/reasoning | none
+  reviewer_capability_policy/model/reasoning | none
   worker_budget
   task_budget | none
     soft_timeout_seconds
@@ -198,6 +147,8 @@ ExecutionPlan
     max_implementation_attempts
     max_replans
     max_replacements
+    max_review_attempts
+    parent_finalization_seconds
   exploration_workers
   implementation_workers
   reviewer_workers
@@ -212,7 +163,7 @@ ExecutionPlan
     soft_timeout_seconds | none
     checkpoint_rearm_seconds | none
     max_worker_repair_attempts | none
-    work_unit_mode: single | bounded
+    work_unit_mode
     minimum_work_units
     join_between_work_units
     maximum_work_units | none
@@ -230,207 +181,153 @@ ExecutionPlan
   notes
 ```
 
-`implementation_stage.max_worker_repair_attempts` bounds local Implementer validation/fix loops and is independent from top-level Parent `max_repair_cycles`.
+Direct plans emit `task_budget=null` and no delegated stages. Delegated built-in strategies emit one canonical `task_budget`; there is no second effective budget.
 
-`implementation_stage.work_unit_mode=bounded` is binding. `minimum_work_units` is the minimum number of logical acceptance-bounded implementation transactions and may be 1. Default to one unit; split only when every split has an independent acceptance delta, validation boundary, and ownership/dependency evidence. `maximum_work_units`, when present, is a hard manifest count bound and must be at least the minimum. `join_between_work_units=true` means control must return to Parent after each completed unit before a dependent next unit begins. These fields do **not** authorize extra writable concurrency. `require_write_paths=true` opts a new bounded policy into generation and normalized repository-relative `write_paths` validation.
-
-### Task-level cumulative budget and phase-aware admission
-
-`task_budget` is a strategy-owned cumulative contract for delegated built-in strategy work. It is separate from `StagePolicy`: stage fields describe one Worker stage, while task reservations live in a durable ledger and are never reset by a replan or a new process. Direct plans emit `task_budget=null`.
-
-Current built-in policy envelopes are strategy-specific:
+For delegated implementation:
 
 ```text
-strategy    task soft/hard        work units      implementation attempts   replans/replacements
-efficient   1500 / 1800           1..3            units + 1                 1 / 1
-speed       1200 / 1800           1..4            units + 1                 1 / 1
-balanced    2400..3000 / 3000..3600 1..3          units + 2                 2 / 2
-quality     4800..6000 / 6000..7200 1..4          units + 3                 3 / 3
+implementation_workers <= task_budget.max_work_units
+implementation_workers <= task_budget.max_implementation_attempts
+implementation_stage.maximum_work_units == task_budget.max_work_units
 ```
 
-The exact values come only from the current immutable ExecutionPlan. Never infer them from the strategy name and never substitute efficient's numbers for another strategy. When both are present, `task_budget.max_work_units` must equal `implementation_stage.maximum_work_units`.
+The compiler enforces these invariants. Do not locally raise topology or counters.
 
-Immediately after the first plan is compiled, persist that exact plan JSON as the task's **initial budget plan** and initialize the durable ledger **through the phase helper**, not through `task_budget_runtime.py init` directly:
+## 4. Canonical task budget and phase admission
+
+Immediately after the **initial** delegated ExecutionPlan is compiled, persist that exact plan JSON as the task's initial budget plan and initialize through the phase helper:
 
 ```bash
 python3 ~/.codex/codex-flow/strategies/task_phase_runtime.py init \
   --state-file <task-ledger-path> \
   --task-id <task-id> \
-  --plan-json '<initial budget plan JSON>' \
+  --plan-json '<initial ExecutionPlan JSON>' \
   --now <unix-seconds>
 ```
 
-The initial budget plan is immutable for task-budget purposes. Every later `task_phase_runtime.py status` and `reserve` call for this task MUST keep passing that same initial budget plan JSON, including after a semantic re-profile/replan compiles a newer ExecutionPlan. The newer plan controls current topology, role resources, lifecycle, validation, and remaining-delta execution, but it never replaces, extends, or reinitializes the durable task budget. If the newer plan needs work outside the remaining original admission envelope, converge/fail closed rather than substituting the newer plan into the phase helper.
+The initial budget-plan identity is immutable for the task. A later semantic re-profile may compile another ExecutionPlan for current topology/lifecycle decisions, but it must not reset, replace, or extend the original task ledger. All phase status/reservation calls continue to pass the initial budget plan.
 
-For an initial budget plan with reviewer Workers, phase-aware init deterministically derives an effective ledger policy whose soft timeout is:
+The canonical task timeline is:
 
 ```text
-min(
-  initial_budget_plan.task_budget.soft_timeout_seconds,
-  initial_budget_plan.task_budget.hard_timeout_seconds - initial_budget_plan.review_stage.hard_timeout_seconds
-)
+started_at
+  |
+  | general exploration / writable implementation
+  v
+soft_deadline == general_work_deadline
+  |
+  | required read-only review, when planned
+  v
+review_deadline == hard_deadline - parent_finalization_seconds
+  |
+  | Parent finalization only
+  v
+hard_deadline == absolute task execution stop
 ```
 
-All counters and the absolute hard timeout remain unchanged. This derived soft timeout is the actual general-work admission boundary stored by the ledger, so the raw ledger preserves its own atomic limit checks and deadline-after-idempotent-replay semantics. `task_phase_runtime.py` binds later status/reserve calls to that budget-policy identity and refuses a different budget plan. A running pre-phase ledger with the original policy fingerprint is grandfathered instead of being shortened retroactively.
+The compiler has already made `hard_timeout_seconds` large enough to contain any planned review-stage hard window plus `parent_finalization_seconds`; the phase helper validates this rather than deriving another budget.
 
-After initialization, **do not use the raw ledger `permits_new_work` flag as a Worker-spawn gate**. Every delegated phase must go through `task_phase_runtime.py`.
-
-Before exploration or implementation admission:
+Before exploration or implementation continuation:
 
 ```bash
 python3 ~/.codex/codex-flow/strategies/task_phase_runtime.py status \
   --state-file <task-ledger-path> \
   --task-id <task-id> \
-  --plan-json '<initial budget plan JSON>' \
+  --plan-json '<initial ExecutionPlan JSON>' \
   --phase exploration|implementation \
   --now <unix-seconds>
 ```
 
-Before each logical work-unit start, implementation attempt, replan, or replacement, reserve through the phase helper rather than calling the raw ledger reserve command directly:
+Before each logical unit, implementation attempt, replan, or implementation replacement:
 
 ```bash
 python3 ~/.codex/codex-flow/strategies/task_phase_runtime.py reserve \
   --state-file <task-ledger-path> \
   --task-id <task-id> \
-  --plan-json '<initial budget plan JSON>' \
-  --now <unix-seconds> \
+  --plan-json '<initial ExecutionPlan JSON>' \
+  --phase implementation \
   --kind work_unit|implementation_attempt|replan|replacement \
   --reservation-id <stable-id> \
-  --fingerprint <stable-fingerprint>
+  --fingerprint <stable-fingerprint> \
+  --now <unix-seconds>
 ```
 
-For a bounded manifest, reserve `work_unit` with the validator's stable `logical_unit_fingerprints[unit_id]`, which excludes generation. Reserve `implementation_attempt` with the generation-aware `unit_fingerprints[unit_id]` and an identity derived from `(scope_id, unit_id, generation)`. A replacement therefore consumes a new implementation attempt/replacement reservation without double-counting the same logical work unit; changing acceptance/scope/path/validation under the same logical unit still fails closed. Exact idempotent replay remains valid even after the general-work deadline; a genuinely new reservation is rejected.
+At `soft_deadline`, genuinely new general-work reservations stop. Exact durable-ledger replay of an already-recorded general reservation remains idempotent and is not new work. Existing writable work must checkpoint/converge rather than silently opening another attempt.
 
-At the effective general-work soft deadline, do not open new exploration/implementation work or create implementation/replan/replacement reservations. Existing implementation must checkpoint/converge and return control. If a writable Worker cannot return before it consumes the required-review tail, harvest its latest checkpoint first, then apply the existing lifecycle/writer-fence rules and review only a terminal or immutable harvested snapshot. Never let a moving writable workspace consume a tail already reserved for required review.
-
-Required completion is a separate phase consisting of the initial budget plan's already-required read-only independent review plus Parent final verification. Before starting a reviewer Worker, query:
+If the plan has reviewers, required completion starts after general-work convergence. Query:
 
 ```bash
 python3 ~/.codex/codex-flow/strategies/task_phase_runtime.py status \
   --state-file <task-ledger-path> \
   --task-id <task-id> \
-  --plan-json '<initial budget plan JSON>' \
+  --plan-json '<initial ExecutionPlan JSON>' \
   --phase required_completion \
   --now <unix-seconds>
 ```
 
-`required_completion` may start after the effective task soft/general-work deadline and remains permitted until the absolute task hard deadline. Soft convergence must therefore **never** silently skip an `independent+parent` or `strict` review that the initial budget plan already requires. Parent should perform non-conflicting final verification while read-only reviewers run when possible, then reconcile their results before the hard boundary. At the hard deadline, first harvest any received checkpoint, then apply lifecycle fencing/cancellation; no new reviewer, replacement Worker, or Parent writer may start. Parent may still report already-collected evidence, but the task hard deadline is the absolute execution stop.
+Before every reviewer Worker start or retry, reserve:
 
-Exploration/review Workers consume wall time but do not consume implementation counters. After every join or wait, re-query the phase gate for the phase you intend to continue, always with the initial budget plan. At task completion, call the raw ledger `finish`. A replan reuses the original ledger/state path and remaining counters, never a fresh budget or a newly initialized phase ledger.
-
-The task-budget helper is a durable ledger/decision boundary and the task-phase helper is an admission boundary; neither schedules Workers. FlowPilot/runtime performs checkpointing, harvesting, fencing, cancellation, spawning, and joins from their deterministic results. The lifecycle helper remains authoritative for Worker-level safety decisions.
-
-### Efficient reasoning rollout
-
-The optional `[reasoning.rollout]` policy applies only when the compiled plan is
-`strategy=efficient` and `routing=delegate` with delegated Worker roles. Its
-release defaults are:
-
-```text
-mode=shadow
-minimum=high, routine=high, complex=xhigh, critical=max
+```bash
+python3 ~/.codex/codex-flow/strategies/task_phase_runtime.py reserve \
+  --state-file <task-ledger-path> \
+  --task-id <task-id> \
+  --plan-json '<initial ExecutionPlan JSON>' \
+  --phase required_completion \
+  --kind review_attempt \
+  --reservation-id <stable-review-attempt-id> \
+  --fingerprint <stable-review-fingerprint> \
+  --now <unix-seconds>
 ```
 
-`legacy` is the kill switch: the current Worker reasoning selection remains
-unchanged. `shadow` also selects the legacy effort, while exposing a proposed
-effort in `ExecutionPlan.reasoning_rollout`. `adaptive` selects the proposal.
-The proposal is computed after the existing legacy selection as:
+`max_review_attempts` counts reviewer starts/retries independently of implementation replans/replacements.
+
+The phase result is binding:
+
+- `permits_general_work`: new exploration/writable implementation may start.
+- `permits_review_start`: a new read-only reviewer may start.
+- `permits_parent_finalization`: Parent may continue final reconciliation/verification before hard.
+- `review_deadline`: no new reviewer starts at or after this boundary.
+- `action=finalize_parent`: reviewer admission is closed; use the remaining tail only for Parent finalization.
+- `action=stop`: task hard deadline/closed state reached; do not start new execution.
+
+A soft deadline must never silently skip an independent/strict review already required by the initial plan. A reviewer must never consume the Parent finalization reserve.
+
+The raw task-budget helper is the durable atomic ledger. The phase helper is the scheduling admission boundary. Neither schedules Workers by itself.
+
+## 5. Worker lifecycle
+
+Lifecycle comes from the relevant StagePolicy, not Parent heuristics. Track stable lineage:
 
 ```text
-max(rollout class target, rollout minimum, parent_reasoning)
+(scope_id, generation)
+(scope_id, unit_id, generation) for bounded implementation
 ```
 
-The selected effort is written consistently to every planned
-`explorer_reasoning`, `implementer_reasoning`, and `reviewer_reasoning` field;
-direct plans and non-efficient strategies emit `reasoning_rollout=null` and
-retain their existing behavior. Adaptive explicitly permits the selected
-Worker effort to equal Parent at the `max` ceiling.
+Replacement/replan increments generation. Checkpoint/continue does not.
 
-User rollout floors are persistent optional policy. Repository policy may raise
-the rollout minimum/class floors, but cannot change a user's `legacy` or
-`shadow` mode to `adaptive`. `--efficient-reasoning legacy|shadow|adaptive` is
-a current-task override and does not mutate policy.
+Track when evidence exists:
 
-The decision is intent, not an observation: `proposed_worker_reasoning` and
-`selected_worker_reasoning` do not prove what the runtime actually applied. If
-the active Codex build cannot apply a per-spawn effort override, use the
-installed Worker baseline and report that limitation; later telemetry may
-record the observed effective effort. This helper does not schedule Workers or
-collect telemetry.
+- `last_progress_at`: liveness/tool/in-flight activity.
+- `last_meaningful_progress_at`: acceptance-relevant delta, validation change, concrete blocker reduction, or bounded-scope completion.
 
-Once compiled, execute the plan. Prohibited duplication includes:
+Do not mark repeated unchanged reads/tests/heartbeats as meaningful progress.
 
-- adding Workers/reviewers beyond planner topology because a strategy name suggests it;
-- changing role model/reasoning locally;
-- treating WorkerBudget maxima as mandatory counts;
-- inventing lifecycle timeout/retry/cancellation rules;
-- terminating a non-terminal Worker because `wait()` returned without a final result;
-- expanding local Worker repair attempts or Parent repair cycles beyond the plan;
-- collapsing a plan with multiple evidenced bounded units back into one giant implementation transaction;
-- converting bounded logical units into parallel writers unless the existing plan already proves distinct writable workstreams;
-- replacing `direct` with delegation because delegation seems useful.
+`idle_timeout_seconds` is a renewable liveness lease. `soft_timeout_seconds` is an advisory checkpoint/convergence boundary. `hard_timeout_seconds` is the Worker wall-clock ceiling.
 
-If requested per-spawn model/capability override is unsupported, use installed baseline, preserve topology/lifecycle/work-unit/repair semantics, and report the limitation.
+**A `wait()` timeout is never a Worker timeout.**
 
-## 4. Parent owns semantic decisions
-
-Parent owns root cause/architecture, scope/non-goals, compatibility constraints, implementation sequence, risks, acceptance criteria, TaskProfile construction, and bounded-unit partitioning when required by the plan.
-
-Parent should spend reasoning on high-value semantic decisions rather than duplicating Worker loops. Delegated Workers intentionally run with deeper reasoning than Parent by default because the efficient Worker model is cheaper. Parent=max is the top-tier exception where Worker cannot exceed max.
-
-Capability and reasoning are independent. `Luna max` is not automatically Parent-class capability.
-
-## 5. Async Worker lifecycle and progress tracking
-
-Lifecycle comes from ExecutionPlan, not Parent heuristics. Every Worker gets a stable bounded lineage before spawn: `(scope_id, unit_id, generation)` for bounded implementation units, or `(scope_id, generation)` for legacy/single work. A replacement Worker or replan increments `generation`; checkpoint/continue of the same unit does not. Parent accepts result evidence only for the current generation.
-
-Semantic states:
-
-```text
-queued
-running
-progressing
-completed
-stalled
-failed
-superseded
-cancelled
-```
-
-Track independently when reliable evidence exists:
-
-- `last_progress_at`: liveness activity; tool/command/search/file-read/in-flight activity may renew it;
-- `last_meaningful_progress_at`: acceptance-relevant delta; advance only for new evidence, code/output change, validation-state change, bounded-scope completion, or a concrete blocker narrowing remaining work.
-
-Do not advance meaningful progress for repeated unchanged search/read/test loops or heartbeat chatter.
-
-Meaningful-progress quality is observational and non-destructive. `activity_only` does not authorize cancellation. Existing liveness lease and hard ceiling remain safety boundaries.
-
-`idle_timeout_seconds` is a renewable liveness lease. `soft_timeout_seconds` is an advisory checkpoint/convergence budget. `hard_timeout_seconds` is the absolute Worker wall-clock ceiling.
-
-The lifecycle helper is a deterministic evaluator, not a durable scheduler or checkpoint store. The separate task-budget helper is the durable cross-process ledger for task-level reservations; the task-phase helper derives phase admission and completion-tail reservation from the immutable initial budget plan. These helpers report decisions/requirements; the runtime must enforce cancellation, checkpoint harvest, writer fencing, and Worker scheduling.
-
-**A `wait()` timeout is never a Worker timeout.** Repeated Parent waits without terminal output do not by themselves justify stalled/failed/cancelled.
-
-If intermediate activity is unreliable, do not guess. Omit `--last-meaningful-progress-at`; legacy behavior may treat `last_progress_at` as meaningful for progress classification and the first soft checkpoint, but it never uses that fallback to re-arm a harvested multi-round checkpoint.
-
-### Deterministic lifecycle evaluator
-
-Use Unix seconds and invoke:
+Use the deterministic evaluator:
 
 ```bash
 python3 ~/.codex/codex-flow/strategies/lifecycle_runtime.py \
-  --policy-json '<relevant StagePolicy JSON>' \
+  --policy-json '<StagePolicy JSON>' \
   --scope-id <scope-id> \
   --stage exploration|implementation|review \
   --started-at <unix-seconds> \
   --last-progress-at <unix-seconds> \
   [--last-meaningful-progress-at <unix-seconds>] \
-  [--checkpoint-requested-at <unix-seconds>] \
-  [--checkpoint-received-at <unix-seconds>] \
-  [--checkpoint-harvested-at <unix-seconds>] \
-  [--generation <non-negative-int>] \
   [--checkpoint-sequence-json <json-array>] \
+  [--generation <non-negative-int>] \
   --now <unix-seconds> \
   [--writable] [--in-flight] \
   [--terminal-success] [--terminal-failure] \
@@ -438,31 +335,28 @@ python3 ~/.codex/codex-flow/strategies/lifecycle_runtime.py \
   [--replacement-isolated]
 ```
 
-Use returned `state`, `action`, `cancel_required`, `replacement_allowed`, `fence_required`, `progress_quality`, `meaningful_idle_seconds`, `checkpoint_status`, `replan_scope`, `checkpoint_reuse_mode`, and `fallback_policy` exactly.
+Use returned `state`, `action`, `cancel_required`, `replacement_allowed`, `fence_required`, `progress_quality`, checkpoint fields, `replan_scope`, `checkpoint_reuse_mode`, and `fallback_policy` exactly.
 
-The legacy checkpoint flags remain supported and normalize to sequence 1. Do not mix them with `--checkpoint-sequence-json`; sequence records must be contiguous within the current generation, and only the latest may be unharvested. Replacement/replan starts generation+1 with sequence reset. Decisions also expose `checkpoint_generation`, latest `checkpoint_sequence` (0 when absent), `harvested_checkpoint_sequence` (0 when absent), and `next_checkpoint_sequence` only for `request_checkpoint`, plus `checkpoint_rearm_at` and `checkpoint_rearm_remaining_seconds` when a policy cooldown is configured.
+### Checkpoints
 
-Checkpoint state is monotonic within each sequence; globally `checkpoint_status` reports the latest sequence, so a new sequence transitions from the prior harvested state back to requested:
+Checkpoint sequence state is:
 
 ```text
 not_requested -> requested -> received -> harvested
 ```
 
-Record timestamps only after real events.
-
 Soft-budget actions:
 
-- `request_checkpoint`: ask the existing Worker for a non-terminal checkpoint; do not cancel or add a writer;
-- `await_checkpoint`: request is already outstanding; do not spam;
-- `harvest_checkpoint`: preserve returned payload before anything that could discard partial work;
-- `continue` with harvested checkpoint: existing Worker continues its assigned scope/unit until completion or a real lifecycle boundary;
-- after a harvest, request the next sequence only when the Worker explicitly reports `last_meaningful_progress_at` later than the latest harvest, `checkpoint_rearm_seconds` has elapsed, and the soft budget is reached; `last_progress_at` activity alone never re-arms it. Without the explicit timestamp or cooldown policy, continue as a one-shot/legacy plan without repeating the request.
+- `request_checkpoint`: ask the same Worker for a non-terminal checkpoint.
+- `await_checkpoint`: do not spam another request.
+- `harvest_checkpoint`: persist returned partial work before any destructive boundary.
+- after a harvest, re-arm only when explicit acceptance-relevant progress occurred after the harvest and `checkpoint_rearm_seconds` elapsed.
 
-Implementation checkpoint payload must include:
+Implementation checkpoint payload must carry enough evidence to continue safely:
 
 ```text
 scope_id / unit_id when bounded
-status: progressing | blocked | ready
+status
 completed
 changed_files/current_patch_state
 validation
@@ -471,54 +365,49 @@ remaining_delta
 workspace_state
 ```
 
-Checkpoint is not completion. Never reset/revert/clean/stash/discard work merely to checkpoint. If required fields are missing, request correction from the same Worker; do not fabricate empty remaining delta.
+Checkpoint is not completion. Never discard/reset/stash work merely to checkpoint.
 
-**Harvest-before-fallback invariant:** a returned but unharvested checkpoint outranks terminal failure, idle fallback, hard timeout, cancellation handling, and writer replacement. Preserve it first, then re-evaluate lifecycle with the real harvested timestamp.
-
-This precedence also applies when the Worker reports terminal success in the same observation: `checkpoint_status=received` must return `harvest_checkpoint` before `consume_result`. A requested checkpoint without a returned payload does not postpone hard/idle fallback.
+**Harvest-before-fallback invariant:** a received but unharvested checkpoint outranks terminal failure, idle fallback, hard timeout, cancellation handling, and writer replacement. Harvest it first, then re-evaluate.
 
 ### Remaining-delta replan
 
-Fallback always operates on the missing delta, never by restarting the whole stage:
+Fallback always operates on the missing delta, never by restarting the whole stage.
 
-When `fallback_policy=replan`, obey evaluator `replan_scope`:
+For implementation `fallback_policy=replan`:
 
-- `uncovered_scope`: replan only demonstrably uncovered scope, never automatically the full original task;
-- `checkpoint_remaining_delta`: build the replacement handoff from harvested `remaining_delta` only; carry completed work, patch state, prior validation, and blockers as evidence.
+- `uncovered_scope`: replan only demonstrably uncovered scope.
+- `checkpoint_remaining_delta`: use harvested `remaining_delta` plus completed/patch/validation/blocker evidence.
+- `retained_workspace`: only after the old writer is terminal/cancelled.
+- `harvested_snapshot_only`: isolated replacement consumes the immutable harvested snapshot and fences later old-worker output.
 
-For checkpoint-based replan, `checkpoint_reuse_mode` is binding:
+Completed accepted work is reopened only with concrete invalidating evidence.
 
-- `retained_workspace`: after old writer terminal/cancelled, preserve current workspace/patch;
-- `harvested_snapshot_only`: isolated replacement uses only immutable harvested snapshot; fence all later old-Worker output.
+Writable fallback still obeys cancellation/fencing. Never let a Parent writer or replacement Worker overlap a live old writer on the same scope.
 
-Move completed checkpoint work back into remaining delta only with concrete new invalidating evidence and record the reason.
+### Read-only review retry
 
-If `cancel_required=true`, old non-terminal Worker still requires cancellation even if an isolated fallback may proceed safely.
+Review fallback is `retry_review`, not implementation `replan`.
 
-### Hard writable writer fence
+`retry_review`:
 
-A downstream writer may enter an old writable scope only after either:
+- is valid only for review stage;
+- is read-only;
+- never produces implementation `replan_scope`;
+- never opens writable scope or requires writer fencing;
+- must consume a `review_attempt` reservation before the new reviewer starts;
+- is forbidden once `review_deadline` is reached.
 
-1. old writer is confirmed terminal/cancelled/failed; or
-2. downstream writer uses a fresh isolated worktree and old output is fenced from integration.
+## 6. Exploration
 
-This applies to both Parent `parent_delta` and replacement `replan`. Never let recovered old Worker and downstream writer modify the same live scope concurrently.
+Spawn at most `exploration_workers`, using planned role capability/model/reasoning when supported. Give each Explorer a distinct evidence question.
 
-Parent execution is fork/join, not fork/block: spawn planned Workers, continue non-overlapping Parent work, consume results opportunistically, join only at real dependencies, and never redo a whole Worker scope because it is merely slow.
+Do not kill a Luna `xhigh/max` Explorer merely because a short Parent wait returned no final output. Re-evaluate lifecycle from real progress evidence.
 
-## 6. Execute exploration exactly from the plan
+Respect join policy and `min_successful_workers`. Cancel stragglers only when the plan/evaluator permits it.
 
-If `exploration_workers=0`, Parent performs targeted discovery and `exploration_stage` is none.
+## 7. Evidence-based bounded implementation
 
-Otherwise query the task-phase gate with `phase=exploration` before each planned spawn, using the initial budget plan JSON, then delegate exactly the permitted planned count to distinct bounded read-only questions, each with a unique `scope_id`. Respect `max_concurrent_threads` and role capability/model/reasoning. Do not collapse multiple planned explorers merely out of habit, and do not open a new explorer after general-work admission has closed.
-
-Execute exploration join/cancellation/fallback only from `exploration_stage`. In particular, do not kill a Luna `xhigh/max` Explorer merely because it has taken multiple Parent wait intervals while continuing to read files, run commands, or produce other observable progress.
-
-## 7. Partition bounded implementation before spawning
-
-If `implementation_stage.work_unit_mode=single`, keep historical behavior: one assigned implementation scope/transaction per planned implementer slot.
-
-If `work_unit_mode=bounded`, Parent must create an explicit implementation unit manifest **before spawning implementation work**. It must contain at least `minimum_work_units` logical units. Each unit owns exactly one acceptance delta and must include:
+When `implementation_stage.work_unit_mode=bounded`, Parent creates an explicit manifest before implementation spawn. Every unit contains:
 
 ```text
 unit_id
@@ -527,14 +416,14 @@ generation
 acceptance_delta
 write_scope_id
 validation: non-empty list
-write_paths: normalized repo-relative POSIX paths when required by the plan
-depends_on: unit ids, when ordered
+write_paths: normalized repo-relative POSIX paths when required
+depends_on
 parallel_group: optional
 ```
 
-Partition by acceptance boundary, module/file ownership, dependency order, or validation boundary. Do not manufacture meaningless splits solely to satisfy a number; each unit must represent independently describable progress that can be harvested and resumed. A typical same-scope split may be “core implementation” -> “dependent integration/regression completion”.
+Do not manufacture meaningless splits solely to satisfy a number. `minimum_work_units` remains the hard minimum; current built-in strategies keep it at `1`. `maximum_work_units` is a hard manifest bound, not a Worker count.
 
-Validate the manifest deterministically before spawn. Copy `implementation_workers` and `max_concurrent_threads` verbatim from the same immutable ExecutionPlan; never raise either value locally:
+Validate before spawn:
 
 ```bash
 python3 ~/.codex/codex-flow/strategies/work_unit_runtime.py \
@@ -544,170 +433,122 @@ python3 ~/.codex/codex-flow/strategies/work_unit_runtime.py \
   --max-concurrent-threads <ExecutionPlan max_concurrent_threads>
 ```
 
-Use the helper result as the gate. If validation fails, fix the manifest; do not bypass the work-unit contract. The helper caps a parallel wave at `min(implementation_workers, max_concurrent_threads)` and rejects direct or transitive dependency-linked units in the same wave.
+Safety rules:
 
-Safety rules enforced by the manifest/runtime contract:
+- same write scope is serial and dependency ordered;
+- overlapping/ancestor-descendant `write_paths` require dependency ordering;
+- a parallel group requires distinct non-overlapping write scopes/paths and no dependency path inside the group;
+- a parallel group cannot exceed already-planned implementation/thread concurrency;
+- work-unit partitioning never creates new writable workstreams;
+- `write_paths` are lexical preflight evidence, not OS locks or symlink-safe ownership enforcement.
 
-- same `write_scope_id` units are sequential and each later unit must depend on the previous same-scope unit;
-- same or ancestor/descendant `write_paths` across units require a direct or transitive dependency;
-- `parallel_group` may contain only isolated distinct `write_scope_id`s with no direct or transitive dependency path inside that group;
-- every unit in a `parallel_group` must provide non-empty, normalized `write_paths`, and paths in that group must be completely non-overlapping;
-- path checks reject absolute, traversal, glob, backslash, NUL, and Windows drive/UNC forms;
-- `maximum_work_units`, when present, bounds total manifest units;
-- a parallel group cannot exceed the already-resolved implementation/thread concurrency from ExecutionPlan;
-- bounded mode cannot collapse to fewer than `minimum_work_units`;
-- work-unit partitioning never creates new `writable_workstreams`; existing ExecutionPlan isolation is still authoritative.
+`implementation_workers` is concurrent topology, not total logical units. Reuse planned slots across serial waves. `join_between_work_units=true` returns control to Parent after each completed unit.
 
-`write_paths` are static lexical preflight evidence only. They are not an OS lock, do not resolve symlinks, and do not provide durable scheduler enforcement. Parent still owns real writable-scope fencing and must persist/compare the current `(scope_id, unit_id, generation)` lineage when accepting results.
+Do not send all bounded units to one Worker as a giant “complete everything” transaction.
 
-`implementation_workers` is the maximum concurrent implementer topology for a wave, **not permission to run every logical unit concurrently**. When only one writable workstream is proven, execute bounded units serially even if there are multiple units. When the plan already authorizes isolated parallel implementation workers, independent units may share a validated `parallel_group` up to the existing concurrency ceiling.
+## 8. Implementation handoff and local repair
 
-Logical work-unit boundaries do not enlarge WorkerBudget. Reuse the same planned implementer slot/thread for subsequent serial units when the runtime supports continued agent input. If a fresh Worker identity is required for a later unit, it replaces a terminal prior slot sequentially; never exceed `implementation_workers`, `max_concurrent_threads`, or the strategy's speculative WorkerBudget envelope merely because there are more logical units than concurrent implementer slots.
+Every implementation handoff should be bounded to its assigned scope/unit and contain:
 
-`join_between_work_units=true` means every completed unit returns control to Parent. Parent harvests the unit result/workspace state, verifies its unit acceptance delta, then decides whether the next dependent unit may start. This is a normal execution boundary, not cancellation and not a reason to discard the workspace.
-
-Do not send all bounded units to one Worker in a single “complete everything” handoff. That recreates the long transaction this policy is designed to avoid.
-
-Before every implementation spawn/replan/replacement, query `task_phase_runtime.py` with `phase=implementation` and perform the corresponding reservation through its `reserve` subcommand, always passing the initial budget plan rather than a later recompiled plan. `permits_phase_start=false` is binding; the effective ledger soft deadline already includes any required-completion tail reserved by phase-aware init.
-
-## 8. Compact implementation handoff
-
-Every implementation handoff includes only:
-
-- `scope_id` / isolated writable scope;
-- one `unit_id` and `acceptance_delta` when bounded;
-- current `generation` for that unit;
-- allowed `write_scope_id`;
-- normalized `write_paths` when required by the plan;
-- dependencies and harvested prior-unit evidence;
-- root cause/design decision;
-- relevant files/components;
-- unit-local steps;
+- scope/unit/generation;
+- acceptance delta;
+- allowed write scope/paths;
+- dependencies and prior harvested evidence;
+- root-cause/design decision;
 - constraints/non-goals;
-- unit-local acceptance criteria;
-- required validation;
-- `implementation_stage.max_worker_repair_attempts` when present.
+- validation;
+- `max_worker_repair_attempts` when present.
 
-For `checkpoint_remaining_delta`, replace full-scope handoff with the same `scope_id`/`unit_id` lineage and unchanged generation, `replan_scope`, `checkpoint_reuse_mode`, harvested completed/validation/patch baseline, and **only** harvested remaining delta. A replacement Worker or replan superseding a prior attempt uses generation+1; checkpoint/continue does not increment. Parent accepts only current-generation evidence. Never paste the original complete task as a second goal.
+A Worker changes only its assigned unit and proves it with validation. For bounded mode it must return to Parent rather than beginning the next unit.
 
-Prefer fresh/no-history child context when supported.
+Local repair semantics:
 
-If planned multiple implementation workers no longer have proven isolated writable workstreams, re-profile and recompile instead of silently changing topology.
-
-Prefer `worker-implementer`; apply planned capability/model/reasoning when supported. If not supported, use installed baseline and report the limitation.
-
-Implementation normally uses required lifecycle. Do not cancel a progressing writer merely so Parent can recreate its patch. On failure/stall follow deterministic lifecycle and writer fencing. The task-phase completion boundary is an additional task-level join requirement: once the required-review tail begins, do not open more implementation work, and existing writable work must converge to a stable harvested/terminal state rather than consuming that tail indefinitely.
-
-When lifecycle says `request_checkpoint`, send it to the same Worker. When payload returns, preserve it and record real timestamps; do not mark completion just because it checkpointed.
-
-## 9. Worker implements and proves one unit
-
-Worker changes only assigned scope/unit, runs narrow validation first, fixes failures caused by the patch within local budget, and returns:
-
-- scope id / unit id;
-- acceptance delta satisfied;
-- changed files;
-- concise implementation summary;
-- validation commands/results;
-- local repair attempts used/budget;
-- deviations;
-- unresolved risks/failures;
-- retained workspace state.
-
-For bounded mode Worker must not begin the next unit. Unit completion is a Parent join point.
-
-`max_worker_repair_attempts` semantics:
-
-- initial implementation + first validation is not a repair attempt;
-- one attempt = attributable validation failure -> corrective edit pass -> targeted revalidation;
-- investigation without corrective edit does not count;
+- initial implementation + first validation = zero repairs;
+- one repair = attributable validation failure -> corrective edit -> targeted revalidation;
+- investigation without an edit does not consume an attempt;
 - unrelated pre-existing failures do not count;
-- when exhausted, preserve patch, report failing validation/blocker/smallest remaining delta, and return control to Parent.
+- on exhaustion, preserve patch/evidence and return the smallest remaining delta.
 
-Budget exhaustion is controlled handoff, not lifecycle timeout. Do not cancel/discard patch or count it as lifecycle failure.
+Local repair is separate from Parent `max_repair_cycles` and from lifecycle fallback.
 
-If local repair field is absent in an older plan, do not retroactively impose a cap.
-
-Evidence beats verbose logs.
-
-## 10. Review exactly according to the plan
+## 9. Review and Parent finalization
 
 Parent always reviews relevant diff, affected call sites, validation evidence, acceptance criteria, architecture consistency, and regression risk.
 
-- `review_mode=parent`: no reviewer Workers;
-- `review_mode=independent+parent`: spawn exactly `reviewer_workers` bounded independent reviewers, execute `review_stage`, then Parent final verification.
+- `review_mode=parent`: no reviewer Worker.
+- `review_mode=independent+parent`: spawn exactly the planned reviewer topology, subject to `review_attempt` reservations and the review window.
 
-Before any independent reviewer spawn, query the phase helper with `phase=required_completion`, passing the initial budget plan. A task soft/general-work deadline is **not** permission to skip the planned review; only the absolute task hard deadline closes required completion. Review a terminal workspace or immutable harvested snapshot, never a concurrently mutating writable scope. If the implementation phase reaches its completion handoff boundary with a non-terminal writer, harvest first and apply writer fencing/cancellation according to lifecycle before consuming the reserved review tail.
+Review only a terminal workspace or immutable harvested snapshot, never concurrently mutating writable scope.
 
-Multiple reviewers get complementary scopes, not duplicated prompts. Reviewers are read-only and must not silently implement.
+Multiple reviewers should receive complementary scopes. They are read-only and must not silently implement.
 
-Do not terminate progressing reviewers merely because Parent completed unrelated work or waits returned. Execute review lifecycle exactly from plan, bounded by the absolute task hard deadline.
+Once `action=finalize_parent`, do not start/retry reviewers. Use the remaining tail for Parent reconciliation, final verification, and delivery. At hard deadline, no new Worker or Parent writer starts; only already-collected evidence may be reported.
 
 Direct mode still requires Parent self-review.
 
-## 11. Parent repair from bounded deltas
+## 10. Parent repair and replan
 
-On implementation defect returned to Parent, send the smallest repair delta: exact defect, impact, correction, relevant symbol/file, and validation.
+Parent repair receives the smallest defect delta, not the original full task. Never exceed `max_repair_cycles`.
 
-Never exceed top-level `max_repair_cycles`. These cycles begin only after Implementer returned control and are separate from local Worker repair attempts.
+A repair requiring writes is general work and therefore cannot open after the task soft/general-work deadline.
 
-If repair fails or evidence materially changes the task, update TaskProfile and compile a new ExecutionPlan. Do not mutate old plan ad hoc. Keep the original initial budget plan and ledger for all task-phase admission/reservations; the new ExecutionPlan must fit inside their remaining envelope.
+Re-profile and compile a newer ExecutionPlan when material evidence changes task semantics, but continue using the original task ledger and initial budget plan for cumulative admission. A newer plan cannot reset counters or extend deadlines.
 
-Worker stall/failure/supersession, checkpoint handling, timeout fallback, unit joins, and remaining-delta replan do not themselves consume Parent repair cycles.
+Worker stall/failure/checkpoint/replan does not itself consume Parent repair cycles.
 
-A repair that requires new implementation work is still general work and must pass the task-phase admission gate; do not reopen writable repair work inside a tail already reserved for required completion.
+## 11. Efficient reasoning rollout
+
+Reasoning rollout is currently efficient-specific. Modes:
+
+- `legacy`: select historical Worker effort.
+- `shadow`: report proposal but select historical effort.
+- `adaptive`: select proposal.
+
+Proposal:
+
+```text
+max(rollout class target, rollout minimum, parent_reasoning)
+```
+
+The planner output is intent, not proof that the active runtime applied a per-spawn override. If runtime override is unsupported, use the installed baseline and report that limitation. Do not fabricate observed effort.
 
 ## 12. Quota and telemetry discipline
 
-Quota is never guessed. Planner reads app-server rate-limit state when available; unavailable state is `unknown`.
+Quota is never guessed. Unavailable quota state is `unknown`.
 
-Telemetry is observational and deterministic. Never call a model solely to estimate tokens/quota/duration or produce a usage summary.
+Telemetry is observational. Never call a model solely to estimate tokens, quota, or duration.
 
-For every Worker spawn, retain its Unix-second start time and the plan's strategy, task class, stage/role/model, rollout mode, and legacy/proposed/selected effort. On each received checkpoint and once at terminal state, invoke the installed telemetry CLI's `latency record` path with a stable event ID, task/Worker/work-unit IDs, the boundary time, repair/checkpoint counters, and terminal outcome where applicable. The helper hashes identifiers with a local salt and rejects free-form payload fields; never send prompt, transcript, conclusion, tool arguments/output, cwd, or paths. A checkpoint has `boundary=checkpoint` and no outcome. A terminal observation has `boundary=terminal` and `outcome=completed|failed|cancelled|timeout`.
+For each Worker, record available deterministic lifecycle/latency evidence with stable IDs and no prompt/transcript/path payload. `observed_effort` must be runtime-confirmed; otherwise record null.
 
-`observed_effort` means effort confirmed by the runtime for that exact spawn. If the runtime does not expose it, record null; never copy `selected_worker_reasoning` into observed merely because it was requested. Telemetry is fail-open: a collection failure is reported concisely but must not block checkpoint harvest, fencing, cancellation, join, or delivery.
+Telemetry failures are fail-open and must never block checkpoint harvest, cancellation/fencing, joining, or delivery.
 
-`telemetry latency report` uses deterministic nearest-rank p50/p95 over uncensored terminal observations and separately reports completed, success, censored, missing, and checkpoint counts. Treat `eligible_for_tuning=true` only as permission to evaluate a homogeneous group after at least 20 uncensored samples with confirmed observed effort. It is not permission to mutate policy automatically. Compare latency with success/censoring before moving `shadow` to `adaptive`, and keep `legacy` as the rollback switch.
+Do not auto-tune policy from a handful of runs. Compare latency, completion, failures/censoring, and quota after a sufficiently homogeneous sample.
 
-Quota pressure may constrain speculative fan-out and Parent repair budget for quota-sensitive strategies, but must not silently lower configured reasoning/quality floors. Safety ceilings remain authoritative.
+## 13. Concurrency discipline
 
-Lifecycle/work-unit/task-phase policy is deterministic. Do not invent historical latency predictions outside explicit runtime logic.
+`max_concurrent_threads` is a stage concurrency ceiling. WorkerBudget maxima are envelopes, not mandatory counts.
 
-## 13. Context and concurrency discipline
+Parallel writable work requires already-proven isolated scopes/worktrees represented in `writable_workstreams`. Replan does not magically create another safe writer.
 
-Prefer targeted search, concise excerpts, diff-scoped review, and small validation output. Avoid full-repo dumps, duplicate agents, rereading unchanged files, Parent reimplementation of Worker work, or cancelling useful work only to recreate it.
+Prefer targeted search, compact context, diff-scoped review, narrow validation, and harvested evidence. Avoid duplicated agents, rereading unchanged files, and Parent reimplementation of Worker work.
 
-`max_concurrent_threads` is a per-stage concurrency ceiling. `implementation_workers` is concurrent implementation topology. Bounded `minimum_work_units` is a logical transaction count and may therefore be executed across multiple serial waves; it does not itself increase writable concurrency.
+## 14. Re-plan triggers
 
-Parallel writable work requires isolated non-overlapping scopes/worktrees already represented by `writable_workstreams`. A downstream fallback writer is not a new proven workstream merely because replan occurred.
-
-## 14. Re-plan checkpoints
-
-Re-profile and invoke planner again when:
+Re-profile when:
 
 - complexity/risk materially changes;
-- explicit quality intent materially changes;
 - root cause is disproven;
 - cross-module dependency appears;
 - writable isolation changes;
-- required stage chooses `fallback_policy=replan`;
-- Parent repair cycles fail;
+- explicit quality intent changes;
+- a required implementation stage returns `fallback_policy=replan`;
+- Parent repair fails;
 - reliable quota/runtime state materially changes.
 
-Replan from evaluator-provided scope, never original task by default. For `checkpoint_remaining_delta`, harvested checkpoint is authoritative boundary. For `uncovered_scope`, derive smallest still-uncovered scope. A new plan never overrides old writable-worker fencing or the existing durable task ledger. It also never replaces the initial budget plan passed to `task_phase_runtime.py`; all phase admission and cumulative reservations remain bound to the initial budget plan for this task.
+Replan from evaluator-provided missing scope, never the original task by default. Completed accepted units remain evidence unless specifically invalidated.
 
-Completed bounded units remain prior evidence across replan unless concrete new evidence invalidates them. Do not restart already accepted units merely because a later unit failed.
+## Runtime/version invariant
 
-## Compatibility invariant
+Persistent user policy remains schema v4. This FlowPilot runtime consumes ExecutionPlan schema v11 and task-ledger schema v2 for this feature set. These task-ledger semantics were not released with an older persisted-task format, so there is intentionally no grandfather/adoption path for incompatible task-ledger state: mismatched plan/policy/schema fails closed.
 
-For schema-v3 users with no strategy/routing fields:
-
-```text
-strategy = efficient
-routing = adaptive
-review = auto
-fanout = auto
-quality_intent = normal
-```
-
-Persistent policy remains schema v4. ExecutionPlan schema v10 adds optional task-level cumulative budget and reasoning-rollout decision fields alongside StagePolicy convergence/repair/work-unit/checkpoint-rearm fields. Older plans without `task_budget`, `reasoning_rollout`, `soft_timeout_seconds`, meaningful-progress/checkpoint state, `checkpoint_rearm_seconds`, `max_worker_repair_attempts`, or work-unit fields retain historical behavior for that run. In particular, missing checkpoint-rearm policy is safe one-shot behavior and absent task-budget/work-unit/rollout fields resolve to the legacy path; updates must not retroactively split, cancel, change reasoning, reserve completion tail, or reset already-running Workers. Existing pre-phase ledgers with the initial plan's original task-budget fingerprint remain `legacy_unclamped` rather than being rewritten to the new effective soft deadline.
+This does **not** relax ordinary persistent policy precedence or installer configuration preservation; it only means the new v11 task-execution contract has one canonical interpretation.

--- a/templates/skills/flow-pilot/SKILL.md
+++ b/templates/skills/flow-pilot/SKILL.md
@@ -11,7 +11,7 @@ The invariant is:
 
 > **FlowPilot profiles. `strategy_runtime.py` + the strategy registry decide. FlowPilot executes the returned plan.**
 
-Do not independently re-implement strategy topology, capability selection, reasoning selection, quota policy, worker counts, review mode, fan-out, lifecycle/join policy, cancellation policy, fallback policy, local repair budget, task budget, or implementation work-unit policy in this skill. The installed planner and built-in strategy registry are the single source of truth for those decisions. Hard Worker lifecycle safety invariants are evaluated by the installed deterministic lifecycle helper; bounded implementation manifests are validated by the installed deterministic work-unit helper.
+Do not independently re-implement strategy topology, capability selection, reasoning selection, quota policy, worker counts, review mode, fan-out, lifecycle/join policy, cancellation policy, fallback policy, local repair budget, task budget, task-phase admission, or implementation work-unit policy in this skill. The installed planner and built-in strategy registry are the single source of truth for those decisions. Hard Worker lifecycle safety invariants are evaluated by the installed deterministic lifecycle helper; bounded implementation manifests are validated by the installed deterministic work-unit helper; cumulative task counters live in the task-budget ledger; phase-aware admission is evaluated by the installed task-phase helper.
 
 Default compatibility remains `strategy = efficient` plus `routing = adaptive`.
 
@@ -234,7 +234,7 @@ ExecutionPlan
 
 `implementation_stage.work_unit_mode=bounded` is binding. `minimum_work_units` is the minimum number of logical acceptance-bounded implementation transactions and may be 1. Default to one unit; split only when every split has an independent acceptance delta, validation boundary, and ownership/dependency evidence. `maximum_work_units`, when present, is a hard manifest count bound and must be at least the minimum. `join_between_work_units=true` means control must return to Parent after each completed unit before a dependent next unit begins. These fields do **not** authorize extra writable concurrency. `require_write_paths=true` opts a new bounded policy into generation and normalized repository-relative `write_paths` validation.
 
-### Task-level cumulative budget
+### Task-level cumulative budget and phase-aware admission
 
 `task_budget` is a strategy-owned cumulative contract for delegated built-in strategy work. It is separate from `StagePolicy`: stage fields describe one Worker stage, while task reservations live in a durable ledger and are never reset by a replan or a new process. Direct plans emit `task_budget=null`.
 
@@ -250,13 +250,63 @@ quality     4800..6000 / 6000..7200 1..4          units + 3                 3 / 
 
 The exact values come only from the current immutable ExecutionPlan. Never infer them from the strategy name and never substitute efficient's numbers for another strategy. When both are present, `task_budget.max_work_units` must equal `implementation_stage.maximum_work_units`.
 
-Immediately after the first plan is compiled, initialize `task_budget_runtime.py` with the plan's exact `task_budget`, task id, and runtime-owned state path. Before any Worker spawn, query `status`; exploration/review Workers consume wall time but do not consume implementation counters. Before each logical work-unit start, implementation Worker attempt, replan, or replacement, reserve the corresponding kind (`work_unit`, `implementation_attempt`, `replan`, or `replacement`). After every join or wait, query `status`; at task completion, call `finish`. A replan reuses the original ledger/state path and remaining counters, never a fresh budget.
+Immediately after the first plan is compiled, initialize `task_budget_runtime.py` with the plan's exact `task_budget`, task id, and runtime-owned state path. After that, **do not use the raw ledger `permits_new_work` flag as the Worker-spawn gate**. Every delegated phase must go through `task_phase_runtime.py`, because a plan that already requires independent review needs a reserved completion tail.
+
+Before exploration or implementation admission:
+
+```bash
+python3 ~/.codex/codex-flow/strategies/task_phase_runtime.py status \
+  --state-file <task-ledger-path> \
+  --task-id <task-id> \
+  --plan-json '<immutable ExecutionPlan JSON>' \
+  --phase exploration|implementation \
+  --now <unix-seconds>
+```
+
+Before each logical work-unit start, implementation attempt, replan, or replacement, reserve through the phase helper rather than calling the raw ledger reserve command directly:
+
+```bash
+python3 ~/.codex/codex-flow/strategies/task_phase_runtime.py reserve \
+  --state-file <task-ledger-path> \
+  --task-id <task-id> \
+  --plan-json '<immutable ExecutionPlan JSON>' \
+  --now <unix-seconds> \
+  --kind work_unit|implementation_attempt|replan|replacement \
+  --reservation-id <stable-id> \
+  --fingerprint <stable-fingerprint>
+```
 
 For a bounded manifest, reserve `work_unit` with the validator's stable `logical_unit_fingerprints[unit_id]`, which excludes generation. Reserve `implementation_attempt` with the generation-aware `unit_fingerprints[unit_id]` and an identity derived from `(scope_id, unit_id, generation)`. A replacement therefore consumes a new implementation attempt/replacement reservation without double-counting the same logical work unit; changing acceptance/scope/path/validation under the same logical unit still fails closed.
 
-At the plan's `task_budget.soft_timeout_seconds` deadline, do not open new work or create reservations; ask existing Workers to checkpoint/converge and harvest their evidence. At the plan's `task_budget.hard_timeout_seconds` deadline, first harvest any received checkpoint, then apply lifecycle fencing and cancel active writers. Do not start a replacement Worker or Parent writer after hard stop. An implementation handoff must carry the task-budget state path and current remaining seconds/counters.
+The phase helper computes the general-work deadline as:
 
-The task-budget helper is a ledger/decision boundary, not an automatic scheduler: it does not spawn, checkpoint, cancel, fence, or replace Workers. FlowPilot/runtime performs those actions from its result. The lifecycle helper likewise reports requirements; actual cancellation and scheduling remain runtime responsibilities.
+```text
+min(
+  ledger.soft_deadline,
+  ledger.hard_deadline - review_stage.hard_timeout_seconds
+)
+```
+
+when `reviewer_workers > 0` and `review_stage` exists. With no reviewer Worker, the general-work deadline remains the ordinary task soft deadline. This does not change the immutable strategy budget or ledger fingerprint; it is a deterministic admission reserve derived from that plan's already-required completion stage.
+
+At the general-work deadline, do not open new exploration/implementation work or create implementation/replan/replacement reservations. Existing implementation must checkpoint/converge and return control. If a writable Worker cannot return before it consumes the required-review tail, harvest its latest checkpoint first, then apply the existing lifecycle/writer-fence rules and review only a terminal or immutable harvested snapshot. Never let a moving writable workspace consume a tail already reserved for required review.
+
+Required completion is a separate phase consisting of the immutable plan's already-required read-only independent review plus Parent final verification. Before starting a reviewer Worker, query:
+
+```bash
+python3 ~/.codex/codex-flow/strategies/task_phase_runtime.py status \
+  --state-file <task-ledger-path> \
+  --task-id <task-id> \
+  --plan-json '<immutable ExecutionPlan JSON>' \
+  --phase required_completion \
+  --now <unix-seconds>
+```
+
+`required_completion` may start after the task soft/general-work deadline and remains permitted until the absolute task hard deadline. Soft convergence must therefore **never** silently skip an `independent+parent` or `strict` review that the immutable ExecutionPlan already requires. At the hard deadline, first harvest any received checkpoint, then apply lifecycle fencing/cancellation; no new reviewer, replacement Worker, or Parent writer may start. Parent may still report already-collected evidence, but the task hard deadline is the absolute execution stop.
+
+Exploration/review Workers consume wall time but do not consume implementation counters. After every join or wait, re-query the phase gate for the phase you intend to continue. At task completion, call the raw ledger `finish`. A replan reuses the original ledger/state path and remaining counters, never a fresh budget.
+
+The task-budget helper is a durable ledger/decision boundary and the task-phase helper is an admission boundary; neither schedules Workers. FlowPilot/runtime performs checkpointing, harvesting, fencing, cancellation, spawning, and joins from their deterministic results. The lifecycle helper remains authoritative for Worker-level safety decisions.
 
 ### Efficient reasoning rollout
 
@@ -271,7 +321,7 @@ minimum=high, routine=high, complex=xhigh, critical=max
 
 `legacy` is the kill switch: the current Worker reasoning selection remains
 unchanged. `shadow` also selects the legacy effort, while exposing a proposed
-effort in `ExecutionPlan.reasoning_rollout`. `adaptive` selects that proposal.
+effort in `ExecutionPlan.reasoning_rollout`. `adaptive` selects the proposal.
 The proposal is computed after the existing legacy selection as:
 
 ```text
@@ -346,7 +396,7 @@ Meaningful-progress quality is observational and non-destructive. `activity_only
 
 `idle_timeout_seconds` is a renewable liveness lease. `soft_timeout_seconds` is an advisory checkpoint/convergence budget. `hard_timeout_seconds` is the absolute Worker wall-clock ceiling.
 
-The lifecycle helper is a deterministic evaluator, not a durable scheduler or checkpoint store. The separate task-budget helper is the durable cross-process ledger for task-level reservations. Both helpers report decisions/requirements; the runtime must enforce cancellation, checkpoint harvest, writer fencing, and Worker scheduling.
+The lifecycle helper is a deterministic evaluator, not a durable scheduler or checkpoint store. The separate task-budget helper is the durable cross-process ledger for task-level reservations; the task-phase helper derives phase admission and completion-tail reservation from the immutable plan. These helpers report decisions/requirements; the runtime must enforce cancellation, checkpoint harvest, writer fencing, and Worker scheduling.
 
 **A `wait()` timeout is never a Worker timeout.** Repeated Parent waits without terminal output do not by themselves justify stalled/failed/cancelled.
 
@@ -448,7 +498,7 @@ Parent execution is fork/join, not fork/block: spawn planned Workers, continue n
 
 If `exploration_workers=0`, Parent performs targeted discovery and `exploration_stage` is none.
 
-Otherwise delegate exactly the planned count to distinct bounded read-only questions, each with a unique `scope_id`. Respect `max_concurrent_threads` and role capability/model/reasoning. Do not collapse multiple planned explorers merely out of habit.
+Otherwise query the task-phase gate with `phase=exploration` before each planned spawn, then delegate exactly the permitted planned count to distinct bounded read-only questions, each with a unique `scope_id`. Respect `max_concurrent_threads` and role capability/model/reasoning. Do not collapse multiple planned explorers merely out of habit, and do not open a new explorer after general-work admission has closed.
 
 Execute exploration join/cancellation/fallback only from `exploration_stage`. In particular, do not kill a Luna `xhigh/max` Explorer merely because it has taken multiple Parent wait intervals while continuing to read files, run commands, or produce other observable progress.
 
@@ -506,6 +556,8 @@ Logical work-unit boundaries do not enlarge WorkerBudget. Reuse the same planned
 
 Do not send all bounded units to one Worker in a single “complete everything” handoff. That recreates the long transaction this policy is designed to avoid.
 
+Before every implementation spawn/replan/replacement, query `task_phase_runtime.py` with `phase=implementation` and perform the corresponding reservation through its `reserve` subcommand. `permits_phase_start=false` is binding even if the raw task ledger has not yet reached its ordinary soft deadline; the difference is the required-completion tail reserved by the immutable plan.
+
 ## 8. Compact implementation handoff
 
 Every implementation handoff includes only:
@@ -532,7 +584,7 @@ If planned multiple implementation workers no longer have proven isolated writab
 
 Prefer `worker-implementer`; apply planned capability/model/reasoning when supported. If not supported, use installed baseline and report the limitation.
 
-Implementation normally uses required lifecycle. Do not cancel a progressing writer merely so Parent can recreate its patch. On failure/stall follow deterministic lifecycle and writer fencing.
+Implementation normally uses required lifecycle. Do not cancel a progressing writer merely so Parent can recreate its patch. On failure/stall follow deterministic lifecycle and writer fencing. The task-phase completion boundary is an additional task-level join requirement: once the required-review tail begins, do not open more implementation work, and existing writable work must converge to a stable harvested/terminal state rather than consuming that tail indefinitely.
 
 When lifecycle says `request_checkpoint`, send it to the same Worker. When payload returns, preserve it and record real timestamps; do not mark completion just because it checkpointed.
 
@@ -573,9 +625,11 @@ Parent always reviews relevant diff, affected call sites, validation evidence, a
 - `review_mode=parent`: no reviewer Workers;
 - `review_mode=independent+parent`: spawn exactly `reviewer_workers` bounded independent reviewers, execute `review_stage`, then Parent final verification.
 
+Before any independent reviewer spawn, query the phase helper with `phase=required_completion`. A task soft/general-work deadline is **not** permission to skip the planned review; only the absolute task hard deadline closes required completion. Review a terminal workspace or immutable harvested snapshot, never a concurrently mutating writable scope. If the implementation phase reaches its completion handoff boundary with a non-terminal writer, harvest first and apply writer fencing/cancellation according to lifecycle before consuming the reserved review tail.
+
 Multiple reviewers get complementary scopes, not duplicated prompts. Reviewers are read-only and must not silently implement.
 
-Do not terminate progressing reviewers merely because Parent completed unrelated work or waits returned. Execute review lifecycle exactly from plan.
+Do not terminate progressing reviewers merely because Parent completed unrelated work or waits returned. Execute review lifecycle exactly from plan, bounded by the absolute task hard deadline.
 
 Direct mode still requires Parent self-review.
 
@@ -588,6 +642,8 @@ Never exceed top-level `max_repair_cycles`. These cycles begin only after Implem
 If repair fails or evidence materially changes the task, update TaskProfile and compile a new ExecutionPlan. Do not mutate old plan ad hoc.
 
 Worker stall/failure/supersession, checkpoint handling, timeout fallback, unit joins, and remaining-delta replan do not themselves consume Parent repair cycles.
+
+A repair that requires new implementation work is still general work and must pass the task-phase admission gate; do not reopen writable repair work inside a tail already reserved for required completion.
 
 ## 12. Quota and telemetry discipline
 
@@ -603,7 +659,7 @@ For every Worker spawn, retain its Unix-second start time and the plan's strateg
 
 Quota pressure may constrain speculative fan-out and Parent repair budget for quota-sensitive strategies, but must not silently lower configured reasoning/quality floors. Safety ceilings remain authoritative.
 
-Lifecycle/work-unit policy is deterministic. Do not invent historical latency predictions outside explicit runtime logic.
+Lifecycle/work-unit/task-phase policy is deterministic. Do not invent historical latency predictions outside explicit runtime logic.
 
 ## 13. Context and concurrency discipline
 
@@ -626,7 +682,7 @@ Re-profile and invoke planner again when:
 - Parent repair cycles fail;
 - reliable quota/runtime state materially changes.
 
-Replan from evaluator-provided scope, never original task by default. For `checkpoint_remaining_delta`, harvested checkpoint is authoritative boundary. For `uncovered_scope`, derive smallest still-uncovered scope. A new plan never overrides old writable-worker fencing.
+Replan from evaluator-provided scope, never original task by default. For `checkpoint_remaining_delta`, harvested checkpoint is authoritative boundary. For `uncovered_scope`, derive smallest still-uncovered scope. A new plan never overrides old writable-worker fencing or the existing durable task ledger.
 
 Completed bounded units remain prior evidence across replan unless concrete new evidence invalidates them. Do not restart already accepted units merely because a later unit failed.
 
@@ -642,4 +698,4 @@ fanout = auto
 quality_intent = normal
 ```
 
-Persistent policy remains schema v4. ExecutionPlan schema v10 adds optional task-level cumulative budget and reasoning-rollout decision fields alongside StagePolicy convergence/repair/work-unit/checkpoint-rearm fields. Older plans without `task_budget`, `reasoning_rollout`, `soft_timeout_seconds`, meaningful-progress/checkpoint state, `checkpoint_rearm_seconds`, `max_worker_repair_attempts`, or work-unit fields retain historical behavior for that run. In particular, missing checkpoint-rearm policy is safe one-shot behavior and absent task-budget/work-unit/rollout fields resolve to the legacy path; updates must not retroactively split, cancel, change reasoning, or reset already-running Workers.
+Persistent policy remains schema v4. ExecutionPlan schema v10 adds optional task-level cumulative budget and reasoning-rollout decision fields alongside StagePolicy convergence/repair/work-unit/checkpoint-rearm fields. Older plans without `task_budget`, `reasoning_rollout`, `soft_timeout_seconds`, meaningful-progress/checkpoint state, `checkpoint_rearm_seconds`, `max_worker_repair_attempts`, or work-unit fields retain historical behavior for that run. In particular, missing checkpoint-rearm policy is safe one-shot behavior and absent task-budget/work-unit/rollout fields resolve to the legacy path; updates must not retroactively split, cancel, change reasoning, reserve completion tail, or reset already-running Workers.

--- a/templates/skills/flow-pilot/SKILL.md
+++ b/templates/skills/flow-pilot/SKILL.md
@@ -287,10 +287,12 @@ The phase result is binding:
 - `permits_review_start`: a new read-only reviewer may start.
 - `permits_parent_finalization`: Parent may continue final reconciliation/verification before hard.
 - `review_deadline`: no new reviewer starts at or after this boundary.
-- `action=finalize_parent`: reviewer admission is closed; use the remaining tail only for Parent finalization.
+- `action=finalize_parent`: reviewer admission is closed; use the remaining tail only for Parent finalization. This is an admission transition, **not** evidence that required review succeeded.
 - `action=stop`: task hard deadline/closed state reached; do not start new execution.
 
-A soft deadline must never silently skip an independent/strict review already required by the initial plan. A reviewer must never consume the Parent finalization reserve.
+A soft deadline must never silently skip an independent/strict review already required by the initial plan. A reviewer must never consume the Parent finalization reserve. If `review_stage.join_policy` is required/quorum, successful delivery still requires at least `review_stage.min_successful_workers` accepted reviewer results. Reaching `review_deadline` without satisfying that join is fail-closed: do not silently downgrade to Parent-only review or report task success.
+
+Before entering Parent-only finalization, every writable Worker must already be terminal/cancel-confirmed or safely fenced with its latest returned checkpoint harvested. The Parent finalization tail must not be consumed by unresolved writable execution.
 
 The raw task-budget helper is the durable atomic ledger. The phase helper is the scheduling admission boundary. Neither schedules Workers by itself.
 
@@ -421,7 +423,7 @@ depends_on
 parallel_group: optional
 ```
 
-Do not manufacture meaningless splits solely to satisfy a number. `minimum_work_units` remains the hard minimum; current built-in strategies keep it at `1`. `maximum_work_units` is a hard manifest bound, not a Worker count.
+Do not manufacture meaningless splits solely to satisfy a number. `minimum_work_units` remains the hard minimum; current built-in strategies keep it at `1`. `maximum_work_units` is a hard manifest bound, not a Worker count. Strategy semantic limits may be raised only by already-proven writable topology within the strategy's WorkerBudget; this permits serial waves without inventing extra workstreams.
 
 Validate before spawn:
 
@@ -482,7 +484,9 @@ Review only a terminal workspace or immutable harvested snapshot, never concurre
 
 Multiple reviewers should receive complementary scopes. They are read-only and must not silently implement.
 
-Once `action=finalize_parent`, do not start/retry reviewers. Use the remaining tail for Parent reconciliation, final verification, and delivery. At hard deadline, no new Worker or Parent writer starts; only already-collected evidence may be reported.
+Track accepted reviewer completions against `review_stage.min_successful_workers`. `action=finalize_parent` only closes reviewer admission; it does not satisfy the review join. If the required/quorum reviewer join is still unsatisfied at `review_deadline`, preserve the available review evidence and fail/escalate rather than silently converting the plan to Parent-only success.
+
+Once `action=finalize_parent`, do not start/retry reviewers. Use the remaining tail for Parent reconciliation and final verification. Enter that tail only after writable Workers are terminal/cancel-confirmed or safely fenced and all returned checkpoints have been harvested. At hard deadline, no new Worker or Parent writer starts; only already-collected evidence may be reported.
 
 Direct mode still requires Parent self-review.
 

--- a/templates/skills/flow-pilot/SKILL.md
+++ b/templates/skills/flow-pilot/SKILL.md
@@ -11,7 +11,7 @@ The invariant is:
 
 > **FlowPilot profiles. `strategy_runtime.py` + the strategy registry decide. FlowPilot executes the returned plan.**
 
-Do not independently re-implement strategy topology, capability selection, reasoning selection, quota policy, worker counts, review mode, fan-out, lifecycle/join policy, cancellation policy, fallback policy, local repair budget, or implementation work-unit policy in this skill. The installed planner and built-in strategy registry are the single source of truth for those decisions. Hard Worker lifecycle safety invariants are evaluated by the installed deterministic lifecycle helper; bounded implementation manifests are validated by the installed deterministic work-unit helper.
+Do not independently re-implement strategy topology, capability selection, reasoning selection, quota policy, worker counts, review mode, fan-out, lifecycle/join policy, cancellation policy, fallback policy, local repair budget, task budget, or implementation work-unit policy in this skill. The installed planner and built-in strategy registry are the single source of truth for those decisions. Hard Worker lifecycle safety invariants are evaluated by the installed deterministic lifecycle helper; bounded implementation manifests are validated by the installed deterministic work-unit helper.
 
 Default compatibility remains `strategy = efficient` plus `routing = adaptive`.
 
@@ -156,7 +156,7 @@ For explicit current-task overrides append only requested dimensions:
 --efficient-reasoning legacy|shadow|adaptive
 ```
 
-The planner merges release/user/repository policy, loads the selected strategy, resolves WorkerBudget, computes topology, resolves StagePolicy, chooses per-role capability/reasoning, applies runtime ceilings and writable-isolation checks, reads reliable quota state when available, and emits one ExecutionPlan without extra LLM calls.
+The planner merges release/user/repository policy, loads the selected strategy, resolves WorkerBudget, computes topology, resolves StagePolicy and task budget, chooses per-role capability/reasoning, applies runtime ceilings and writable-isolation checks, reads reliable quota state when available, and emits one ExecutionPlan without extra LLM calls.
 
 If planner/registry is unavailable, treat it as installation/runtime failure. Do not reconstruct strategy logic from this file.
 
@@ -236,24 +236,25 @@ ExecutionPlan
 
 ### Task-level cumulative budget
 
-`task_budget` is an optional strategy-owned cumulative contract for delegated work. It is separate from `StagePolicy`: stage fields describe one Worker stage, while task reservations live in a durable ledger and are never reset by a replan or a new process. Efficient uses these caps:
+`task_budget` is a strategy-owned cumulative contract for delegated built-in strategy work. It is separate from `StagePolicy`: stage fields describe one Worker stage, while task reservations live in a durable ledger and are never reset by a replan or a new process. Direct plans emit `task_budget=null`.
+
+Current built-in policy envelopes are strategy-specific:
 
 ```text
-                         max_work_units   max_implementation_attempts
-routine/local/module             1                         2
-complex, cross-module, critical  2                         3
-repo-wide or heavy-loop          3                         4
-max_replans = 1, max_replacements = 1
-soft_timeout_seconds = 1500, hard_timeout_seconds = 1800
+strategy    task soft/hard        work units      implementation attempts   replans/replacements
+efficient   1500 / 1800           1..3            units + 1                 1 / 1
+speed       1200 / 1800           1..4            units + 1                 1 / 1
+balanced    2400..3000 / 3000..3600 1..3          units + 2                 2 / 2
+quality     4800..6000 / 6000..7200 1..4          units + 3                 3 / 3
 ```
 
-The compiler emits `task_budget` only when the resolved route is `delegate`; direct plans and legacy strategies emit `null`. When both are present, `task_budget.max_work_units` must equal `implementation_stage.maximum_work_units`.
+The exact values come only from the current immutable ExecutionPlan. Never infer them from the strategy name and never substitute efficient's numbers for another strategy. When both are present, `task_budget.max_work_units` must equal `implementation_stage.maximum_work_units`.
 
-Immediately after the first plan is compiled, initialize `task_budget_runtime.py` with the plan's budget, task id, and runtime-owned state path. Before any Worker spawn, query `status`; exploration/review Workers consume wall time but do not consume implementation counters. Before each logical work-unit start, implementation Worker attempt, replan, or replacement, reserve the corresponding kind (`work_unit`, `implementation_attempt`, `replan`, or `replacement`). After every join or wait, query `status`; at task completion, call `finish`. A replan reuses the original ledger/state path and remaining counters, never a fresh budget.
+Immediately after the first plan is compiled, initialize `task_budget_runtime.py` with the plan's exact `task_budget`, task id, and runtime-owned state path. Before any Worker spawn, query `status`; exploration/review Workers consume wall time but do not consume implementation counters. Before each logical work-unit start, implementation Worker attempt, replan, or replacement, reserve the corresponding kind (`work_unit`, `implementation_attempt`, `replan`, or `replacement`). After every join or wait, query `status`; at task completion, call `finish`. A replan reuses the original ledger/state path and remaining counters, never a fresh budget.
 
 For a bounded manifest, reserve `work_unit` with the validator's stable `logical_unit_fingerprints[unit_id]`, which excludes generation. Reserve `implementation_attempt` with the generation-aware `unit_fingerprints[unit_id]` and an identity derived from `(scope_id, unit_id, generation)`. A replacement therefore consumes a new implementation attempt/replacement reservation without double-counting the same logical work unit; changing acceptance/scope/path/validation under the same logical unit still fails closed.
 
-At the 1500-second soft deadline, do not open work or create reservations; ask existing Workers to checkpoint/converge and harvest their evidence. At the 1800-second hard deadline, first harvest any received checkpoint, then apply lifecycle fencing and cancel active writers. Do not start a replacement Worker or Parent writer after hard stop. An implementation handoff must carry the task-budget state path and current remaining seconds/counters.
+At the plan's `task_budget.soft_timeout_seconds` deadline, do not open new work or create reservations; ask existing Workers to checkpoint/converge and harvest their evidence. At the plan's `task_budget.hard_timeout_seconds` deadline, first harvest any received checkpoint, then apply lifecycle fencing and cancel active writers. Do not start a replacement Worker or Parent writer after hard stop. An implementation handoff must carry the task-budget state path and current remaining seconds/counters.
 
 The task-budget helper is a ledger/decision boundary, not an automatic scheduler: it does not spawn, checkpoint, cancel, fence, or replace Workers. FlowPilot/runtime performs those actions from its result. The lifecycle helper likewise reports requirements; actual cancellation and scheduling remain runtime responsibilities.
 

--- a/tests/lifecycle-runtime.sh
+++ b/tests/lifecycle-runtime.sh
@@ -41,282 +41,190 @@ plan() {
 }
 
 python3 -m py_compile "$LIFECYCLE"
-
 plan --routing delegate --complexity complex --uncertainty high > "$TMP/impl-plan.json"
 python3 - "$TMP/impl-plan.json" > "$TMP/impl-policy.json" <<'PY'
-import json, sys
-p=json.load(open(sys.argv[1]))
-stage=p['implementation_stage']
-assert stage['soft_timeout_seconds']==900 and stage['hard_timeout_seconds']==1800, stage
-assert stage['checkpoint_rearm_seconds']==240 and stage['fallback_policy']=='replan', stage
-print(json.dumps(stage,separators=(',',':')))
+import json,sys
+p=json.load(open(sys.argv[1])); s=p['implementation_stage']
+assert s['soft_timeout_seconds']==900 and s['checkpoint_rearm_seconds']==240 and s['hard_timeout_seconds']==1800,s
+assert s['fallback_policy']=='replan',s
+print(json.dumps(s,separators=(',',':')))
 PY
 IMPL_POLICY="$(cat "$TMP/impl-policy.json")"
 
-# Active liveness is not a timeout and Parent wait intervals are not lifecycle evidence.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl \
-  --stage implementation --started-at 100 --last-progress-at 220 --now 250 --writable > "$TMP/active.json"
+python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id active --stage implementation \
+  --started-at 100 --last-progress-at 220 --now 250 --writable > "$TMP/active.json"
 python3 - "$TMP/active.json" <<'PY'
 import json,sys
-d=json.load(open(sys.argv[1]))
-assert d['action']=='continue' and d['state']=='progressing',d
+d=json.load(open(sys.argv[1])); assert d['action']=='continue' and d['state']=='progressing',d
 assert not d['cancel_required'] and not d['fence_required'],d
-assert d['progress_quality']=='meaningful',d
 PY
 
-# Soft budget requests a non-terminal checkpoint and does not cancel/fence.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id soft \
-  --stage implementation --started-at 100 --last-progress-at 995 --last-meaningful-progress-at 995 \
-  --now 1000 --writable --in-flight > "$TMP/soft.json"
+python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id soft --stage implementation \
+  --started-at 100 --last-progress-at 995 --last-meaningful-progress-at 995 --now 1000 --writable --in-flight > "$TMP/soft.json"
 python3 - "$TMP/soft.json" <<'PY'
 import json,sys
-d=json.load(open(sys.argv[1]))
-assert d['action']=='request_checkpoint' and d['next_checkpoint_sequence']==1,d
-assert d['checkpoint_status']=='not_requested',d
-assert not d['cancel_required'] and not d['fence_required'],d
+d=json.load(open(sys.argv[1])); assert d['action']=='request_checkpoint' and d['next_checkpoint_sequence']==1,d
+assert d['checkpoint_status']=='not_requested' and not d['cancel_required'],d
 PY
 
-# Outstanding checkpoint request is awaited, not spammed.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id soft \
-  --stage implementation --started-at 100 --last-progress-at 1005 --now 1010 --writable --in-flight \
-  --checkpoint-requested-at 1000 > "$TMP/requested.json"
+SEQ_REQUESTED='[{"sequence":1,"generation":0,"requested_at":1000}]'
+python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id soft --stage implementation \
+  --started-at 100 --last-progress-at 1005 --now 1010 --writable --in-flight --checkpoint-sequence-json "$SEQ_REQUESTED" > "$TMP/requested.json"
 python3 - "$TMP/requested.json" <<'PY'
 import json,sys
-d=json.load(open(sys.argv[1]))
-assert d['action']=='await_checkpoint' and d['checkpoint_status']=='requested',d
-assert not d['cancel_required'],d
+d=json.load(open(sys.argv[1])); assert d['action']=='await_checkpoint' and d['checkpoint_status']=='requested',d
 PY
 
-# Returned checkpoint is always harvested before terminal/fallback processing.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id soft \
-  --stage implementation --started-at 100 --last-progress-at 1005 --last-meaningful-progress-at 1005 \
-  --now 1010 --writable --terminal-failure --checkpoint-requested-at 1000 --checkpoint-received-at 1005 \
-  > "$TMP/received.json"
+SEQ_RECEIVED='[{"sequence":1,"generation":0,"requested_at":1000,"received_at":1005}]'
+python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id soft --stage implementation \
+  --started-at 100 --last-progress-at 1005 --last-meaningful-progress-at 1005 --now 1010 --writable --terminal-failure \
+  --checkpoint-sequence-json "$SEQ_RECEIVED" > "$TMP/received.json"
 python3 - "$TMP/received.json" <<'PY'
 import json,sys
-d=json.load(open(sys.argv[1]))
-assert d['action']=='harvest_checkpoint' and d['checkpoint_status']=='received',d
+d=json.load(open(sys.argv[1])); assert d['action']=='harvest_checkpoint' and d['checkpoint_status']=='received',d
 assert d['fallback_policy'] is None and not d['cancel_required'],d
 PY
 
-# A harvested checkpoint is non-terminal. With no new explicit meaningful delta,
-# liveness alone does not re-arm another checkpoint.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id soft \
-  --stage implementation --started-at 100 --last-progress-at 1195 --now 1200 --writable --in-flight \
-  --checkpoint-sequence-json '[{"sequence":1,"generation":0,"requested_at":900,"received_at":910,"harvested_at":920}]' \
-  > "$TMP/no-rearm.json"
+SEQ_HARVESTED='[{"sequence":1,"generation":0,"requested_at":900,"received_at":910,"harvested_at":920}]'
+python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id no-rearm --stage implementation \
+  --started-at 100 --last-progress-at 1195 --now 1200 --writable --in-flight --checkpoint-sequence-json "$SEQ_HARVESTED" > "$TMP/no-rearm.json"
 python3 - "$TMP/no-rearm.json" <<'PY'
 import json,sys
-d=json.load(open(sys.argv[1]))
-assert d['action']=='continue' and d['checkpoint_status']=='harvested',d
-assert d['next_checkpoint_sequence'] is None,d
+d=json.load(open(sys.argv[1])); assert d['action']=='continue' and d['next_checkpoint_sequence'] is None,d
 assert 'last_progress_at cannot re-arm' in d['reason'],d
 PY
 
-# Explicit acceptance-relevant progress plus cooldown re-arms sequence 2.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id rearm \
-  --stage implementation --started-at 100 --last-progress-at 1155 --last-meaningful-progress-at 1155 \
-  --now 1160 --writable --in-flight \
-  --checkpoint-sequence-json '[{"sequence":1,"generation":0,"requested_at":900,"received_at":910,"harvested_at":920}]' \
-  > "$TMP/rearm.json"
+python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id rearm --stage implementation \
+  --started-at 100 --last-progress-at 1155 --last-meaningful-progress-at 1155 --now 1160 --writable --in-flight \
+  --checkpoint-sequence-json "$SEQ_HARVESTED" > "$TMP/rearm.json"
 python3 - "$TMP/rearm.json" <<'PY'
 import json,sys
-d=json.load(open(sys.argv[1]))
-assert d['action']=='request_checkpoint' and d['checkpoint_sequence']==1,d
-assert d['next_checkpoint_sequence']==2 and d['checkpoint_rearm_at']==1160,d
+d=json.load(open(sys.argv[1])); assert d['action']=='request_checkpoint' and d['next_checkpoint_sequence']==2,d
+assert d['checkpoint_rearm_at']==1160 and d['checkpoint_rearm_remaining_seconds']==0,d
 PY
 
-# Before cooldown expiry, even meaningful progress does not churn checkpoints.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id cooldown \
-  --stage implementation --started-at 100 --last-progress-at 995 --last-meaningful-progress-at 995 \
-  --now 1000 --writable --in-flight \
-  --checkpoint-sequence-json '[{"sequence":1,"generation":0,"requested_at":900,"received_at":910,"harvested_at":920}]' \
-  > "$TMP/cooldown.json"
+python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id cooldown --stage implementation \
+  --started-at 100 --last-progress-at 995 --last-meaningful-progress-at 995 --now 1000 --writable --in-flight \
+  --checkpoint-sequence-json "$SEQ_HARVESTED" > "$TMP/cooldown.json"
 python3 - "$TMP/cooldown.json" <<'PY'
 import json,sys
-d=json.load(open(sys.argv[1]))
-assert d['action']=='continue' and d['checkpoint_rearm_remaining_seconds']==160,d
+d=json.load(open(sys.argv[1])); assert d['action']=='continue' and d['checkpoint_rearm_remaining_seconds']==160,d
 PY
 
-# At Worker hard ceiling, a returned checkpoint still wins and is harvested first.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id hard \
-  --stage implementation --started-at 100 --last-progress-at 1895 --last-meaningful-progress-at 1890 \
-  --now 1900 --writable --checkpoint-requested-at 1850 --checkpoint-received-at 1890 > "$TMP/hard-received.json"
+SEQ_HARD_RECEIVED='[{"sequence":1,"generation":0,"requested_at":1850,"received_at":1890}]'
+python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id hard --stage implementation \
+  --started-at 100 --last-progress-at 1895 --last-meaningful-progress-at 1890 --now 1900 --writable \
+  --checkpoint-sequence-json "$SEQ_HARD_RECEIVED" > "$TMP/hard-received.json"
 python3 - "$TMP/hard-received.json" <<'PY'
 import json,sys
-d=json.load(open(sys.argv[1]))
-assert d['wall_seconds']==1800 and d['action']=='harvest_checkpoint',d
-assert d['checkpoint_status']=='received' and not d['cancel_required'],d
+d=json.load(open(sys.argv[1])); assert d['wall_seconds']==1800 and d['action']=='harvest_checkpoint',d
 PY
 
-# After harvest, a live writer at hard timeout is cancelled/fenced. Replan is
-# restricted to the harvested remaining delta.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id hard \
-  --stage implementation --started-at 100 --last-progress-at 1895 --last-meaningful-progress-at 1890 \
-  --now 1901 --writable --checkpoint-requested-at 1850 --checkpoint-received-at 1890 --checkpoint-harvested-at 1900 \
-  > "$TMP/hard-harvested.json"
+SEQ_HARD_HARVESTED='[{"sequence":1,"generation":0,"requested_at":1850,"received_at":1890,"harvested_at":1900}]'
+python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id hard --stage implementation \
+  --started-at 100 --last-progress-at 1895 --last-meaningful-progress-at 1890 --now 1901 --writable \
+  --checkpoint-sequence-json "$SEQ_HARD_HARVESTED" > "$TMP/hard-harvested.json"
 python3 - "$TMP/hard-harvested.json" <<'PY'
 import json,sys
-d=json.load(open(sys.argv[1]))
-assert d['action']=='request_cancel' and d['cancel_required'],d
-assert d['fence_required'] and not d['replacement_allowed'],d
-assert d['replan_scope']=='checkpoint_remaining_delta',d
-assert d['checkpoint_reuse_mode']=='retained_workspace',d
+d=json.load(open(sys.argv[1])); assert d['action']=='request_cancel' and d['cancel_required'] and d['fence_required'],d
+assert d['replan_scope']=='checkpoint_remaining_delta' and d['checkpoint_reuse_mode']=='retained_workspace',d
 PY
 
-# Once cancellation is confirmed, replacement may replan only the remaining delta.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id hard \
-  --stage implementation --started-at 100 --last-progress-at 1895 --last-meaningful-progress-at 1890 \
-  --now 1902 --writable --cancel-confirmed \
-  --checkpoint-requested-at 1850 --checkpoint-received-at 1890 --checkpoint-harvested-at 1900 \
-  > "$TMP/after-cancel.json"
+python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id hard --stage implementation \
+  --started-at 100 --last-progress-at 1895 --last-meaningful-progress-at 1890 --now 1902 --writable --cancel-confirmed \
+  --checkpoint-sequence-json "$SEQ_HARD_HARVESTED" > "$TMP/after-cancel.json"
 python3 - "$TMP/after-cancel.json" <<'PY'
 import json,sys
-d=json.load(open(sys.argv[1]))
-assert d['action']=='replan' and d['replacement_allowed'],d
+d=json.load(open(sys.argv[1])); assert d['action']=='replan' and d['replacement_allowed'],d
 assert d['replan_scope']=='checkpoint_remaining_delta',d
-assert d['checkpoint_reuse_mode']=='retained_workspace',d
 PY
 
-# Isolated replacement can proceed from immutable harvested snapshot while old
-# writer cancellation remains required; later old output remains fenced.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id isolated \
-  --stage implementation --started-at 100 --last-progress-at 1895 --last-meaningful-progress-at 1890 \
-  --now 1901 --writable --replacement-isolated \
-  --checkpoint-requested-at 1850 --checkpoint-received-at 1890 --checkpoint-harvested-at 1900 \
-  > "$TMP/isolated.json"
+python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id isolated --stage implementation \
+  --started-at 100 --last-progress-at 1895 --last-meaningful-progress-at 1890 --now 1901 --writable --replacement-isolated \
+  --checkpoint-sequence-json "$SEQ_HARD_HARVESTED" > "$TMP/isolated.json"
 python3 - "$TMP/isolated.json" <<'PY'
 import json,sys
-d=json.load(open(sys.argv[1]))
-assert d['action']=='replan' and d['replacement_allowed'] and d['cancel_required'],d
-assert d['fence_required'] and d['checkpoint_reuse_mode']=='harvested_snapshot_only',d
+d=json.load(open(sys.argv[1])); assert d['action']=='replan' and d['replacement_allowed'] and d['cancel_required'],d
+assert d['checkpoint_reuse_mode']=='harvested_snapshot_only' and d['fence_required'],d
 PY
 
-# Without a checkpoint, writable idle fallback claims only uncovered scope and
-# requires cancellation/fencing before replacement on the same live scope.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id idle \
-  --stage implementation --started-at 100 --last-progress-at 100 --now 400 --writable > "$TMP/idle.json"
+python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id idle --stage implementation \
+  --started-at 100 --last-progress-at 100 --now 400 --writable > "$TMP/idle.json"
 python3 - "$TMP/idle.json" <<'PY'
 import json,sys
-d=json.load(open(sys.argv[1]))
-assert d['state']=='stalled' and d['action']=='request_cancel',d
+d=json.load(open(sys.argv[1])); assert d['action']=='request_cancel' and d['replan_scope']=='uncovered_scope',d
 assert d['cancel_required'] and d['fence_required'],d
-assert d['replan_scope']=='uncovered_scope',d
 PY
 
-# Parent delta is also a writer and obeys the same fence.
 python3 - "$TMP/impl-policy.json" > "$TMP/parent-policy.json" <<'PY'
 import json,sys
-p=json.load(open(sys.argv[1])); p['fallback_policy']='parent_delta'
-print(json.dumps(p,separators=(',',':')))
+p=json.load(open(sys.argv[1])); p['fallback_policy']='parent_delta'; print(json.dumps(p,separators=(',',':')))
 PY
 PARENT_POLICY="$(cat "$TMP/parent-policy.json")"
-python3 "$LIFECYCLE" --policy-json "$PARENT_POLICY" --scope-id parent \
-  --stage implementation --started-at 100 --last-progress-at 100 --now 400 --writable > "$TMP/parent.json"
+python3 "$LIFECYCLE" --policy-json "$PARENT_POLICY" --scope-id parent --stage implementation \
+  --started-at 100 --last-progress-at 100 --now 400 --writable > "$TMP/parent.json"
 python3 - "$TMP/parent.json" <<'PY'
 import json,sys
-d=json.load(open(sys.argv[1]))
-assert d['action']=='request_cancel' and d['cancel_required'] and d['fence_required'],d
+d=json.load(open(sys.argv[1])); assert d['action']=='request_cancel' and d['fence_required'],d
 assert d['fallback_policy']=='parent_delta' and d['replan_scope'] is None,d
 PY
 
-# Review fallback is now explicitly read-only retry_review, never implementation replan.
 plan --profile quality --routing delegate --complexity complex --risk high --verification-cost high > "$TMP/review-plan.json"
 python3 - "$TMP/review-plan.json" > "$TMP/review-policy.json" <<'PY'
 import json,sys
-p=json.load(open(sys.argv[1])); stage=p['review_stage']
-assert stage is not None and stage['fallback_policy']=='retry_review',stage
-print(json.dumps(stage,separators=(',',':')))
+p=json.load(open(sys.argv[1])); s=p['review_stage']; assert s and s['fallback_policy']=='retry_review',s
+print(json.dumps(s,separators=(',',':')))
 PY
 REVIEW_POLICY="$(cat "$TMP/review-policy.json")"
-python3 "$LIFECYCLE" --policy-json "$REVIEW_POLICY" --scope-id review \
-  --stage review --started-at 100 --last-progress-at 100 --now 500 > "$TMP/review-stall.json"
-python3 - "$TMP/review-stall.json" <<'PY'
+python3 "$LIFECYCLE" --policy-json "$REVIEW_POLICY" --scope-id review --stage review \
+  --started-at 100 --last-progress-at 100 --now 500 > "$TMP/review.json"
+python3 - "$TMP/review.json" <<'PY'
 import json,sys
-d=json.load(open(sys.argv[1]))
-assert d['state']=='stalled' and d['action']=='retry_review',d
-assert d['cancel_required'] and d['replacement_allowed'],d
-assert not d['fence_required'],d
-assert d['replan_scope'] is None and d['checkpoint_reuse_mode'] is None,d
-assert d['fallback_policy']=='retry_review',d
+d=json.load(open(sys.argv[1])); assert d['action']=='retry_review' and d['replacement_allowed'],d
+assert d['replan_scope'] is None and not d['fence_required'],d
 PY
 
-# Terminal review failure can immediately request a read-only replacement.
-python3 "$LIFECYCLE" --policy-json "$REVIEW_POLICY" --scope-id review \
-  --stage review --started-at 100 --last-progress-at 120 --now 130 --terminal-failure > "$TMP/review-failed.json"
-python3 - "$TMP/review-failed.json" <<'PY'
-import json,sys
-d=json.load(open(sys.argv[1]))
-assert d['action']=='retry_review' and not d['cancel_required'],d
-assert d['replacement_allowed'] and not d['fence_required'],d
-assert d['replan_scope'] is None,d
-PY
-
-# Superseded read-only exploration is cancellable without writer fencing.
 plan --routing delegate --complexity complex --uncertainty high > "$TMP/explore-plan.json"
 python3 - "$TMP/explore-plan.json" > "$TMP/explore-policy.json" <<'PY'
 import json,sys
-p=json.load(open(sys.argv[1])); print(json.dumps(p['exploration_stage'],separators=(',',':')))
+print(json.dumps(json.load(open(sys.argv[1]))['exploration_stage'],separators=(',',':')))
 PY
 EXP_POLICY="$(cat "$TMP/explore-policy.json")"
-python3 "$LIFECYCLE" --policy-json "$EXP_POLICY" --scope-id metadata \
-  --stage exploration --started-at 100 --last-progress-at 120 --now 130 --scope-superseded > "$TMP/superseded.json"
+python3 "$LIFECYCLE" --policy-json "$EXP_POLICY" --scope-id explore --stage exploration \
+  --started-at 100 --last-progress-at 120 --now 130 --scope-superseded > "$TMP/superseded.json"
 python3 - "$TMP/superseded.json" <<'PY'
 import json,sys
-d=json.load(open(sys.argv[1]))
-assert d['action']=='request_cancel' and d['cancel_required'],d
-assert not d['fence_required'] and not d['replacement_allowed'],d
+d=json.load(open(sys.argv[1])); assert d['action']=='request_cancel' and not d['fence_required'],d
 PY
 
-# Invalid checkpoint/timestamp/type contracts fail closed.
-if python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id invalid \
-  --stage implementation --started-at 100 --last-progress-at 500 --now 600 --writable \
-  --checkpoint-received-at 550 >/dev/null 2>"$TMP/checkpoint.err"; then
-  echo "checkpoint without request unexpectedly accepted" >&2
-  exit 1
-fi
-grep -Fq 'checkpoint_received_at requires checkpoint_requested_at' "$TMP/checkpoint.err"
-
-if python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id future \
-  --stage implementation --started-at 100 --last-progress-at 601 --now 600 >/dev/null 2>"$TMP/future.err"; then
-  echo "future progress unexpectedly accepted" >&2
-  exit 1
-fi
-grep -Fq 'last_progress_at must be between started_at and now' "$TMP/future.err"
-
-if python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id ms \
-  --stage implementation --started-at 1725324000000 --last-progress-at 1725324001000 --now 1725324002000 \
-  >/dev/null 2>"$TMP/ms.err"; then
-  echo "millisecond timestamp unexpectedly accepted" >&2
-  exit 1
-fi
-grep -Fq 'timestamps must use Unix seconds' "$TMP/ms.err"
-
-python3 - "$ROOT" <<'PY'
-import sys
+# v11 implementation lifecycle is strict: no missing soft/rearm compatibility path.
+python3 - "$ROOT" "$IMPL_POLICY" <<'PY'
+import json,sys
 sys.path.insert(0,sys.argv[1]+'/scripts')
-from strategies.lifecycle_runtime import LifecyclePolicy, WorkerObservation, CheckpointRecord
-base={
- 'join_policy':'required','min_successful_workers':1,'idle_timeout_seconds':10,'hard_timeout_seconds':20,
- 'cancel_if_superseded':False,'cancel_stragglers_after_quorum':False,'fallback_policy':'replan'
-}
-for key,value in (
- ('join_policy',1),('fallback_policy',1),('min_successful_workers',True),
- ('idle_timeout_seconds','10'),('hard_timeout_seconds',float('inf')),('checkpoint_rearm_seconds',True),
-):
-    candidate=dict(base); candidate[key]=value
-    try: LifecyclePolicy.from_dict(candidate)
+from strategies.lifecycle_runtime import LifecyclePolicy,WorkerObservation,evaluate_worker,CheckpointRecord
+base=json.loads(sys.argv[2])
+obs=WorkerObservation('strict','implementation',100,100,101)
+for field in ('soft_timeout_seconds','checkpoint_rearm_seconds'):
+    bad=dict(base); bad.pop(field,None)
+    try: evaluate_worker(LifecyclePolicy.from_dict(bad),obs)
     except ValueError: pass
-    else: raise AssertionError((key,value))
-for observation in (
-    WorkerObservation('future','implementation',100,101,100),
-    WorkerObservation('generation','implementation',100,100,100,generation=1,checkpoint_sequence=(CheckpointRecord(1,0,100),)),
-    WorkerObservation('mixed','implementation',100,100,100,checkpoint_requested_at=100,checkpoint_sequence=()),
+    else: raise AssertionError(field)
+for candidate in (
+    WorkerObservation('gap','implementation',100,100,200,checkpoint_sequence=(CheckpointRecord(2,0,150),)),
+    WorkerObservation('gen','implementation',100,100,200,generation=1,checkpoint_sequence=(CheckpointRecord(1,0,150),)),
+    WorkerObservation('meaningful','implementation',100,150,200,last_meaningful_progress_at=160),
 ):
-    try: observation.validate()
+    try: candidate.validate()
     except ValueError: pass
-    else: raise AssertionError(observation)
-print('adversarial lifecycle contract tests passed')
+    else: raise AssertionError(candidate)
+print('strict v11 lifecycle contract tests passed')
 PY
 
-printf 'lifecycle runtime and restored regression tests passed\n'
+# Removed legacy checkpoint CLI flags must fail argument parsing.
+if python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id legacy --stage implementation \
+  --started-at 100 --last-progress-at 100 --now 101 --checkpoint-requested-at 100 >/dev/null 2>&1; then
+  echo "removed legacy checkpoint flag unexpectedly accepted" >&2
+  exit 1
+fi
+
+printf 'lifecycle runtime v11 contract tests passed\n'

--- a/tests/lifecycle-runtime.sh
+++ b/tests/lifecycle-runtime.sh
@@ -5,20 +5,17 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 POLICY="$TMP/codex-flow.toml"
+LIFECYCLE="$ROOT/scripts/strategies/lifecycle_runtime.py"
 
 cat > "$POLICY" <<'EOF'
 schema_version = 4
-
 [strategy]
 profile = "efficient"
-
 [routing]
 mode = "adaptive"
-
 [modifiers]
 review = "auto"
 fanout = "auto"
-
 [parent]
 model_policy = "latest-capable"
 min_model = "auto"
@@ -26,7 +23,6 @@ min_reasoning_effort = "high"
 routine_effort = "high"
 complex_effort = "high"
 critical_effort = "xhigh"
-
 [worker]
 model_policy = "latest-efficient"
 model = "auto"
@@ -35,7 +31,6 @@ min_reasoning_effort = "xhigh"
 routine_effort = "xhigh"
 complex_effort = "xhigh"
 critical_effort = "max"
-
 [runtime]
 max_concurrent_threads = 4
 max_repair_cycles = 2
@@ -45,778 +40,283 @@ plan() {
   python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" plan --repo-policy none --quota-pressure unknown "$@"
 }
 
-LIFECYCLE="$ROOT/scripts/strategies/lifecycle_runtime.py"
 python3 -m py_compile "$LIFECYCLE"
 
-# The lifecycle state machine consumes observable facts, never Parent wait counts.
-plan --routing delegate --complexity complex --uncertainty high > "$TMP/plan.json"
-python3 - "$TMP/plan.json" > "$TMP/impl-policy.json" <<'PY'
+plan --routing delegate --complexity complex --uncertainty high > "$TMP/impl-plan.json"
+python3 - "$TMP/impl-plan.json" > "$TMP/impl-policy.json" <<'PY'
 import json, sys
 p=json.load(open(sys.argv[1]))
-assert p["implementation_stage"]["soft_timeout_seconds"] == 900, p
-assert p["implementation_stage"]["hard_timeout_seconds"] == 1800, p
-print(json.dumps(p["implementation_stage"], separators=(",", ":")))
+stage=p['implementation_stage']
+assert stage['soft_timeout_seconds']==900 and stage['hard_timeout_seconds']==1800, stage
+assert stage['checkpoint_rearm_seconds']==240 and stage['fallback_policy']=='replan', stage
+print(json.dumps(stage,separators=(',',':')))
 PY
 IMPL_POLICY="$(cat "$TMP/impl-policy.json")"
 
-# Efficient soft budgets are complexity-aware while preserving the existing 30-minute hard ceiling.
-plan --routing delegate --complexity routine > "$TMP/routine-plan.json"
-plan --routing delegate --complexity critical --risk critical > "$TMP/critical-plan.json"
-python3 - "$TMP/routine-plan.json" "$TMP/critical-plan.json" <<'PY'
-import json, sys
-routine=json.load(open(sys.argv[1])); critical=json.load(open(sys.argv[2]))
-assert routine["implementation_stage"]["soft_timeout_seconds"] == 600, routine
-assert critical["implementation_stage"]["soft_timeout_seconds"] == 1200, critical
-assert routine["implementation_stage"]["hard_timeout_seconds"] == 1800, routine
-assert critical["implementation_stage"]["hard_timeout_seconds"] == 1800, critical
-assert routine["implementation_stage"]["checkpoint_rearm_seconds"] == 180, routine
-assert critical["implementation_stage"]["checkpoint_rearm_seconds"] == 300, critical
-for plan in (routine, critical):
-    stage = plan["implementation_stage"]
-    assert stage["soft_timeout_seconds"] + stage["checkpoint_rearm_seconds"] < stage["hard_timeout_seconds"], stage
-PY
-
+# Active liveness is not a timeout and Parent wait intervals are not lifecycle evidence.
 python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl \
-  --stage implementation --started-at 100 --last-progress-at 220 --now 250 --writable > "$TMP/progress.json"
-python3 - "$TMP/progress.json" <<'PY'
-import json, sys
+  --stage implementation --started-at 100 --last-progress-at 220 --now 250 --writable > "$TMP/active.json"
+python3 - "$TMP/active.json" <<'PY'
+import json,sys
 d=json.load(open(sys.argv[1]))
-assert d["state"]=="progressing" and d["action"]=="continue", d
-assert d["cancel_required"] is False, d
-assert d["replacement_allowed"] is False and d["fence_required"] is False, d
-assert d["progress_quality"]=="meaningful" and d["meaningful_idle_seconds"]==30, d
-assert d["checkpoint_status"]=="not_requested", d
-assert d["replan_scope"] is None and d["checkpoint_reuse_mode"] is None, d
+assert d['action']=='continue' and d['state']=='progressing',d
+assert not d['cancel_required'] and not d['fence_required'],d
+assert d['progress_quality']=='meaningful',d
 PY
 
-# Reaching the soft budget requests convergence/checkpoint only. It never cancels or fences a healthy Worker.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl-soft \
-  --stage implementation --started-at 100 --last-progress-at 995 --now 1000 --writable --in-flight > "$TMP/soft.json"
+# Soft budget requests a non-terminal checkpoint and does not cancel/fence.
+python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id soft \
+  --stage implementation --started-at 100 --last-progress-at 995 --last-meaningful-progress-at 995 \
+  --now 1000 --writable --in-flight > "$TMP/soft.json"
 python3 - "$TMP/soft.json" <<'PY'
-import json, sys
+import json,sys
 d=json.load(open(sys.argv[1]))
-assert d["state"]=="progressing" and d["action"]=="request_checkpoint", d
-assert d["checkpoint_status"]=="not_requested", d
-assert d["cancel_required"] is False, d
-assert d["replacement_allowed"] is False and d["fence_required"] is False, d
-assert d["fallback_policy"] is None, d
-assert d["progress_quality"]=="meaningful", d
-assert d["replan_scope"] is None, d
-assert "without cancelling Worker" in d["reason"], d
+assert d['action']=='request_checkpoint' and d['next_checkpoint_sequence']==1,d
+assert d['checkpoint_status']=='not_requested',d
+assert not d['cancel_required'] and not d['fence_required'],d
 PY
 
-# Checkpoint request is stateful: after requesting it, do not repeatedly request or cancel the Worker.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl-soft \
-  --stage implementation --started-at 100 --last-progress-at 995 --now 1010 --writable --in-flight \
-  --checkpoint-requested-at 1000 > "$TMP/checkpoint-requested.json"
-python3 - "$TMP/checkpoint-requested.json" <<'PY'
-import json, sys
+# Outstanding checkpoint request is awaited, not spammed.
+python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id soft \
+  --stage implementation --started-at 100 --last-progress-at 1005 --now 1010 --writable --in-flight \
+  --checkpoint-requested-at 1000 > "$TMP/requested.json"
+python3 - "$TMP/requested.json" <<'PY'
+import json,sys
 d=json.load(open(sys.argv[1]))
-assert d["action"]=="await_checkpoint" and d["checkpoint_status"]=="requested", d
-assert d["cancel_required"] is False and d["fallback_policy"] is None, d
-assert d["fence_required"] is False and d["replacement_allowed"] is False, d
+assert d['action']=='await_checkpoint' and d['checkpoint_status']=='requested',d
+assert not d['cancel_required'],d
 PY
 
-# Once the Worker returns a checkpoint, Parent must harvest it before any later fallback.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl-soft \
+# Returned checkpoint is always harvested before terminal/fallback processing.
+python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id soft \
   --stage implementation --started-at 100 --last-progress-at 1005 --last-meaningful-progress-at 1005 \
-  --now 1010 --writable --in-flight --checkpoint-requested-at 1000 --checkpoint-received-at 1005 \
-  > "$TMP/checkpoint-received.json"
-python3 - "$TMP/checkpoint-received.json" <<'PY'
-import json, sys
+  --now 1010 --writable --terminal-failure --checkpoint-requested-at 1000 --checkpoint-received-at 1005 \
+  > "$TMP/received.json"
+python3 - "$TMP/received.json" <<'PY'
+import json,sys
 d=json.load(open(sys.argv[1]))
-assert d["action"]=="harvest_checkpoint" and d["checkpoint_status"]=="received", d
-assert d["cancel_required"] is False and d["fallback_policy"] is None, d
-assert d["fence_required"] is False and d["replacement_allowed"] is False, d
-assert d["replan_scope"] is None, d
-assert "remaining delta" in d["reason"], d
+assert d['action']=='harvest_checkpoint' and d['checkpoint_status']=='received',d
+assert d['fallback_policy'] is None and not d['cancel_required'],d
 PY
 
-# A terminal-success flag does not let Parent consume a returned checkpoint
-# without harvesting it first.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl-terminal-checkpoint \
-  --stage implementation --started-at 100 --last-progress-at 1005 --last-meaningful-progress-at 1005 \
-  --now 1010 --writable --terminal-success --checkpoint-requested-at 1000 --checkpoint-received-at 1005 \
-  > "$TMP/terminal-checkpoint.json"
-python3 - "$TMP/terminal-checkpoint.json" <<'PY'
-import json, sys
+# A harvested checkpoint is non-terminal. With no new explicit meaningful delta,
+# liveness alone does not re-arm another checkpoint.
+python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id soft \
+  --stage implementation --started-at 100 --last-progress-at 1195 --now 1200 --writable --in-flight \
+  --checkpoint-sequence-json '[{"sequence":1,"generation":0,"requested_at":900,"received_at":910,"harvested_at":920}]' \
+  > "$TMP/no-rearm.json"
+python3 - "$TMP/no-rearm.json" <<'PY'
+import json,sys
 d=json.load(open(sys.argv[1]))
-assert d["action"]=="harvest_checkpoint" and d["checkpoint_status"]=="received", d
-assert d["cancel_required"] is False and d["fallback_policy"] is None, d
+assert d['action']=='continue' and d['checkpoint_status']=='harvested',d
+assert d['next_checkpoint_sequence'] is None,d
+assert 'last_progress_at cannot re-arm' in d['reason'],d
 PY
 
-# A harvested checkpoint is non-terminal; the existing Worker continues instead of being recalled.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl-soft \
-  --stage implementation --started-at 100 --last-progress-at 1010 --last-meaningful-progress-at 1005 \
-  --now 1020 --writable --in-flight --checkpoint-requested-at 1000 --checkpoint-received-at 1005 \
-  --checkpoint-harvested-at 1010 > "$TMP/checkpoint-harvested.json"
-python3 - "$TMP/checkpoint-harvested.json" <<'PY'
-import json, sys
+# Explicit acceptance-relevant progress plus cooldown re-arms sequence 2.
+python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id rearm \
+  --stage implementation --started-at 100 --last-progress-at 1155 --last-meaningful-progress-at 1155 \
+  --now 1160 --writable --in-flight \
+  --checkpoint-sequence-json '[{"sequence":1,"generation":0,"requested_at":900,"received_at":910,"harvested_at":920}]' \
+  > "$TMP/rearm.json"
+python3 - "$TMP/rearm.json" <<'PY'
+import json,sys
 d=json.load(open(sys.argv[1]))
-assert d["action"]=="continue" and d["checkpoint_status"]=="harvested", d
-assert d["cancel_required"] is False and d["fallback_policy"] is None, d
-assert d["replan_scope"] is None and d["checkpoint_reuse_mode"] is None, d
-assert "already been harvested" in d["reason"], d
+assert d['action']=='request_checkpoint' and d['checkpoint_sequence']==1,d
+assert d['next_checkpoint_sequence']==2 and d['checkpoint_rearm_at']==1160,d
 PY
 
-# Critical invariant: even at the hard ceiling, an already-returned checkpoint is harvested before cancellation/fallback.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl-hard-checkpoint \
+# Before cooldown expiry, even meaningful progress does not churn checkpoints.
+python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id cooldown \
+  --stage implementation --started-at 100 --last-progress-at 995 --last-meaningful-progress-at 995 \
+  --now 1000 --writable --in-flight \
+  --checkpoint-sequence-json '[{"sequence":1,"generation":0,"requested_at":900,"received_at":910,"harvested_at":920}]' \
+  > "$TMP/cooldown.json"
+python3 - "$TMP/cooldown.json" <<'PY'
+import json,sys
+d=json.load(open(sys.argv[1]))
+assert d['action']=='continue' and d['checkpoint_rearm_remaining_seconds']==160,d
+PY
+
+# At Worker hard ceiling, a returned checkpoint still wins and is harvested first.
+python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id hard \
   --stage implementation --started-at 100 --last-progress-at 1895 --last-meaningful-progress-at 1890 \
-  --now 1900 --writable --checkpoint-requested-at 1850 --checkpoint-received-at 1890 \
-  > "$TMP/hard-checkpoint-unharvested.json"
-python3 - "$TMP/hard-checkpoint-unharvested.json" <<'PY'
-import json, sys
+  --now 1900 --writable --checkpoint-requested-at 1850 --checkpoint-received-at 1890 > "$TMP/hard-received.json"
+python3 - "$TMP/hard-received.json" <<'PY'
+import json,sys
 d=json.load(open(sys.argv[1]))
-assert d["wall_seconds"]==1800 and d["action"]=="harvest_checkpoint", d
-assert d["checkpoint_status"]=="received", d
-assert d["cancel_required"] is False and d["fallback_policy"] is None, d
-assert d["fence_required"] is False and d["replan_scope"] is None, d
+assert d['wall_seconds']==1800 and d['action']=='harvest_checkpoint',d
+assert d['checkpoint_status']=='received' and not d['cancel_required'],d
 PY
 
-# A requested checkpoint without a returned payload does not defeat a hard
-# timeout: the Worker still needs fallback and cancellation/fencing.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl-requested-hard \
-  --stage implementation --started-at 100 --last-progress-at 1895 --now 1900 --writable --in-flight \
-  --checkpoint-requested-at 1850 > "$TMP/requested-hard.json"
-python3 - "$TMP/requested-hard.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["wall_seconds"]==1800 and d["checkpoint_status"]=="requested", d
-assert d["action"]=="request_cancel" and d["cancel_required"] is True, d
-assert d["fence_required"] is True and d["fallback_policy"]=="replan", d
-assert d["replan_scope"]=="uncovered_scope", d
-PY
-
-# The same requested-without-payload state remains a fallback/cancel decision
-# after the hard boundary, not an indefinitely pending checkpoint.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl-requested-timeout \
-  --stage implementation --started-at 100 --last-progress-at 1895 --now 2000 --writable \
-  --checkpoint-requested-at 1850 > "$TMP/requested-timeout.json"
-python3 - "$TMP/requested-timeout.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["wall_seconds"]==1900 and d["checkpoint_status"]=="requested", d
-assert d["action"]=="request_cancel" and d["cancel_required"] is True, d
-assert d["fence_required"] is True and d["fallback_policy"]=="replan", d
-assert d["replan_scope"]=="uncovered_scope", d
-PY
-
-# After harvest, hard-timeout cancellation is fenced and the future replan is explicitly restricted to remaining_delta.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl-hard-checkpoint \
+# After harvest, a live writer at hard timeout is cancelled/fenced. Replan is
+# restricted to the harvested remaining delta.
+python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id hard \
   --stage implementation --started-at 100 --last-progress-at 1895 --last-meaningful-progress-at 1890 \
-  --now 1901 --writable --checkpoint-requested-at 1850 --checkpoint-received-at 1890 \
-  --checkpoint-harvested-at 1900 > "$TMP/hard-checkpoint-harvested.json"
-python3 - "$TMP/hard-checkpoint-harvested.json" <<'PY'
-import json, sys
+  --now 1901 --writable --checkpoint-requested-at 1850 --checkpoint-received-at 1890 --checkpoint-harvested-at 1900 \
+  > "$TMP/hard-harvested.json"
+python3 - "$TMP/hard-harvested.json" <<'PY'
+import json,sys
 d=json.load(open(sys.argv[1]))
-assert d["action"]=="request_cancel" and d["checkpoint_status"]=="harvested", d
-assert d["cancel_required"] is True and d["fence_required"] is True, d
-assert d["fallback_policy"]=="replan", d
-assert d["replan_scope"]=="checkpoint_remaining_delta", d
-assert d["checkpoint_reuse_mode"]=="retained_workspace", d
-assert "remaining_delta" in d["reason"] and "completed work must be preserved" in d["reason"], d
+assert d['action']=='request_cancel' and d['cancel_required'],d
+assert d['fence_required'] and not d['replacement_allowed'],d
+assert d['replan_scope']=='checkpoint_remaining_delta',d
+assert d['checkpoint_reuse_mode']=='retained_workspace',d
 PY
 
-# Even an already-harvested checkpoint cannot keep a Worker past hard timeout;
-# the fallback is limited to the harvested remaining delta and is fenced.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl-harvested-hard \
+# Once cancellation is confirmed, replacement may replan only the remaining delta.
+python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id hard \
   --stage implementation --started-at 100 --last-progress-at 1895 --last-meaningful-progress-at 1890 \
-  --now 1900 --writable --checkpoint-requested-at 1850 --checkpoint-received-at 1890 \
-  --checkpoint-harvested-at 1895 > "$TMP/harvested-hard.json"
-python3 - "$TMP/harvested-hard.json" <<'PY'
-import json, sys
+  --now 1902 --writable --cancel-confirmed \
+  --checkpoint-requested-at 1850 --checkpoint-received-at 1890 --checkpoint-harvested-at 1900 \
+  > "$TMP/after-cancel.json"
+python3 - "$TMP/after-cancel.json" <<'PY'
+import json,sys
 d=json.load(open(sys.argv[1]))
-assert d["wall_seconds"]==1800 and d["checkpoint_status"]=="harvested", d
-assert d["action"]=="request_cancel" and d["cancel_required"] is True, d
-assert d["fence_required"] is True and d["fallback_policy"]=="replan", d
-assert d["replan_scope"]=="checkpoint_remaining_delta", d
+assert d['action']=='replan' and d['replacement_allowed'],d
+assert d['replan_scope']=='checkpoint_remaining_delta',d
+assert d['checkpoint_reuse_mode']=='retained_workspace',d
 PY
 
-# Once the old writer is confirmed cancelled, replacement replan still receives only remaining_delta and retains the workspace.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl-hard-checkpoint \
+# Isolated replacement can proceed from immutable harvested snapshot while old
+# writer cancellation remains required; later old output remains fenced.
+python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id isolated \
   --stage implementation --started-at 100 --last-progress-at 1895 --last-meaningful-progress-at 1890 \
-  --now 1902 --writable --cancel-confirmed --checkpoint-requested-at 1850 --checkpoint-received-at 1890 \
-  --checkpoint-harvested-at 1900 > "$TMP/replan-after-cancel.json"
-python3 - "$TMP/replan-after-cancel.json" <<'PY'
-import json, sys
+  --now 1901 --writable --replacement-isolated \
+  --checkpoint-requested-at 1850 --checkpoint-received-at 1890 --checkpoint-harvested-at 1900 \
+  > "$TMP/isolated.json"
+python3 - "$TMP/isolated.json" <<'PY'
+import json,sys
 d=json.load(open(sys.argv[1]))
-assert d["action"]=="replan" and d["replacement_allowed"] is True, d
-assert d["replan_scope"]=="checkpoint_remaining_delta", d
-assert d["checkpoint_reuse_mode"]=="retained_workspace", d
-assert d["cancel_required"] is False, d
+assert d['action']=='replan' and d['replacement_allowed'] and d['cancel_required'],d
+assert d['fence_required'] and d['checkpoint_reuse_mode']=='harvested_snapshot_only',d
 PY
 
-# An isolated replacement may start from the immutable harvested snapshot only; later old-Worker output stays fenced.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl-hard-checkpoint \
-  --stage implementation --started-at 100 --last-progress-at 1895 --last-meaningful-progress-at 1890 \
-  --now 1901 --writable --replacement-isolated --checkpoint-requested-at 1850 --checkpoint-received-at 1890 \
-  --checkpoint-harvested-at 1900 > "$TMP/replan-isolated.json"
-python3 - "$TMP/replan-isolated.json" <<'PY'
-import json, sys
+# Without a checkpoint, writable idle fallback claims only uncovered scope and
+# requires cancellation/fencing before replacement on the same live scope.
+python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id idle \
+  --stage implementation --started-at 100 --last-progress-at 100 --now 400 --writable > "$TMP/idle.json"
+python3 - "$TMP/idle.json" <<'PY'
+import json,sys
 d=json.load(open(sys.argv[1]))
-assert d["action"]=="replan" and d["replacement_allowed"] is True, d
-assert d["cancel_required"] is True and d["fence_required"] is True, d
-assert d["replan_scope"]=="checkpoint_remaining_delta", d
-assert d["checkpoint_reuse_mode"]=="harvested_snapshot_only", d
+assert d['state']=='stalled' and d['action']=='request_cancel',d
+assert d['cancel_required'] and d['fence_required'],d
+assert d['replan_scope']=='uncovered_scope',d
 PY
 
-# Terminal failure also harvests a returned checkpoint before replanning, so partial work is never silently discarded.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl-failed-checkpoint \
-  --stage implementation --started-at 100 --last-progress-at 300 --now 320 --writable --terminal-failure \
-  --checkpoint-requested-at 250 --checkpoint-received-at 300 > "$TMP/failed-checkpoint.json"
-python3 - "$TMP/failed-checkpoint.json" <<'PY'
-import json, sys
+# Parent delta is also a writer and obeys the same fence.
+python3 - "$TMP/impl-policy.json" > "$TMP/parent-policy.json" <<'PY'
+import json,sys
+p=json.load(open(sys.argv[1])); p['fallback_policy']='parent_delta'
+print(json.dumps(p,separators=(',',':')))
+PY
+PARENT_POLICY="$(cat "$TMP/parent-policy.json")"
+python3 "$LIFECYCLE" --policy-json "$PARENT_POLICY" --scope-id parent \
+  --stage implementation --started-at 100 --last-progress-at 100 --now 400 --writable > "$TMP/parent.json"
+python3 - "$TMP/parent.json" <<'PY'
+import json,sys
 d=json.load(open(sys.argv[1]))
-assert d["action"]=="harvest_checkpoint" and d["checkpoint_status"]=="received", d
-assert d["cancel_required"] is False and d["fallback_policy"] is None, d
+assert d['action']=='request_cancel' and d['cancel_required'] and d['fence_required'],d
+assert d['fallback_policy']=='parent_delta' and d['replan_scope'] is None,d
 PY
 
-# After that checkpoint is harvested, terminal failure replan is remaining-delta-only.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl-failed-checkpoint \
-  --stage implementation --started-at 100 --last-progress-at 300 --now 321 --writable --terminal-failure \
-  --checkpoint-requested-at 250 --checkpoint-received-at 300 --checkpoint-harvested-at 320 \
-  > "$TMP/failed-checkpoint-harvested.json"
-python3 - "$TMP/failed-checkpoint-harvested.json" <<'PY'
-import json, sys
+# Review fallback is now explicitly read-only retry_review, never implementation replan.
+plan --profile quality --routing delegate --complexity complex --risk high --verification-cost high > "$TMP/review-plan.json"
+python3 - "$TMP/review-plan.json" > "$TMP/review-policy.json" <<'PY'
+import json,sys
+p=json.load(open(sys.argv[1])); stage=p['review_stage']
+assert stage is not None and stage['fallback_policy']=='retry_review',stage
+print(json.dumps(stage,separators=(',',':')))
+PY
+REVIEW_POLICY="$(cat "$TMP/review-policy.json")"
+python3 "$LIFECYCLE" --policy-json "$REVIEW_POLICY" --scope-id review \
+  --stage review --started-at 100 --last-progress-at 100 --now 500 > "$TMP/review-stall.json"
+python3 - "$TMP/review-stall.json" <<'PY'
+import json,sys
 d=json.load(open(sys.argv[1]))
-assert d["action"]=="replan" and d["replacement_allowed"] is True, d
-assert d["replan_scope"]=="checkpoint_remaining_delta", d
-assert d["checkpoint_reuse_mode"]=="retained_workspace", d
+assert d['state']=='stalled' and d['action']=='retry_review',d
+assert d['cancel_required'] and d['replacement_allowed'],d
+assert not d['fence_required'],d
+assert d['replan_scope'] is None and d['checkpoint_reuse_mode'] is None,d
+assert d['fallback_policy']=='retry_review',d
 PY
 
-# Invalid checkpoint timelines fail fast instead of pretending a payload was harvested.
-if python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl-invalid-checkpoint \
+# Terminal review failure can immediately request a read-only replacement.
+python3 "$LIFECYCLE" --policy-json "$REVIEW_POLICY" --scope-id review \
+  --stage review --started-at 100 --last-progress-at 120 --now 130 --terminal-failure > "$TMP/review-failed.json"
+python3 - "$TMP/review-failed.json" <<'PY'
+import json,sys
+d=json.load(open(sys.argv[1]))
+assert d['action']=='retry_review' and not d['cancel_required'],d
+assert d['replacement_allowed'] and not d['fence_required'],d
+assert d['replan_scope'] is None,d
+PY
+
+# Superseded read-only exploration is cancellable without writer fencing.
+plan --routing delegate --complexity complex --uncertainty high > "$TMP/explore-plan.json"
+python3 - "$TMP/explore-plan.json" > "$TMP/explore-policy.json" <<'PY'
+import json,sys
+p=json.load(open(sys.argv[1])); print(json.dumps(p['exploration_stage'],separators=(',',':')))
+PY
+EXP_POLICY="$(cat "$TMP/explore-policy.json")"
+python3 "$LIFECYCLE" --policy-json "$EXP_POLICY" --scope-id metadata \
+  --stage exploration --started-at 100 --last-progress-at 120 --now 130 --scope-superseded > "$TMP/superseded.json"
+python3 - "$TMP/superseded.json" <<'PY'
+import json,sys
+d=json.load(open(sys.argv[1]))
+assert d['action']=='request_cancel' and d['cancel_required'],d
+assert not d['fence_required'] and not d['replacement_allowed'],d
+PY
+
+# Invalid checkpoint/timestamp/type contracts fail closed.
+if python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id invalid \
   --stage implementation --started-at 100 --last-progress-at 500 --now 600 --writable \
-  --checkpoint-received-at 550 > /dev/null 2> "$TMP/checkpoint.err"; then
+  --checkpoint-received-at 550 >/dev/null 2>"$TMP/checkpoint.err"; then
   echo "checkpoint without request unexpectedly accepted" >&2
   exit 1
 fi
 grep -Fq 'checkpoint_received_at requires checkpoint_requested_at' "$TMP/checkpoint.err"
 
-# Liveness activity and meaningful progress are independent: repeated tool activity does not fake an acceptance delta.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl-activity-only \
-  --stage implementation --started-at 100 --last-progress-at 995 --last-meaningful-progress-at 200 \
-  --now 1000 --writable --in-flight > "$TMP/activity-only-soft.json"
-python3 - "$TMP/activity-only-soft.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["state"]=="progressing" and d["action"]=="request_checkpoint", d
-assert d["progress_quality"]=="activity_only", d
-assert d["idle_seconds"]==5 and d["meaningful_idle_seconds"]==800, d
-assert d["cancel_required"] is False and d["fence_required"] is False, d
-assert "no recent acceptance-relevant delta" in d["reason"], d
-PY
-
-# Recent acceptance-relevant output is classified separately from mere liveness.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl-meaningful \
-  --stage implementation --started-at 100 --last-progress-at 995 --last-meaningful-progress-at 950 \
-  --now 1000 --writable --in-flight > "$TMP/meaningful-soft.json"
-python3 - "$TMP/meaningful-soft.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["progress_quality"]=="meaningful" and d["meaningful_idle_seconds"]==50, d
-assert d["action"]=="request_checkpoint" and d["cancel_required"] is False, d
-assert "recent acceptance-relevant progress" in d["reason"], d
-PY
-
-# Before the soft budget, activity-only work remains alive and is not cancelled or stalled.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl-activity-only-early \
-  --stage implementation --started-at 100 --last-progress-at 500 --last-meaningful-progress-at 100 \
-  --now 600 --writable > "$TMP/activity-only-early.json"
-python3 - "$TMP/activity-only-early.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["state"]=="progressing" and d["action"]=="continue", d
-assert d["progress_quality"]=="activity_only", d
-assert d["cancel_required"] is False and d["fallback_policy"] is None, d
-PY
-
-# Meaningful progress is itself observable progress and cannot be newer than the liveness timestamp.
-if python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl-invalid-meaningful \
-  --stage implementation --started-at 100 --last-progress-at 500 --last-meaningful-progress-at 510 \
-  --now 600 --writable > /dev/null 2> "$TMP/meaningful.err"; then
-  echo "future meaningful progress timestamp unexpectedly accepted" >&2
+if python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id future \
+  --stage implementation --started-at 100 --last-progress-at 601 --now 600 >/dev/null 2>"$TMP/future.err"; then
+  echo "future progress unexpectedly accepted" >&2
   exit 1
 fi
-grep -Fq 'last_meaningful_progress_at cannot be newer than last_progress_at' "$TMP/meaningful.err"
+grep -Fq 'last_progress_at cannot be in the future' "$TMP/future.err"
 
-# Old ExecutionPlans/callers without the optional soft/meaningful/checkpoint fields retain historical lifecycle behavior after upgrade.
-python3 - "$TMP/impl-policy.json" > "$TMP/legacy-impl-policy.json" <<'PY'
-import json, sys
-p=json.load(open(sys.argv[1]))
-p.pop("soft_timeout_seconds", None)
-print(json.dumps(p, separators=(",", ":")))
-PY
-LEGACY_IMPL_POLICY="$(cat "$TMP/legacy-impl-policy.json")"
-python3 "$LIFECYCLE" --policy-json "$LEGACY_IMPL_POLICY" --scope-id impl-legacy \
-  --stage implementation --started-at 100 --last-progress-at 995 --now 1000 --writable --in-flight > "$TMP/legacy.json"
-python3 - "$TMP/legacy.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["state"]=="progressing" and d["action"]=="continue", d
-assert d["progress_quality"]=="meaningful", d
-assert d["checkpoint_status"]=="not_requested", d
-assert d["cancel_required"] is False and d["fallback_policy"] is None, d
-PY
-
-# Millisecond timestamps are rejected rather than silently misclassified as huge elapsed seconds.
-if python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl \
-  --stage implementation --started-at 1725324000000 --last-progress-at 1725324001000 \
-  --now 1725324002000 --writable > /dev/null 2> "$TMP/millisecond.err"; then
+if python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id ms \
+  --stage implementation --started-at 1725324000000 --last-progress-at 1725324001000 --now 1725324002000 \
+  >/dev/null 2>"$TMP/ms.err"; then
   echo "millisecond timestamp unexpectedly accepted" >&2
   exit 1
 fi
-grep -Fq 'timestamps must use seconds, not milliseconds' "$TMP/millisecond.err"
+grep -Fq 'timestamps must use seconds, not milliseconds' "$TMP/ms.err"
 
-# A visible in-flight operation keeps the idle lease alive even beyond idle timeout.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl \
-  --stage implementation --started-at 100 --last-progress-at 100 --now 400 --writable --in-flight > "$TMP/inflight.json"
-python3 - "$TMP/inflight.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["state"] in {"running","progressing"} and d["action"]=="continue", d
-assert d["progress_quality"]=="activity_only", d
-assert d["cancel_required"] is False, d
-PY
-
-# Writable stall + replan without a harvested checkpoint still reports uncovered scope and is fenced.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl \
-  --stage implementation --started-at 100 --last-progress-at 100 --now 400 --writable > "$TMP/stall.json"
-python3 - "$TMP/stall.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["state"]=="stalled" and d["action"]=="request_cancel", d
-assert d["cancel_required"] is True, d
-assert d["fence_required"] is True and d["replacement_allowed"] is False, d
-assert d["replan_scope"]=="uncovered_scope" and d["checkpoint_reuse_mode"] is None, d
-PY
-
-# Once cancellation/termination is confirmed, replan may create a replacement for uncovered scope.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl \
-  --stage implementation --started-at 100 --last-progress-at 100 --now 400 --writable --cancel-confirmed > "$TMP/cancelled.json"
-python3 - "$TMP/cancelled.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["state"]=="cancelled" and d["action"]=="replan", d
-assert d["cancel_required"] is False, d
-assert d["fence_required"] is True and d["replacement_allowed"] is True, d
-assert d["replan_scope"]=="uncovered_scope", d
-PY
-
-# A fresh isolated replacement may proceed while cancellation is still required for the old Worker.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl \
-  --stage implementation --started-at 100 --last-progress-at 100 --now 400 --writable --replacement-isolated > "$TMP/isolated.json"
-python3 - "$TMP/isolated.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["state"]=="stalled" and d["action"]=="replan", d
-assert d["cancel_required"] is True, d
-assert d["replacement_allowed"] is True and d["fence_required"] is True, d
-assert d["replan_scope"]=="uncovered_scope", d
-assert "isolated" in d["reason"], d
-PY
-
-# Writable Parent delta is also a new writer and must obey the same hard fence.
-python3 - "$TMP/impl-policy.json" > "$TMP/parent-delta-policy.json" <<'PY'
-import json, sys
-p=json.load(open(sys.argv[1]))
-p["fallback_policy"]="parent_delta"
-print(json.dumps(p, separators=(",", ":")))
-PY
-PARENT_DELTA_POLICY="$(cat "$TMP/parent-delta-policy.json")"
-python3 "$LIFECYCLE" --policy-json "$PARENT_DELTA_POLICY" --scope-id impl-parent \
-  --stage implementation --started-at 100 --last-progress-at 100 --now 400 --writable > "$TMP/parent-delta-stall.json"
-python3 - "$TMP/parent-delta-stall.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["state"]=="stalled" and d["action"]=="request_cancel", d
-assert d["cancel_required"] is True and d["fence_required"] is True, d
-assert d["replacement_allowed"] is False and d["fallback_policy"]=="parent_delta", d
-assert d["replan_scope"] is None, d
-PY
-
-# Parent may take the writable delta only after old Worker termination is confirmed.
-python3 "$LIFECYCLE" --policy-json "$PARENT_DELTA_POLICY" --scope-id impl-parent \
-  --stage implementation --started-at 100 --last-progress-at 100 --now 400 --writable --cancel-confirmed > "$TMP/parent-delta-cancelled.json"
-python3 - "$TMP/parent-delta-cancelled.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["state"]=="cancelled" and d["action"]=="parent_delta", d
-assert d["cancel_required"] is False and d["fence_required"] is True, d
-assert d["replacement_allowed"] is False, d
-PY
-
-# Or Parent may write in a fresh isolated worktree while the old Worker is still being cancelled.
-python3 "$LIFECYCLE" --policy-json "$PARENT_DELTA_POLICY" --scope-id impl-parent \
-  --stage implementation --started-at 100 --last-progress-at 100 --now 400 --writable --replacement-isolated > "$TMP/parent-delta-isolated.json"
-python3 - "$TMP/parent-delta-isolated.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["state"]=="stalled" and d["action"]=="parent_delta", d
-assert d["cancel_required"] is True and d["fence_required"] is True, d
-assert d["replacement_allowed"] is False, d
-assert "downstream writer is explicitly isolated" in d["reason"], d
-PY
-
-# Terminal failure without a checkpoint may immediately replan, but only uncovered scope is claimed.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl \
-  --stage implementation --started-at 100 --last-progress-at 100 --now 120 --writable --terminal-failure > "$TMP/failed.json"
-python3 - "$TMP/failed.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["state"]=="failed" and d["action"]=="replan", d
-assert d["cancel_required"] is False and d["replacement_allowed"] is True, d
-assert d["replan_scope"]=="uncovered_scope", d
-PY
-
-# Hard wall ceiling still wins when there is no returned checkpoint to preserve, even if work is visibly in-flight.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id impl \
-  --stage implementation --started-at 100 --last-progress-at 1800 --now 2000 --writable --in-flight > "$TMP/hard.json"
-python3 - "$TMP/hard.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["state"]=="stalled" and d["action"]=="request_cancel", d
-assert d["cancel_required"] is True, d
-assert d["replan_scope"]=="uncovered_scope", d
-assert "hard worker wall-clock ceiling" in d["reason"], d
-PY
-
-# Read-only supersession remains cancellable without writable replacement fencing.
-plan --routing delegate --complexity complex --uncertainty high > "$TMP/explorer-plan.json"
-python3 - "$TMP/explorer-plan.json" > "$TMP/explorer-policy.json" <<'PY'
-import json, sys
-p=json.load(open(sys.argv[1]))
-print(json.dumps(p["exploration_stage"], separators=(",", ":")))
-PY
-EXP_POLICY="$(cat "$TMP/explorer-policy.json")"
-python3 "$LIFECYCLE" --policy-json "$EXP_POLICY" --scope-id metadata \
-  --stage exploration --started-at 100 --last-progress-at 120 --now 130 --scope-superseded > "$TMP/superseded.json"
-python3 - "$TMP/superseded.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["state"]=="superseded" and d["action"]=="request_cancel", d
-assert d["cancel_required"] is True, d
-assert d["fence_required"] is False and d["replacement_allowed"] is False, d
-PY
-
-# Once a superseded Worker is cancelled, the scope is already satisfied: no fallback duplication.
-python3 "$LIFECYCLE" --policy-json "$EXP_POLICY" --scope-id metadata \
-  --stage exploration --started-at 100 --last-progress-at 120 --now 140 --scope-superseded --cancel-confirmed > "$TMP/superseded-cancelled.json"
-python3 - "$TMP/superseded-cancelled.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["state"]=="superseded" and d["action"]=="continue", d
-assert d["cancel_required"] is False, d
-assert d["fallback_policy"] is None, d
-PY
-
-# A read-only stalled Worker can fall back immediately, but cancellation is still mandatory.
-python3 "$LIFECYCLE" --policy-json "$EXP_POLICY" --scope-id metadata \
-  --stage exploration --started-at 100 --last-progress-at 100 --now 250 > "$TMP/read-stall.json"
-python3 - "$TMP/read-stall.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["state"]=="stalled" and d["action"]=="parent_delta", d
-assert d["cancel_required"] is True, d
-assert d["fence_required"] is False and d["replacement_allowed"] is False, d
-PY
-
-# Read-only replan may launch a replacement while the old stalled Worker is being cancelled.
-plan --profile quality --routing delegate --complexity complex --risk high --verification-cost high > "$TMP/review-plan.json"
-python3 - "$TMP/review-plan.json" > "$TMP/review-policy.json" <<'PY'
-import json, sys
-p=json.load(open(sys.argv[1]))
-assert p["review_stage"] is not None, p
-print(json.dumps(p["review_stage"], separators=(",", ":")))
-PY
-REV_POLICY="$(cat "$TMP/review-policy.json")"
-python3 "$LIFECYCLE" --policy-json "$REV_POLICY" --scope-id review-runtime \
-  --stage review --started-at 100 --last-progress-at 100 --now 500 > "$TMP/review-stall.json"
-python3 - "$TMP/review-stall.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["state"]=="stalled" and d["action"]=="replan", d
-assert d["cancel_required"] is True, d
-assert d["replacement_allowed"] is True and d["fence_required"] is False, d
-assert d["replan_scope"]=="uncovered_scope", d
-PY
-
-# ---- Restored PR5 regression coverage ----
-
-# Release defaults remain the source of truth for reasoning policy.
-mkdir -p "$TMP/runtime"
-cp "$ROOT/scripts/strategy_runtime.py" "$TMP/runtime/strategy_runtime.py"
-cp -R "$ROOT/scripts/strategies" "$TMP/runtime/strategies"
-cp "$ROOT/policy/defaults.toml" "$TMP/runtime/defaults.toml"
-python3 - "$TMP/runtime/defaults.toml" <<'PY'
-from pathlib import Path
-import sys
-p=Path(sys.argv[1]); s=p.read_text()
-s=s.replace('[reasoning.parent]\nminimum = "high"\nroutine = "high"', '[reasoning.parent]\nminimum = "high"\nroutine = "xhigh"')
-p.write_text(s)
-PY
-cat > "$TMP/release-only.toml" <<'EOF'
-schema_version = 3
-EOF
-python3 "$TMP/runtime/strategy_runtime.py" --policy "$TMP/release-only.toml" plan --repo-policy none --quota-pressure unknown \
-  --routing delegate --complexity routine --risk low > "$TMP/release-default.json"
-python3 - "$TMP/release-default.json" <<'PY'
-import json, sys
-p=json.load(open(sys.argv[1]))
-assert p["parent_reasoning"]=="xhigh" and p["implementer_reasoning"]=="max", p
-PY
-
-# Role-specific model/reasoning behavior from PR5 remains intact.
-plan --profile quality --complexity complex --uncertainty high --risk high --parallelism high \
-  --scope repo-wide --exploration-need high > "$TMP/quality.json"
-python3 - "$TMP/quality.json" <<'PY'
-import json, sys
-p=json.load(open(sys.argv[1]))
-assert p["parent_reasoning"]=="xhigh", p
-assert p["explorer_reasoning"]=="max" and p["implementer_reasoning"]=="max", p
-assert p["explorer_model"]=="gpt-test-efficient" and p["implementer_model"]=="gpt-test-efficient", p
-assert p["reviewer_model"]=="gpt-test-efficient" and p["reviewer_reasoning"]=="max", p
-PY
-
-plan --profile quality --quality-intent strong --complexity routine --risk medium --parallelism limited > "$TMP/quality-strong.json"
-python3 - "$TMP/quality-strong.json" <<'PY'
-import json, sys
-p=json.load(open(sys.argv[1]))
-assert p["explorer_capability_policy"]=="latest-efficient" and p["explorer_model"]=="gpt-test-efficient", p
-assert p["implementer_capability_policy"]=="latest-capable" and p["implementer_model"] is None, p
-assert p["reviewer_capability_policy"]=="latest-capable" and p["reviewer_model"] is None, p
-assert p["explorer_reasoning"]=="max" and p["implementer_reasoning"]=="max", p
-PY
-
-# Speed scaling still follows proven writable-workstream count.
-plan --profile speed --complexity routine --parallelism high --write-conflict low > "$TMP/speed-one.json"
-plan --profile speed --complexity routine --parallelism high --write-conflict low --writable-workstreams 4 > "$TMP/speed-four.json"
-python3 - "$TMP/speed-one.json" "$TMP/speed-four.json" <<'PY'
-import json, sys
-one=json.load(open(sys.argv[1])); four=json.load(open(sys.argv[2]))
-assert one["implementation_workers"]==1, one
-assert four["implementation_workers"]==4 and four["max_concurrent_threads"]==4, four
-assert four["worker_budget"]["max_implementers"]==8, four
-assert any("4 proven isolated workstreams" in n for n in four["notes"]), four
-PY
-
-# Modifiers cannot bypass strategy budgets or writable isolation.
-plan --profile efficient --review strict --fanout aggressive --complexity complex --uncertainty high \
-  --parallelism high --write-conflict low --writable-workstreams 2 > "$TMP/modifiers.json"
-python3 - "$TMP/modifiers.json" <<'PY'
-import json, sys
-p=json.load(open(sys.argv[1]))
-assert p["exploration_workers"]==2 and p["implementation_workers"]==2, p
-assert p["reviewer_workers"]==1 and p["planned_worker_count"]==5, p
-assert p["worker_budget"]["max_total_workers"]==5, p
-PY
-
-# Explicit repo-policy none still disables repository policy discovery.
-mkdir -p "$TMP/repo/subdir"
-touch "$TMP/repo/.git"
-cat > "$TMP/repo/.codex-flow.toml" <<'EOF'
-[strategy]
-profile = "quality"
-[routing]
-mode = "delegate"
-[modifiers]
-review = "strict"
-fanout = "conservative"
-[parent]
-min_reasoning_effort = "xhigh"
-[runtime]
-max_concurrent_threads = 2
-max_repair_cycles = 1
-EOF
-(
-  cd "$TMP/repo/subdir"
-  python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" show --effective --repo-policy none --json > "$TMP/no-repo-show.json"
-  python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" plan --repo-policy none --quota-pressure unknown --complexity routine > "$TMP/no-repo-plan.json"
-)
-python3 - "$TMP/no-repo-show.json" "$TMP/no-repo-plan.json" <<'PY'
-import json, sys
-show=json.load(open(sys.argv[1])); p=json.load(open(sys.argv[2]))
-assert show["strategy"]=="efficient" and show["routing"]=="adaptive", show
-assert show["repo_policy"] is None and p["repo_policy"] is None, (show,p)
-PY
-
-# Task flags may tighten but never raise repository runtime ceilings.
-(
-  cd "$TMP/repo/subdir"
-  python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" plan --quota-pressure unknown --routing delegate \
-    --complexity complex --parallelism high --max-threads 99 --max-repairs 99 > "$TMP/hard-ceiling.json"
-  python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" plan --quota-pressure unknown --routing delegate \
-    --complexity complex --parallelism high --max-threads 1 --max-repairs 0 > "$TMP/tightened.json"
-)
-python3 - "$TMP/hard-ceiling.json" "$TMP/tightened.json" <<'PY'
-import json, sys
-hard=json.load(open(sys.argv[1])); tight=json.load(open(sys.argv[2]))
-assert hard["max_concurrent_threads"] <= 2 and hard["max_repair_cycles"] == 1, hard
-assert tight["max_concurrent_threads"] == 1 and tight["max_repair_cycles"] == 0, tight
-PY
-
-# Critical quota pressure compresses fan-out without lowering reasoning floors.
-python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" plan --repo-policy none --profile balanced --routing delegate \
-  --complexity complex --uncertainty high --parallelism high --quota-pressure critical > "$TMP/quota.json"
-python3 - "$TMP/quota.json" <<'PY'
-import json, sys
-p=json.load(open(sys.argv[1]))
-assert p["exploration_workers"]==1 and p["implementation_workers"]==1, p
-assert p["max_concurrent_threads"]==1 and p["max_repair_cycles"]==1, p
-assert p["parent_reasoning"]=="high", p
-assert p["explorer_reasoning"]=="xhigh" and p["implementer_reasoning"]=="xhigh", p
-PY
-
-# Multi-round checkpoints are immutable, contiguous, and re-arm only after an
-# explicit meaningful delta plus the configured cooldown. The latest record is
-# the current lifecycle status.
-SEQ='[{"sequence":1,"generation":0,"requested_at":900,"received_at":910,"harvested_at":920},{"sequence":2,"generation":0,"requested_at":950}]'
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id multi --stage implementation \
-  --started-at 100 --last-progress-at 960 --last-meaningful-progress-at 960 --now 1000 --writable \
-  --checkpoint-sequence-json "$SEQ" > "$TMP/multi-requested.json"
-python3 - "$TMP/multi-requested.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["checkpoint_generation"] == 0 and d["checkpoint_sequence"] == 2, d
-assert d["checkpoint_status"] == "requested" and d["action"] == "await_checkpoint", d
-assert d["next_checkpoint_sequence"] is None, d
-PY
-
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id multi --stage implementation \
-  --started-at 100 --last-progress-at 1155 --last-meaningful-progress-at 1155 --now 1160 --writable --in-flight \
-  --checkpoint-sequence-json '[{"sequence":1,"generation":0,"requested_at":900,"received_at":910,"harvested_at":920}]' > "$TMP/multi-rearm.json"
-python3 - "$TMP/multi-rearm.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["action"] == "request_checkpoint" and d["checkpoint_sequence"] == 1, d
-assert d["next_checkpoint_sequence"] == 2, d
-assert d["checkpoint_rearm_at"] == 1160 and d["checkpoint_rearm_remaining_seconds"] == 0, d
-PY
-
-# Explicit meaningful progress does not re-arm before the policy cooldown.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id multi-cooldown --stage implementation \
-  --started-at 100 --last-progress-at 995 --last-meaningful-progress-at 995 --now 1000 --writable --in-flight \
-  --checkpoint-sequence-json '[{"sequence":1,"generation":0,"requested_at":900,"received_at":910,"harvested_at":920}]' > "$TMP/multi-cooldown.json"
-python3 - "$TMP/multi-cooldown.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["action"] == "continue" and d["checkpoint_status"] == "harvested", d
-assert d["checkpoint_rearm_at"] == 1160 and d["checkpoint_rearm_remaining_seconds"] == 160, d
-assert "cooldown" in d["reason"], d
-PY
-
-# Liveness activity alone never re-arms a harvested checkpoint, even when the
-# legacy last_progress_at timestamp advances beyond the harvest.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id multi-liveness --stage implementation \
-  --started-at 100 --last-progress-at 1195 --now 1200 --writable --in-flight \
-  --checkpoint-sequence-json '[{"sequence":1,"generation":0,"requested_at":900,"received_at":910,"harvested_at":920}]' > "$TMP/multi-liveness.json"
-python3 - "$TMP/multi-liveness.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["action"] == "continue" and d["checkpoint_status"] == "harvested", d
-assert d["next_checkpoint_sequence"] is None, d
-assert "last_progress_at cannot re-arm" in d["reason"], d
-PY
-
-# A legacy plan without the rearm field remains one-shot, even with explicit
-# meaningful progress after the harvested checkpoint.
-python3 - "$TMP/impl-policy.json" > "$TMP/legacy-checkpoint-policy.json" <<'PY'
-import json, sys
-p=json.load(open(sys.argv[1]))
-p.pop("checkpoint_rearm_seconds", None)
-print(json.dumps(p, separators=(",", ":")))
-PY
-LEGACY_CHECKPOINT_POLICY="$(cat "$TMP/legacy-checkpoint-policy.json")"
-python3 "$LIFECYCLE" --policy-json "$LEGACY_CHECKPOINT_POLICY" --scope-id multi-legacy --stage implementation \
-  --started-at 100 --last-progress-at 1195 --last-meaningful-progress-at 1195 --now 1200 --writable --in-flight \
-  --checkpoint-sequence-json '[{"sequence":1,"generation":0,"requested_at":900,"received_at":910,"harvested_at":920}]' > "$TMP/multi-legacy.json"
-python3 - "$TMP/multi-legacy.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["action"] == "continue" and d["checkpoint_status"] == "harvested", d
-assert d["checkpoint_rearm_at"] is None and d["checkpoint_rearm_remaining_seconds"] is None, d
-assert "legacy/one-shot" in d["reason"], d
-PY
-
-# A pending later round must not hide the earlier durable baseline from replan.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id multi-hard --stage implementation \
-  --started-at 100 --last-progress-at 995 --now 1900 --writable \
-  --checkpoint-sequence-json '[{"sequence":1,"generation":0,"requested_at":900,"received_at":910,"harvested_at":920},{"sequence":2,"generation":0,"requested_at":950}]' > "$TMP/multi-hard.json"
-python3 - "$TMP/multi-hard.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["action"] == "request_cancel" and d["replan_scope"] == "checkpoint_remaining_delta", d
-assert d["checkpoint_sequence"] == 2 and d["harvested_checkpoint_sequence"] == 1, d
-PY
-
-# A returned later checkpoint still wins over hard timeout and must be harvested first.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id multi-hard --stage implementation \
-  --started-at 100 --last-progress-at 1895 --now 1900 --writable \
-  --checkpoint-sequence-json '[{"sequence":1,"generation":0,"requested_at":900,"received_at":910,"harvested_at":920},{"sequence":2,"generation":0,"requested_at":950,"received_at":1895}]' > "$TMP/multi-received-hard.json"
-python3 - "$TMP/multi-received-hard.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["action"] == "harvest_checkpoint" and d["checkpoint_status"] == "received", d
-assert d["harvested_checkpoint_sequence"] == 1, d
-PY
-
-# Repeated soft evaluations without a new meaningful delta are idempotent.
-python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id multi-hard --stage implementation \
-  --started-at 100 --last-progress-at 995 --last-meaningful-progress-at 920 --now 1000 --writable \
-  --checkpoint-sequence-json '[{"sequence":1,"generation":0,"requested_at":900,"received_at":910,"harvested_at":920}]' > "$TMP/multi-no-delta.json"
-python3 - "$TMP/multi-no-delta.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["action"] == "continue" and d["checkpoint_status"] == "harvested", d
-assert d["next_checkpoint_sequence"] is None and d["harvested_checkpoint_sequence"] == 1, d
-PY
-
-if python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id multi --stage implementation \
-  --started-at 100 --last-progress-at 960 --now 1000 --checkpoint-sequence-json \
-  '[{"sequence":1,"generation":0,"requested_at":900,"received_at":910,"harvested_at":920},{"sequence":3,"generation":0,"requested_at":950}]' >/dev/null 2>"$TMP/sequence.err"; then
-  echo "checkpoint sequence gap unexpectedly accepted" >&2
-  exit 1
-fi
-grep -Fq "contiguous starting at 1" "$TMP/sequence.err"
-
-# Strict policy coercion and future progress timestamps fail fast, including
-# values arriving through the JSON CLI boundary.
 python3 - "$ROOT" <<'PY'
-import json
-import subprocess
-import sys
-sys.path.insert(0, sys.argv[1] + "/scripts")
-from strategies.lifecycle_runtime import LifecyclePolicy, WorkerObservation
-from strategies.lifecycle_runtime import CheckpointRecord
-root=sys.argv[1]
-base={"join_policy":"required","min_successful_workers":1,"idle_timeout_seconds":10,"hard_timeout_seconds":20,"cancel_if_superseded":False,"cancel_stragglers_after_quorum":False,"fallback_policy":"replan"}
-for key, value in (("join_policy", 1), ("fallback_policy", 1), ("min_successful_workers", True), ("idle_timeout_seconds", "10"), ("hard_timeout_seconds", float("inf")), ("checkpoint_rearm_seconds", True), ("checkpoint_rearm_seconds", "10"), ("checkpoint_rearm_seconds", float("inf"))):
+import math,sys
+sys.path.insert(0,sys.argv[1]+'/scripts')
+from strategies.lifecycle_runtime import LifecyclePolicy, WorkerObservation, CheckpointRecord
+base={
+ 'join_policy':'required','min_successful_workers':1,'idle_timeout_seconds':10,'hard_timeout_seconds':20,
+ 'cancel_if_superseded':False,'cancel_stragglers_after_quorum':False,'fallback_policy':'replan'
+}
+for key,value in (
+ ('join_policy',1),('fallback_policy',1),('min_successful_workers',True),
+ ('idle_timeout_seconds','10'),('hard_timeout_seconds',float('inf')),('checkpoint_rearm_seconds',True),
+):
     candidate=dict(base); candidate[key]=value
     try: LifecyclePolicy.from_dict(candidate)
     except ValueError: pass
-    else: raise AssertionError(key)
-for key, value in (("min_successful_workers", "1"), ("min_successful_workers", 1.0), ("idle_timeout_seconds", "10"), ("hard_timeout_seconds", float("nan")), ("hard_timeout_seconds", float("inf")), ("hard_timeout_seconds", 10**400), ("checkpoint_rearm_seconds", "10"), ("checkpoint_rearm_seconds", 0), ("checkpoint_rearm_seconds", -1), ("checkpoint_rearm_seconds", 20), ("checkpoint_rearm_seconds", 10)):
-    candidate=dict(base); candidate[key]=value
-    if key == "checkpoint_rearm_seconds" and value == 10:
-        candidate["soft_timeout_seconds"] = 10
-    result=subprocess.run([sys.executable, root + "/scripts/strategies/lifecycle_runtime.py", "--policy-json", json.dumps(candidate), "--scope-id", "strict", "--stage", "implementation", "--started-at", "0", "--last-progress-at", "0", "--now", "1"], capture_output=True, text=True)
-    if result.returncode == 0:
-        raise AssertionError((key, value, result.stdout))
-for in_flight in (False, True):
-    try: WorkerObservation("future", "implementation", 100, 101, 100, in_flight=in_flight).validate()
-    except ValueError: pass
-    else: raise AssertionError(in_flight)
-for in_flight in (False, True):
-    WorkerObservation("equal", "implementation", 100, 100, 100, in_flight=in_flight).validate()
-for candidate in (
-    WorkerObservation("mismatch", "implementation", 100, 100, 100, generation=1, checkpoint_sequence=(CheckpointRecord(1, 0, 100),)),
-    WorkerObservation("mixed", "implementation", 100, 100, 100, checkpoint_requested_at=100, checkpoint_sequence=()),
-    WorkerObservation("unharvested", "implementation", 100, 100, 100, checkpoint_sequence=(CheckpointRecord(1, 0, 100), CheckpointRecord(2, 0, 100))),
+    else: raise AssertionError((key,value))
+for observation in (
+    WorkerObservation('future','implementation',100,101,100),
+    WorkerObservation('generation','implementation',100,100,100,generation=1,checkpoint_sequence=(CheckpointRecord(1,0,100),)),
+    WorkerObservation('mixed','implementation',100,100,100,checkpoint_requested_at=100,checkpoint_sequence=()),
 ):
-    try: candidate.validate()
+    try: observation.validate()
     except ValueError: pass
-    else: raise AssertionError(candidate)
-print("adversarial lifecycle contract tests passed")
+    else: raise AssertionError(observation)
+print('adversarial lifecycle contract tests passed')
 PY
 
 printf 'lifecycle runtime and restored regression tests passed\n'

--- a/tests/lifecycle-runtime.sh
+++ b/tests/lifecycle-runtime.sh
@@ -282,7 +282,7 @@ if python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id future \
   echo "future progress unexpectedly accepted" >&2
   exit 1
 fi
-grep -Fq 'last_progress_at cannot be in the future' "$TMP/future.err"
+grep -Fq 'last_progress_at must be between started_at and now' "$TMP/future.err"
 
 if python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id ms \
   --stage implementation --started-at 1725324000000 --last-progress-at 1725324001000 --now 1725324002000 \
@@ -290,10 +290,10 @@ if python3 "$LIFECYCLE" --policy-json "$IMPL_POLICY" --scope-id ms \
   echo "millisecond timestamp unexpectedly accepted" >&2
   exit 1
 fi
-grep -Fq 'timestamps must use seconds, not milliseconds' "$TMP/ms.err"
+grep -Fq 'timestamps must use Unix seconds' "$TMP/ms.err"
 
 python3 - "$ROOT" <<'PY'
-import math,sys
+import sys
 sys.path.insert(0,sys.argv[1]+'/scripts')
 from strategies.lifecycle_runtime import LifecyclePolicy, WorkerObservation, CheckpointRecord
 base={

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -62,6 +62,15 @@ printf '%s\n' "$disabled_output"
 [[ -f "$CODEX_HOME/codex-flow/telemetry.py" ]]
 [[ -f "$CODEX_HOME/codex-flow/strategy_runtime.py" ]]
 [[ -d "$CODEX_HOME/codex-flow/strategies" ]]
+[[ -f "$CODEX_HOME/codex-flow/strategies/lifecycle_runtime.py" ]]
+[[ -f "$CODEX_HOME/codex-flow/strategies/task_budget_runtime.py" ]]
+[[ -f "$CODEX_HOME/codex-flow/strategies/task_phase_runtime.py" ]]
+[[ -f "$CODEX_HOME/codex-flow/strategies/work_unit_runtime.py" ]]
+python3 -m py_compile \
+  "$CODEX_HOME/codex-flow/strategies/lifecycle_runtime.py" \
+  "$CODEX_HOME/codex-flow/strategies/task_budget_runtime.py" \
+  "$CODEX_HOME/codex-flow/strategies/task_phase_runtime.py" \
+  "$CODEX_HOME/codex-flow/strategies/work_unit_runtime.py"
 [[ -d "$CODEX_HOME/codex-flow/telemetry_core" ]]
 [[ -f "$CODEX_HOME/codex-flow/telemetry_core/latency.py" ]]
 [[ -f "$CODEX_HOME/codex-flow/menu.py" ]]
@@ -125,7 +134,7 @@ codex-flow strategy plan --complexity complex --uncertainty high > "$TMP/install
 python3 - "$TMP/installed-plan.json" <<'PY'
 import json, sys
 p=json.load(open(sys.argv[1]))
-assert p['schema_version']==10, p
+assert p['schema_version']==11, p
 assert p['quality_intent']=='normal', p
 assert p['strategy']=='efficient' and p['routing']=='delegate', p
 assert p['parent_reasoning']=='high', p
@@ -135,9 +144,14 @@ assert p['exploration_workers']==2 and p['implementation_workers']==1, p
 assert p['planned_worker_count']==3, p
 assert p['exploration_stage']['join_policy']=='quorum', p
 assert p['implementation_stage']['join_policy']=='required', p
+assert p['implementation_stage']['soft_timeout_seconds']==900, p
+assert p['implementation_stage']['checkpoint_rearm_seconds']==240, p
+assert p['implementation_stage']['maximum_work_units']==2, p
+assert p['implementation_stage']['require_write_paths'] is True, p
 assert p['review_stage'] is None, p
 assert p['task_budget']['soft_timeout_seconds']==1500, p
 assert p['task_budget']['hard_timeout_seconds']==1800, p
+assert p['task_budget']['max_review_attempts']==0, p
 PY
 codex-flow usage list >/dev/null || true
 codex-flow usage stats >/dev/null || true

--- a/tests/strategy-runtime.sh
+++ b/tests/strategy-runtime.sh
@@ -46,541 +46,193 @@ plan() {
   python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" plan --repo-policy none --quota-pressure unknown "$@"
 }
 
+# Global strategy state and task-only bypass remain deterministic.
 python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" show --json > "$TMP/show.json"
 python3 - "$TMP/show.json" <<'PY'
 import json, sys
-obj=json.load(open(sys.argv[1]))
-assert obj == {"enabled":True,"strategy":"efficient","routing":"adaptive","valid":True}, obj
-PY
-[[ "$(python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY")" == "enabled=true strategy=efficient routing=adaptive" ]]
-[[ "$(python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" enabled)" == "true" ]]
-
-# Missing master-switch state in older policies remains backward-compatible.
-cp "$POLICY" "$TMP/legacy-policy.toml"
-python3 - "$TMP/legacy-policy.toml" <<'PY'
-from pathlib import Path
-import sys
-p=Path(sys.argv[1]); p.write_text(p.read_text().replace("enabled = true\n", "", 1))
-PY
-[[ "$(python3 "$ROOT/scripts/strategy_runtime.py" --policy "$TMP/legacy-policy.toml" enabled)" == "true" ]]
-
-# A present-but-invalid master switch fails closed instead of silently enabling dispatch.
-for invalid_value in flase '""'; do
-  cp "$POLICY" "$TMP/invalid-enabled.toml"
-  python3 - "$TMP/invalid-enabled.toml" "$invalid_value" <<'PY'
-from pathlib import Path
-import sys
-p=Path(sys.argv[1]); value=sys.argv[2]
-p.write_text(p.read_text().replace("enabled = true\n", f"enabled = {value}\n", 1))
-PY
-  set +e
-  python3 "$ROOT/scripts/strategy_runtime.py" --policy "$TMP/invalid-enabled.toml" show --json > "$TMP/invalid-enabled.json" 2> "$TMP/invalid-enabled.err"
-  invalid_show_rc=$?
-  set -e
-  [[ "$invalid_show_rc" -eq 2 ]]
-  python3 - "$TMP/invalid-enabled.json" <<'PY'
-import json, sys
 p=json.load(open(sys.argv[1]))
-assert p["enabled"] is False and p["valid"] is False, p
-assert "invalid [strategy].enabled" in p["error"], p
+assert p == {"enabled":True,"strategy":"efficient","routing":"adaptive","valid":True}, p
 PY
-  if python3 "$ROOT/scripts/strategy_runtime.py" --policy "$TMP/invalid-enabled.toml" enabled >/dev/null 2>"$TMP/invalid-enabled-command.err"; then
-    echo "invalid strategy switch unexpectedly reported a usable state" >&2
-    exit 1
-  fi
-  grep -Fq "invalid [strategy].enabled" "$TMP/invalid-enabled-command.err"
-  if python3 "$ROOT/scripts/strategy_runtime.py" --policy "$TMP/invalid-enabled.toml" plan --repo-policy none --quota-pressure unknown >/dev/null 2>"$TMP/invalid-enabled-plan.err"; then
-    echo "invalid strategy switch unexpectedly compiled a plan" >&2
-    exit 1
-  fi
-  grep -Fq "invalid [strategy].enabled" "$TMP/invalid-enabled-plan.err"
-done
-
-# The global master switch bypasses FlowPilot planning and cannot be re-enabled by repository policy.
 python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" disable >/dev/null
 [[ "$(python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" enabled)" == "false" ]]
-[[ "$(python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY")" == "enabled=false strategy=efficient routing=adaptive" ]]
-python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" show --json > "$TMP/disabled-show.json"
-python3 - "$TMP/disabled-show.json" <<'PY'
-import json, sys
-p=json.load(open(sys.argv[1]))
-assert p["enabled"] is False and p["strategy"] == "efficient" and p["routing"] == "adaptive", p
-PY
-mkdir -p "$TMP/repo"
-cat > "$TMP/repo/.codex-flow.toml" <<'EOF'
-[strategy]
-enabled = true
-profile = "quality"
-[routing]
-mode = "delegate"
-EOF
-python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" show --effective --repo-policy "$TMP/repo/.codex-flow.toml" --json > "$TMP/disabled-effective.json"
-python3 - "$TMP/disabled-effective.json" <<'PY'
-import json, sys
-p=json.load(open(sys.argv[1]))
-assert p["enabled"] is False and p["strategy"] == "quality" and p["routing"] == "delegate", p
-PY
-if python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" plan --repo-policy "$TMP/repo/.codex-flow.toml" --quota-pressure unknown >"$TMP/disabled-plan.json" 2>"$TMP/disabled-plan.err"; then
+if python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" plan --repo-policy none --quota-pressure unknown >/dev/null 2>&1; then
   echo "disabled strategy unexpectedly compiled a plan" >&2
   exit 1
 fi
-grep -q "strategy dispatch is disabled" "$TMP/disabled-plan.err"
-if python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" plan --repo-policy none --profile quality --routing delegate --quota-pressure unknown >/dev/null 2>&1; then
-  echo "current-task overrides unexpectedly bypassed the disabled master switch" >&2
-  exit 1
-fi
 python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" enable >/dev/null
-[[ "$(python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" enabled)" == "true" ]]
-
-# Temporary bypass is one-shot, does not mutate the global switch, and is atomically consumed.
 BYPASS_HOME="$TMP/bypass-home"
-[[ "$(CODEX_HOME="$BYPASS_HOME" python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" bypass-pending)" == "false" ]]
 CODEX_HOME="$BYPASS_HOME" python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" bypass-once >/dev/null
-[[ "$(CODEX_HOME="$BYPASS_HOME" python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" bypass-pending)" == "true" ]]
-[[ "$(python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" enabled)" == "true" ]]
 [[ "$(CODEX_HOME="$BYPASS_HOME" python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" consume-bypass)" == "true" ]]
 [[ "$(CODEX_HOME="$BYPASS_HOME" python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" consume-bypass)" == "false" ]]
 
-CODEX_HOME="$BYPASS_HOME" python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" bypass-once >/dev/null
-CODEX_HOME="$BYPASS_HOME" python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" consume-bypass > "$TMP/consume-a" &
-pid_a=$!
-CODEX_HOME="$BYPASS_HOME" python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" consume-bypass > "$TMP/consume-b" &
-pid_b=$!
-wait "$pid_a" "$pid_b"
-[[ "$(cat "$TMP/consume-a") $(cat "$TMP/consume-b")" == "true false" || "$(cat "$TMP/consume-a") $(cat "$TMP/consume-b")" == "false true" ]]
-grep -Fq "consume-bypass" "$ROOT/templates/skills/flow-pilot/SKILL.md"
-grep -Fq "task only" "$ROOT/templates/skills/flow-pilot/SKILL.md"
-
-# Registry owns topology/resource/lifecycle preferences. Generic Runtime only normalizes them.
+# Registry owns strategy-specific lifecycle/budget decisions. The synthetic task
+# includes every field consumed by current v11 strategy hooks.
 python3 - "$ROOT" <<'PY'
 import sys
 sys.path.insert(0, sys.argv[1] + '/scripts')
 from strategies import all_specs, get, names
 assert names() == ('efficient', 'balanced', 'quality', 'speed'), names()
-assert tuple(spec.name for spec in all_specs()) == names()
 task=type('T', (), {
     'complexity':'routine','risk':'medium','scope':'module','iteration_intensity':'iterative',
     'uncertainty':'medium','exploration_need':'medium','verification_cost':'medium',
-    'quality_intent':'normal'
+    'quality_intent':'normal','parallelism':'limited','write_conflict':'low','writable_workstreams':1,
 })()
 for name in names():
     spec=get(name)
     budget=spec.worker_budget(task); budget.validate()
+    task_budget=spec.task_budget(task); task_budget.validate()
     for role in ('explorer','implementer','reviewer'):
         assert spec.capability(task, role) in {'worker','parent'}, (name, role)
     for stage in ('exploration','implementation','review'):
-        lifecycle=spec.lifecycle(task, stage)
-        lifecycle.validate()
-    assert spec.exploration_bonus(task) >= 0, name
-    assert spec.reviewer_bonus(task) >= 0, name
-    assert isinstance(spec.notes(task), tuple), name
+        policy=spec.lifecycle(task, stage); policy.validate()
+    assert spec.lifecycle(task, 'review').fallback_policy == 'retry_review', name
 PY
 
-# Guard against built-in strategy decisions leaking back into generic Runtime.
-! grep -Eq 'strategy[[:space:]]*(==|!=)[[:space:]]*"(efficient|balanced|quality|speed)"' "$ROOT/scripts/strategy_runtime.py"
-
-# Direct work has no delegated resources or lifecycle stages.
-plan --complexity small --risk low > "$TMP/small.json"
-python3 - "$TMP/small.json" <<'PY'
+# Direct routing has no delegated topology or task ledger.
+plan --routing direct --complexity small --risk low > "$TMP/direct.json"
+python3 - "$TMP/direct.json" <<'PY'
 import json, sys
 p=json.load(open(sys.argv[1]))
-assert p['schema_version']==10, p
-assert p['strategy']=='efficient' and p['routing']=='direct', p
-assert p['quality_intent']=='normal', p
+assert p['schema_version']==11 and p['routing']=='direct', p
+assert p['task_budget'] is None and p['planned_worker_count']==0, p
 for prefix in ('explorer','implementer','reviewer'):
     assert p[f'{prefix}_capability_policy'] is None, p
     assert p[f'{prefix}_model'] is None, p
     assert p[f'{prefix}_reasoning'] is None, p
 for stage in ('exploration_stage','implementation_stage','review_stage'):
-    assert p[stage] is None, (stage,p)
-assert p['implementation_workers']==0 and p['reviewer_workers']==0 and p['planned_worker_count']==0, p
-assert p['max_concurrent_threads']==1, p
+    assert p[stage] is None, p
 PY
 
-# Efficient complex work gets quorum exploration + required implementation.
-plan --complexity complex --uncertainty high --exploration-need high > "$TMP/efficient.json"
+# Efficient complex work keeps required implementation, shared checkpointing,
+# and Parent-only review under auto.
+plan --routing delegate --complexity complex --uncertainty high --exploration-need high > "$TMP/efficient.json"
 python3 - "$TMP/efficient.json" <<'PY'
 import json, sys
 p=json.load(open(sys.argv[1]))
-assert p['routing']=='delegate', p
+assert p['schema_version']==11 and p['strategy']=='efficient', p
 assert p['parent_reasoning']=='high', p
 assert p['explorer_reasoning']=='xhigh' and p['implementer_reasoning']=='xhigh', p
-assert p['explorer_capability_policy']=='latest-efficient' and p['implementer_capability_policy']=='latest-efficient', p
 assert p['exploration_workers']==2 and p['implementation_workers']==1 and p['reviewer_workers']==0, p
-exp=p['exploration_stage']; imp=p['implementation_stage']
-assert exp['join_policy']=='quorum' and exp['min_successful_workers']==1, exp
-assert exp['cancel_if_superseded'] is True and exp['cancel_stragglers_after_quorum'] is True, exp
-assert exp['idle_timeout_seconds']==120 and exp['hard_timeout_seconds']==900, exp
-assert imp['join_policy']=='required' and imp['min_successful_workers']==1, imp
-assert imp['cancel_if_superseded'] is False and imp['fallback_policy']=='replan', imp
-assert imp['checkpoint_rearm_seconds']==240, imp
-assert p['review_stage'] is None, p
+imp=p['implementation_stage']
+assert imp['join_policy']=='required' and imp['fallback_policy']=='replan', imp
+assert imp['soft_timeout_seconds']==900 and imp['checkpoint_rearm_seconds']==240, imp
+assert imp['minimum_work_units']==1 and imp['maximum_work_units']==2, imp
+assert p['task_budget']['soft_timeout_seconds']==1500, p
+assert p['task_budget']['hard_timeout_seconds']==1800, p
+assert p['task_budget']['max_review_attempts']==0, p
 PY
 
-# Efficient delegated workers expose the three rollout modes without changing
-# direct or non-efficient strategy behavior. The proposed effort is the
-# rollout class target/minimum/Parent maximum; shadow and legacy still select
-# the historical worker effort.
+# Efficient reasoning rollout remains scoped to efficient delegated Workers.
 for complexity in routine complex critical; do
   for mode in legacy shadow adaptive; do
-    plan --routing delegate --complexity "$complexity" --efficient-reasoning "$mode" \
-      > "$TMP/rollout-${complexity}-${mode}.json"
+    plan --routing delegate --complexity "$complexity" --efficient-reasoning "$mode" > "$TMP/rollout-${complexity}-${mode}.json"
   done
 done
 python3 - "$TMP" <<'PY'
-import json
-import sys
+import json, sys
 from pathlib import Path
-
-root = Path(sys.argv[1])
-expected = {
-    "routine": ("xhigh", "high"),
-    "complex": ("xhigh", "xhigh"),
-    "critical": ("max", "max"),
-}
-for complexity, (legacy, proposed) in expected.items():
-    for mode in ("legacy", "shadow", "adaptive"):
-        p = json.load(open(root / f"rollout-{complexity}-{mode}.json"))
-        d = p["reasoning_rollout"]
-        assert p["schema_version"] == 10, p
-        assert d["mode"] == mode and d["legacy_worker_reasoning"] == legacy, d
-        assert d["proposed_worker_reasoning"] == proposed, d
-        assert d["selected_worker_reasoning"] == (proposed if mode == "adaptive" else legacy), d
-        assert d["applied"] is (mode == "adaptive"), d
-        assert p["explorer_reasoning"] == d["selected_worker_reasoning"], p
-        assert p["implementer_reasoning"] == d["selected_worker_reasoning"], p
-        assert p["reviewer_reasoning"] is None, p
+root=Path(sys.argv[1])
+expected={"routine":("xhigh","high"),"complex":("xhigh","xhigh"),"critical":("max","max")}
+for complexity,(legacy,proposed) in expected.items():
+    for mode in ('legacy','shadow','adaptive'):
+        p=json.load(open(root / f'rollout-{complexity}-{mode}.json'))
+        d=p['reasoning_rollout']
+        assert p['schema_version']==11, p
+        assert d['mode']==mode and d['legacy_worker_reasoning']==legacy, d
+        assert d['proposed_worker_reasoning']==proposed, d
+        assert d['selected_worker_reasoning']==(proposed if mode=='adaptive' else legacy), d
+        assert d['applied'] is (mode=='adaptive'), d
+        assert p['implementer_reasoning']==d['selected_worker_reasoning'], p
 PY
-
-# A current-task CLI override changes only this plan; the installed policy
-# remains the release-compatible shadow default when its optional section is
-# absent (legacy policy compatibility).
-plan --routing delegate --complexity routine > "$TMP/rollout-default.json"
-plan --routing delegate --complexity routine --efficient-reasoning adaptive > "$TMP/rollout-override.json"
-python3 - "$TMP/rollout-default.json" "$TMP/rollout-override.json" <<'PY'
-import json
-import sys
-
-default, override = (json.load(open(path)) for path in sys.argv[1:])
-assert default["reasoning_rollout"]["mode"] == "shadow", default
-assert default["reasoning_rollout"]["applied"] is False, default
-assert override["reasoning_rollout"]["mode"] == "adaptive", override
-assert override["reasoning_rollout"]["applied"] is True, override
-assert override["implementer_reasoning"] == override["reasoning_rollout"]["selected_worker_reasoning"], override
-PY
-
-# User rollout floors and Parent floors raise the proposal; they never reduce
-# the legacy baseline. Repository floors may raise efforts but cannot switch a
-# user's legacy/shadow mode to adaptive.
-cp "$POLICY" "$TMP/user-rollout-floor.toml"
-cat >> "$TMP/user-rollout-floor.toml" <<'EOF'
-
-[reasoning.rollout]
-minimum = "max"
-routine = "max"
-complex = "max"
-critical = "max"
-EOF
-python3 "$ROOT/scripts/strategy_runtime.py" --policy "$TMP/user-rollout-floor.toml" plan \
-  --repo-policy none --quota-pressure unknown --routing delegate --complexity routine \
-  --efficient-reasoning adaptive > "$TMP/user-rollout-floor.json"
-cp "$POLICY" "$TMP/parent-rollout-floor.toml"
-python3 - "$TMP/parent-rollout-floor.toml" <<'PY'
-from pathlib import Path
-import sys
-
-p = Path(sys.argv[1])
-s = p.read_text().replace(
-    'min_reasoning_effort = "high"\nroutine_effort = "high"',
-    'min_reasoning_effort = "xhigh"\nroutine_effort = "xhigh"',
-    1,
-)
-p.write_text(s)
-PY
-python3 "$ROOT/scripts/strategy_runtime.py" --policy "$TMP/parent-rollout-floor.toml" plan \
-  --repo-policy none --quota-pressure unknown --routing delegate --complexity routine \
-  --efficient-reasoning adaptive > "$TMP/parent-rollout-floor.json"
-cat > "$TMP/repo-rollout-floor.toml" <<'EOF'
-[reasoning.rollout]
-mode = "adaptive"
-minimum = "max"
-EOF
-python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" plan \
-  --repo-policy "$TMP/repo-rollout-floor.toml" --quota-pressure unknown --routing delegate \
-  --complexity routine > "$TMP/repo-rollout-floor.json"
-python3 - "$TMP/user-rollout-floor.json" "$TMP/parent-rollout-floor.json" "$TMP/repo-rollout-floor.json" <<'PY'
-import json
-import sys
-
-user, parent, repo = (json.load(open(path)) for path in sys.argv[1:])
-assert user["reasoning_rollout"]["proposed_worker_reasoning"] == "max", user
-assert user["reasoning_rollout"]["selected_worker_reasoning"] == "max", user
-assert parent["parent_reasoning"] == "xhigh", parent
-assert parent["reasoning_rollout"]["proposed_worker_reasoning"] == "xhigh", parent
-assert parent["implementer_reasoning"] == "xhigh", parent
-assert repo["reasoning_rollout"]["mode"] == "shadow", repo
-assert repo["reasoning_rollout"]["proposed_worker_reasoning"] == "max", repo
-assert repo["reasoning_rollout"]["selected_worker_reasoning"] == "xhigh", repo
-assert repo["reasoning_rollout"]["applied"] is False, repo
-PY
-
-# Parent=max is allowed to equal the proposed/selected max effort.
-cp "$POLICY" "$TMP/max-parent-rollout.toml"
-python3 - "$TMP/max-parent-rollout.toml" <<'PY'
-from pathlib import Path
-import sys
-
-p = Path(sys.argv[1])
-s = p.read_text().replace(
-    'min_reasoning_effort = "high"\nroutine_effort = "high"',
-    'min_reasoning_effort = "max"\nroutine_effort = "max"',
-    1,
-)
-p.write_text(s)
-PY
-python3 "$ROOT/scripts/strategy_runtime.py" --policy "$TMP/max-parent-rollout.toml" plan \
-  --repo-policy none --quota-pressure unknown --routing delegate --complexity routine \
-  --efficient-reasoning adaptive > "$TMP/max-parent-rollout.json"
-python3 - "$TMP/max-parent-rollout.json" <<'PY'
-import json
-import sys
-
-p = json.load(open(sys.argv[1]))
-d = p["reasoning_rollout"]
-assert p["parent_reasoning"] == "max", p
-assert d["proposed_worker_reasoning"] == d["selected_worker_reasoning"] == "max", d
-assert any("cannot exceed max" in note for note in p["notes"]), p
-PY
-
-# Direct efficient work and delegated non-efficient work do not emit or apply
-# rollout decisions, even when the current task asks for adaptive mode.
-plan --routing direct --complexity routine --efficient-reasoning adaptive > "$TMP/rollout-direct.json"
-plan --profile balanced --routing delegate --complexity routine --efficient-reasoning adaptive > "$TMP/rollout-balanced.json"
-python3 - "$TMP/rollout-direct.json" "$TMP/rollout-balanced.json" <<'PY'
-import json
-import sys
-
-direct, balanced = (json.load(open(path)) for path in sys.argv[1:])
-assert direct["routing"] == "direct" and direct["reasoning_rollout"] is None, direct
-assert balanced["strategy"] == "balanced" and balanced["routing"] == "delegate", balanced
-assert balanced["reasoning_rollout"] is None, balanced
-assert balanced["implementer_reasoning"] == "xhigh", balanced
-PY
-
-# Rollout contracts are strict: booleans and unknown values are rejected.
-python3 - "$ROOT" <<'PY'
-import sys
-
-sys.path.insert(0, sys.argv[1] + "/scripts")
-from strategies.base import ReasoningRolloutDecision, ReasoningRolloutPolicy
-
-for value in (
-    {"mode": True},
-    {"mode": "adaptive", "minimum": "low"},
-    {"mode": "adaptive", "unknown": "high"},
-):
-    try:
-        ReasoningRolloutPolicy.from_dict(value)
-    except ValueError:
-        pass
-    else:
-        raise AssertionError(f"invalid rollout policy accepted: {value}")
-try:
-    ReasoningRolloutDecision("adaptive", "high", "high", "high", 1).validate()
-except ValueError:
-    pass
-else:
-    raise AssertionError("boolean rollout decision accepted")
-PY
-
-# Delegated Worker reasoning remains at least one tier above Parent when possible.
-cp "$POLICY" "$TMP/floor.toml"
-python3 - "$TMP/floor.toml" <<'PY'
-from pathlib import Path
-import sys
-p=Path(sys.argv[1]); s=p.read_text()
-s=s.replace('min_reasoning_effort = "high"\nroutine_effort = "high"', 'min_reasoning_effort = "xhigh"\nroutine_effort = "high"', 1)
-p.write_text(s)
-PY
-python3 "$ROOT/scripts/strategy_runtime.py" --policy "$TMP/floor.toml" plan --repo-policy none --quota-pressure unknown \
-  --routing delegate --complexity routine --risk low > "$TMP/floor.json"
-python3 - "$TMP/floor.json" <<'PY'
+plan --profile balanced --routing delegate --complexity routine --efficient-reasoning adaptive > "$TMP/non-efficient-rollout.json"
+python3 - "$TMP/non-efficient-rollout.json" <<'PY'
 import json, sys
 p=json.load(open(sys.argv[1]))
-assert p['parent_reasoning']=='xhigh' and p['implementer_reasoning']=='max', p
-if p['exploration_workers']:
-    assert p['explorer_reasoning']=='max', p
+assert p['reasoning_rollout'] is None and p['implementer_reasoning']=='xhigh', p
 PY
 
-# Parent=max is the only non-strict effort case because max is the top tier.
-cp "$POLICY" "$TMP/max-parent.toml"
-python3 - "$TMP/max-parent.toml" <<'PY'
-from pathlib import Path
-import sys
-p=Path(sys.argv[1]); s=p.read_text()
-s=s.replace('min_reasoning_effort = "high"\nroutine_effort = "high"', 'min_reasoning_effort = "max"\nroutine_effort = "max"', 1)
-p.write_text(s)
-PY
-python3 "$ROOT/scripts/strategy_runtime.py" --policy "$TMP/max-parent.toml" plan --repo-policy none --quota-pressure unknown \
-  --routing delegate --complexity routine > "$TMP/max-parent.json"
-python3 - "$TMP/max-parent.json" <<'PY'
-import json, sys
-p=json.load(open(sys.argv[1]))
-assert p['parent_reasoning']=='max' and p['implementer_reasoning']=='max', p
-assert any('cannot exceed max' in n for n in p['notes']), p
-PY
-
-# Normal quality keeps efficient capability while adding deeper verification/lifecycle.
-plan --profile quality --complexity complex --uncertainty high --risk high --parallelism high \
-  --scope repo-wide --exploration-need high > "$TMP/quality.json"
+# Quality auto review uses read-only retry_review. Strong/absolute intent may
+# raise capability and topology but remains inside runtime ceilings.
+plan --profile quality --complexity complex --uncertainty high --risk high --parallelism high --scope repo-wide --exploration-need high > "$TMP/quality.json"
 python3 - "$TMP/quality.json" <<'PY'
 import json, sys
 p=json.load(open(sys.argv[1]))
-assert p['strategy']=='quality' and p['quality_intent']=='normal' and p['routing']=='delegate', p
-assert p['parent_reasoning']=='xhigh', p
-assert p['explorer_capability_policy']=='latest-efficient' and p['implementer_capability_policy']=='latest-efficient', p
-assert p['exploration_workers']==4 and p['reviewer_workers']==1, p
-assert p['review_mode']=='independent+parent', p
-assert p['exploration_stage']['join_policy']=='quorum', p
-assert p['exploration_stage']['min_successful_workers']==2, p
+assert p['strategy']=='quality' and p['review_mode']=='independent+parent', p
+assert p['reviewer_workers']==1 and p['review_stage']['fallback_policy']=='retry_review', p
 assert p['review_stage']['join_policy']=='required', p
-# Strategy asks for 2 reviewers, Runtime normalizes to the one reviewer actually planned.
-assert p['review_stage']['min_successful_workers']==1, p
-assert p['review_stage']['cancel_if_superseded'] is False, p
-assert p['review_stage']['fallback_policy']=='replan', p
+assert p['task_budget']['max_review_attempts']>=p['reviewer_workers'], p
+assert p['task_budget']['hard_timeout_seconds'] >= p['task_budget']['soft_timeout_seconds'] + p['review_stage']['hard_timeout_seconds'] + p['task_budget']['parent_finalization_seconds'], p
 PY
-
-# Strong quality upgrades implementer/reviewer capability, not ordinary exploration.
-plan --profile quality --quality-intent strong --complexity routine --risk medium --parallelism limited > "$TMP/quality-strong.json"
+plan --profile quality --quality-intent strong --complexity routine --risk medium > "$TMP/quality-strong.json"
 python3 - "$TMP/quality-strong.json" <<'PY'
 import json, sys
 p=json.load(open(sys.argv[1]))
-assert p['quality_intent']=='strong' and p['routing']=='delegate', p
-assert p['parent_reasoning']=='xhigh', p
-assert p['explorer_capability_policy']=='latest-efficient', p
+assert p['routing']=='delegate' and p['quality_intent']=='strong', p
 assert p['implementer_capability_policy']=='latest-capable', p
 assert p['reviewer_capability_policy']=='latest-capable', p
-assert p['exploration_workers']>=2, p
-assert p['exploration_stage']['min_successful_workers']==2, p
-assert p['review_stage']['join_policy']=='required' and p['review_stage']['min_successful_workers']==1, p
-assert p['review_stage']['cancel_if_superseded'] is False, p
-assert any('strong quality intent' in n for n in p['notes']), p
+assert p['review_stage']['fallback_policy']=='retry_review', p
 PY
-
-# Absolute quality retains two useful explorer results and two independent reviewers.
-python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" plan --repo-policy none --quota-pressure critical --profile quality \
-  --quality-intent absolute --complexity routine --risk medium --parallelism high --write-conflict low --writable-workstreams 4 > "$TMP/quality-absolute.json"
+python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" plan --repo-policy none --quota-pressure critical \
+  --profile quality --quality-intent absolute --complexity routine --parallelism high --write-conflict low --writable-workstreams 4 > "$TMP/quality-absolute.json"
 python3 - "$TMP/quality-absolute.json" <<'PY'
 import json, sys
 p=json.load(open(sys.argv[1]))
-assert p['quality_intent']=='absolute' and p['routing']=='delegate', p
 assert p['parent_reasoning']=='max', p
-assert p['explorer_capability_policy']=='latest-efficient', p
-assert p['implementer_capability_policy']=='latest-capable' and p['reviewer_capability_policy']=='latest-capable', p
 assert p['implementation_workers']==4 and p['reviewer_workers']==2, p
 assert p['planned_worker_count']==8, p
-exp=p['exploration_stage']; rev=p['review_stage']; imp=p['implementation_stage']
-assert exp['join_policy']=='quorum' and exp['min_successful_workers']==2, exp
-assert exp['cancel_stragglers_after_quorum'] is False, exp
-assert rev['join_policy']=='required' and rev['min_successful_workers']==2, rev
-assert rev['cancel_if_superseded'] is False and rev['fallback_policy']=='replan', rev
-assert imp['join_policy']=='required' and imp['hard_timeout_seconds']==3600, imp
-for stage in (exp, imp, rev):
-    assert stage['idle_timeout_seconds'] <= 600, stage
-    assert stage['hard_timeout_seconds'] <= 3600, stage
+assert p['review_stage']['fallback_policy']=='retry_review', p
+assert p['task_budget']['max_work_units']>=p['implementation_workers'], p
+for stage in ('exploration_stage','implementation_stage','review_stage'):
+    if p[stage] is not None:
+        assert p[stage]['idle_timeout_seconds']<=600, p[stage]
+        assert p[stage]['hard_timeout_seconds']<=3600, p[stage]
 PY
 
-# Critical normal quality may upgrade all role capabilities.
-plan --profile quality --complexity critical --risk critical --verification-cost high --parallelism high > "$TMP/quality-critical.json"
-python3 - "$TMP/quality-critical.json" <<'PY'
-import json, sys
-p=json.load(open(sys.argv[1]))
-assert p['quality_intent']=='normal', p
-assert p['explorer_capability_policy']=='latest-capable', p
-assert p['implementer_capability_policy']=='latest-capable', p
-assert p['reviewer_capability_policy']=='latest-capable', p
-assert p['reviewer_workers']==2, p
-assert p['review_stage']['min_successful_workers']==2, p
-PY
-
-# quality_intent must not affect non-quality topology, resources, or lifecycle.
-plan --profile balanced --routing delegate --quality-intent normal --complexity routine --risk medium > "$TMP/non-quality-normal.json"
-plan --profile balanced --routing delegate --quality-intent strong --complexity routine --risk medium > "$TMP/non-quality-strong.json"
-python3 - "$TMP/non-quality-normal.json" "$TMP/non-quality-strong.json" <<'PY'
-import json, sys
-normal=json.load(open(sys.argv[1])); strong=json.load(open(sys.argv[2]))
-keys=(
-    'routing','worker_budget','exploration_workers','implementation_workers','reviewer_workers',
-    'planned_worker_count','max_concurrent_threads','parent_reasoning',
-    'explorer_capability_policy','explorer_model','explorer_reasoning',
-    'implementer_capability_policy','implementer_model','implementer_reasoning',
-    'reviewer_capability_policy','reviewer_model','reviewer_reasoning','review_mode',
-    'exploration_stage','implementation_stage','review_stage'
-)
-for key in keys:
-    assert normal[key] == strong[key], (key, normal[key], strong[key])
-PY
-
-# parallelism=none remains a hard topology constraint.
-plan --profile quality --complexity complex --uncertainty high --parallelism none > "$TMP/no-parallel.json"
-python3 - "$TMP/no-parallel.json" <<'PY'
-import json, sys
-p=json.load(open(sys.argv[1]))
-assert p['exploration_workers']==0 and p['exploration_stage'] is None, p
-assert p['implementation_workers']==1 and p['implementation_stage']['join_policy']=='required', p
-assert p['reviewer_workers']==1 and p['max_concurrent_threads']==1, p
-PY
-
-# Speed keeps speculative exploration opportunistic and short-lived.
-plan --profile speed --complexity routine --parallelism high --write-conflict low --writable-workstreams 4 > "$TMP/speed.json"
+# Speed saturates proven writable topology; balanced caps it at its strategy envelope.
+plan --profile speed --routing delegate --complexity routine --parallelism high --write-conflict low --writable-workstreams 4 > "$TMP/speed.json"
 python3 - "$TMP/speed.json" <<'PY'
 import json, sys
 p=json.load(open(sys.argv[1]))
 assert p['implementation_workers']==4 and p['max_concurrent_threads']==4, p
-exp=p['exploration_stage']; imp=p['implementation_stage']
-assert exp['join_policy']=='opportunistic' and exp['min_successful_workers']==0, exp
-assert exp['idle_timeout_seconds']==60 and exp['hard_timeout_seconds']==600, exp
-assert exp['fallback_policy']=='continue_partial', exp
-assert imp['join_policy']=='required' and imp['hard_timeout_seconds']==1200, imp
+assert p['implementation_stage']['maximum_work_units']==4, p
+assert p['task_budget']['max_work_units']==4, p
+assert p['exploration_stage']['join_policy']=='opportunistic', p
 PY
-
-# Balanced consumes multiple proven writable workstreams within its smaller budget.
 plan --profile balanced --routing delegate --complexity complex --parallelism high --write-conflict low --writable-workstreams 4 > "$TMP/balanced.json"
 python3 - "$TMP/balanced.json" <<'PY'
 import json, sys
 p=json.load(open(sys.argv[1]))
 assert p['implementation_workers']==3, p
-assert p['worker_budget']['max_implementers']==3, p
-assert p['implementation_stage']['join_policy']=='required', p
+assert p['implementation_stage']['maximum_work_units']>=3, p
+assert p['task_budget']['max_work_units']>=3, p
 PY
 
-# Strict review is a generic modifier: every planned reviewer must return terminal evidence.
-plan --profile efficient --review strict --fanout aggressive --complexity complex --uncertainty high \
-  --parallelism high --write-conflict low --writable-workstreams 2 > "$TMP/strict.json"
+# Strict review creates a real required-completion tail and review-specific retry,
+# never an implementation replan.
+plan --profile efficient --routing delegate --review strict --fanout aggressive --complexity complex \
+  --uncertainty high --parallelism high --write-conflict low --writable-workstreams 2 > "$TMP/strict.json"
 python3 - "$TMP/strict.json" <<'PY'
 import json, sys
 p=json.load(open(sys.argv[1]))
-assert p['review_modifier']=='strict' and p['review_mode']=='independent+parent', p
-assert p['reviewer_workers']==1, p
-rev=p['review_stage']
-assert rev['join_policy']=='required', rev
-assert rev['min_successful_workers']==p['reviewer_workers'], rev
-assert rev['cancel_if_superseded'] is False, rev
-assert rev['cancel_stragglers_after_quorum'] is False, rev
-assert rev['fallback_policy']=='replan', rev
+rev=p['review_stage']; budget=p['task_budget']
+assert p['review_mode']=='independent+parent' and p['reviewer_workers']==1, p
+assert rev['join_policy']=='required' and rev['fallback_policy']=='retry_review', rev
+assert rev['cancel_if_superseded'] is False and rev['cancel_stragglers_after_quorum'] is False, rev
+assert budget['soft_timeout_seconds']==1500 and budget['hard_timeout_seconds']==2850, budget
+assert budget['max_review_attempts']==2 and budget['parent_finalization_seconds']==150, budget
 PY
 
-# Direct routing cannot create lifecycle stages even with quality + strict.
-plan --profile quality --routing direct --review strict --complexity critical --risk critical > "$TMP/direct.json"
-python3 - "$TMP/direct.json" <<'PY'
+# parallelism=none remains a hard topology constraint.
+plan --profile quality --routing delegate --complexity complex --uncertainty high --parallelism none > "$TMP/no-parallel.json"
+python3 - "$TMP/no-parallel.json" <<'PY'
 import json, sys
 p=json.load(open(sys.argv[1]))
-assert p['routing']=='direct' and p['review_mode']=='parent', p
-assert p['planned_worker_count']==0, p
-assert p['exploration_stage'] is None and p['implementation_stage'] is None and p['review_stage'] is None, p
+assert p['exploration_workers']==0 and p['exploration_stage'] is None, p
+assert p['implementation_workers']==1 and p['reviewer_workers']==1, p
+assert p['max_concurrent_threads']==1, p
 PY
 
-# Runtime hard lifecycle ceilings clamp an otherwise valid strategy preference.
+# Runtime hard lifecycle ceilings normalize strategy preference.
 python3 - "$ROOT" <<'PY'
 import sys
 sys.path.insert(0, sys.argv[1] + '/scripts')
@@ -588,76 +240,13 @@ from strategies.base import StagePolicy
 from strategy_runtime import Modifiers, TaskProfile, _bounded_stage_policy
 class Spec:
     @staticmethod
-    def lifecycle(_task, _stage):
-        return StagePolicy('required', 99, 5000, 10000, False, False, 'replan')
-task=TaskProfile()
-p=_bounded_stage_policy(Spec(), task, 'implementation', 3, Modifiers())
-assert p.min_successful_workers == 3, p
-assert p.idle_timeout_seconds == 600, p
-assert p.hard_timeout_seconds == 3600, p
+    def lifecycle(_task,_stage):
+        return StagePolicy('required',99,5000,10000,False,False,'replan')
+p=_bounded_stage_policy(Spec(), TaskProfile(), 'implementation', 3, Modifiers())
+assert p.min_successful_workers==3 and p.idle_timeout_seconds==600 and p.hard_timeout_seconds==3600, p
 PY
 
-# Lifecycle contract rejects internally inconsistent policies.
-python3 - "$ROOT" <<'PY'
-import sys
-sys.path.insert(0, sys.argv[1] + '/scripts')
-from strategies.base import StagePolicy, WorkerBudget
-from strategy_runtime import Modifiers, TaskProfile
-invalid=(
-    StagePolicy('opportunistic',1,60,600),
-    StagePolicy('quorum',0,60,600),
-    StagePolicy('required',1,600,300),
-    StagePolicy('required',1,60,600,fallback_policy='nonsense'),
-    StagePolicy('required',True,60,600),
-    StagePolicy('required',1,60,600,soft_timeout_seconds=True),
-    StagePolicy('required',1,60,600,checkpoint_rearm_seconds=True),
-    StagePolicy('required',1,60,600,checkpoint_rearm_seconds=0),
-    StagePolicy('required',1,60,600,soft_timeout_seconds=500,checkpoint_rearm_seconds=100),
-    StagePolicy('required',1,60,600,max_worker_repair_attempts=True),
-    StagePolicy('required',1,60,600,join_between_work_units=1),
-    StagePolicy('required',1,60,600,maximum_work_units=True),
-    StagePolicy('required',1,60,600,require_write_paths=1),
-    StagePolicy('required',1,60,600,work_unit_mode='single',maximum_work_units=2),
-    StagePolicy('required',1,60,600,work_unit_mode='bounded',minimum_work_units=2,join_between_work_units=True,maximum_work_units=1),
-)
-for item in invalid:
-    try: item.validate()
-    except ValueError: pass
-    else: raise AssertionError(f'invalid StagePolicy accepted: {item}')
-for item in (TaskProfile(scope='nonsense'), TaskProfile(writable_workstreams=0), TaskProfile(quality_intent='nonsense')):
-    try: item.validate()
-    except ValueError: pass
-    else: raise AssertionError('invalid TaskProfile accepted')
-try: Modifiers(review='nonsense').validate()
-except ValueError: pass
-else: raise AssertionError('invalid modifier accepted')
-try: WorkerBudget(1,0,0,1).validate()
-except ValueError: pass
-else: raise AssertionError('invalid WorkerBudget accepted')
-PY
-
-# Quota adapter remains deterministic and independent of strategy/lifecycle semantics.
-python3 - "$ROOT" <<'PY'
-import sys
-import json
-sys.path.insert(0, sys.argv[1] + '/scripts')
-from telemetry_core.app_server import _nvm_version_sort_key, quota_windows
-from strategy_runtime import quota_pressure_from_snapshot
-from pathlib import Path
-versions = sorted((Path(name) for name in ('v9.0.0', 'v22.1.0', 'v22.0.9')), key=_nvm_version_sort_key, reverse=True)
-assert [path.name for path in versions] == ['v22.1.0', 'v22.0.9', 'v9.0.0'], versions
-assert quota_pressure_from_snapshot(None) == 'unknown'
-assert quota_pressure_from_snapshot({'rateLimits': {'primary': {'usedPercent': 20}}}) == 'low'
-assert quota_pressure_from_snapshot({'rateLimits': {'primary': {'usedPercent': 55}}}) == 'medium'
-assert quota_pressure_from_snapshot({'rateLimits': {'primary': {'usedPercent': 80}}}) == 'high'
-assert quota_pressure_from_snapshot({'rateLimits': {'primary': {'usedPercent': 95}}}) == 'critical'
-fixture = json.load(open(sys.argv[1] + '/tests/fixtures/account-rate-limits.json'))
-windows = quota_windows(fixture)
-assert [(row['window_duration_mins'], row['used_percent']) for row in windows] == [(300, 42), (10080, 61)], windows
-assert quota_pressure_from_snapshot(fixture) == 'medium', windows
-PY
-
-# Repository policy precedence/ceilings continue to work with lifecycle v8.
+# Repository policy precedence and ceilings remain authoritative.
 mkdir -p "$TMP/repo/subdir"
 touch "$TMP/repo/.git"
 cat > "$TMP/repo/.codex-flow.toml" <<'EOF'
@@ -685,25 +274,11 @@ show=json.load(open(sys.argv[1])); p=json.load(open(sys.argv[2]))
 assert show['strategy']=='quality' and show['routing']=='delegate', show
 assert show['review']=='strict' and show['fanout']=='conservative', show
 assert p['parent_reasoning']=='xhigh' and p['implementer_reasoning']=='max', p
-assert p['reviewer_workers']==1 and p['review_stage']['join_policy']=='required', p
+assert p['reviewer_workers']==1 and p['review_stage']['fallback_policy']=='retry_review', p
 assert p['max_concurrent_threads']<=2 and p['max_repair_cycles']==1, p
 PY
 
-# Explicit current-task overrides still outrank repo policy without mutating it.
-(
-  cd "$TMP/repo/subdir"
-  python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" plan --quota-pressure unknown \
-    --profile speed --routing direct --review standard --fanout aggressive --complexity routine > "$TMP/override.json"
-)
-python3 - "$TMP/override.json" <<'PY'
-import json, sys
-p=json.load(open(sys.argv[1]))
-assert p['strategy']=='speed' and p['routing']=='direct', p
-assert p['review_modifier']=='standard' and p['fanout_modifier']=='aggressive', p
-PY
-grep -Fq 'profile = "quality"' "$TMP/repo/.codex-flow.toml"
-
-# Critical quota pressure compresses worker counts; lifecycle is normalized after compression.
+# Critical quota pressure compresses quota-sensitive strategies before lifecycle normalization.
 python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" plan --repo-policy none --profile balanced --routing delegate \
   --complexity complex --uncertainty high --parallelism high --quota-pressure critical > "$TMP/quota.json"
 python3 - "$TMP/quota.json" <<'PY'
@@ -711,35 +286,48 @@ import json, sys
 p=json.load(open(sys.argv[1]))
 assert p['exploration_workers']==1 and p['implementation_workers']==1, p
 assert p['max_concurrent_threads']==1 and p['max_repair_cycles']==1, p
-assert p['exploration_stage']['min_successful_workers']==1, p
 assert p['implementation_stage']['min_successful_workers']==1, p
 PY
 
-# Schema-v3 persistent-policy users retain the historical default strategy/routing.
-cat > "$TMP/v3.toml" <<'EOF'
-schema_version = 3
-[parent]
-min_reasoning_effort = "high"
-[worker]
-min_reasoning_effort = "high"
-[runtime]
-max_concurrent_threads = 4
-max_repair_cycles = 2
-EOF
-python3 "$ROOT/scripts/strategy_runtime.py" --policy "$TMP/v3.toml" show --json > "$TMP/v3.json"
-python3 - "$TMP/v3.json" <<'PY'
-import json, sys
-p=json.load(open(sys.argv[1]))
-assert p['strategy']=='efficient' and p['routing']=='adaptive' and p['valid'], p
+# Invalid public contracts fail closed.
+python3 - "$ROOT" <<'PY'
+import sys
+sys.path.insert(0, sys.argv[1] + '/scripts')
+from strategies.base import StagePolicy, TaskBudgetPolicy, WorkerBudget
+from strategy_runtime import Modifiers, TaskProfile
+invalid=(
+    StagePolicy('opportunistic',1,60,600),
+    StagePolicy('quorum',0,60,600),
+    StagePolicy('required',1,600,300),
+    StagePolicy('required',1,60,600,fallback_policy='nonsense'),
+    StagePolicy('required',1,60,600,soft_timeout_seconds=True),
+    StagePolicy('required',1,60,600,work_unit_mode='single',maximum_work_units=2),
+)
+for item in invalid:
+    try: item.validate()
+    except ValueError: pass
+    else: raise AssertionError(f'invalid StagePolicy accepted: {item}')
+try: TaskProfile(writable_workstreams=0).validate()
+except ValueError: pass
+else: raise AssertionError('invalid TaskProfile accepted')
+try: Modifiers(review='nonsense').validate()
+except ValueError: pass
+else: raise AssertionError('invalid modifier accepted')
+try: WorkerBudget(1,0,0,1).validate()
+except ValueError: pass
+else: raise AssertionError('invalid WorkerBudget accepted')
+try:
+    TaskBudgetPolicy(10,20,1,1,0,0,max_review_attempts=True,parent_finalization_seconds=120).validate()
+except ValueError: pass
+else: raise AssertionError('boolean review budget accepted')
 PY
 
-# Skill must treat lifecycle as an authoritative plan boundary, not a prose heuristic.
+# FlowPilot must consume the current v11 runtime contract rather than old prose heuristics.
 grep -Fq 'FlowPilot profiles. `strategy_runtime.py` + the strategy registry decide. FlowPilot executes the returned plan.' "$ROOT/templates/skills/flow-pilot/SKILL.md"
-grep -Fq 'Current contract (schema v10)' "$ROOT/templates/skills/flow-pilot/SKILL.md"
+grep -Fq 'Current contract (schema v11)' "$ROOT/templates/skills/flow-pilot/SKILL.md"
 grep -Fq 'A `wait()` timeout is never a Worker timeout.' "$ROOT/templates/skills/flow-pilot/SKILL.md"
-grep -Fq 'cancel_if_superseded' "$ROOT/templates/skills/flow-pilot/SKILL.md"
+grep -Fq 'retry_review' "$ROOT/templates/skills/flow-pilot/SKILL.md"
+grep -Fq 'review_deadline' "$ROOT/templates/skills/flow-pilot/SKILL.md"
 grep -Fq 'Fallback always operates on the missing delta' "$ROOT/templates/skills/flow-pilot/SKILL.md"
-grep -Fq 'scope_id' "$ROOT/templates/skills/flow-pilot/SKILL.md"
-grep -Fq 'do not kill a Luna `xhigh/max` Explorer' "$ROOT/templates/skills/flow-pilot/SKILL.md"
 
 printf 'strategy runtime test passed\n'

--- a/tests/task-budget-runtime.sh
+++ b/tests/task-budget-runtime.sh
@@ -8,7 +8,13 @@ RUNTIME="$ROOT/scripts/strategies/task_budget_runtime.py"
 STATE="$TMP/task-budget.json"
 POLICY='{"soft_timeout_seconds":10,"hard_timeout_seconds":20,"max_work_units":2,"max_implementation_attempts":2,"max_replans":1,"max_replacements":1}'
 
-python3 -m py_compile "$ROOT/scripts/strategies/base.py" "$ROOT/scripts/strategies/efficient.py" "$RUNTIME"
+python3 -m py_compile \
+  "$ROOT/scripts/strategies/base.py" \
+  "$ROOT/scripts/strategies/efficient.py" \
+  "$ROOT/scripts/strategies/balanced.py" \
+  "$ROOT/scripts/strategies/quality.py" \
+  "$ROOT/scripts/strategies/speed.py" \
+  "$RUNTIME"
 
 run() {
   python3 "$RUNTIME" "$@"
@@ -27,7 +33,6 @@ run init --state-file "$STATE" --task-id task-alpha --now 100 --policy-json "$PO
 python3 - "$TMP/init.json" "$STATE" <<'PY'
 import hashlib
 import json
-import pathlib
 import sys
 
 result = json.load(open(sys.argv[1]))
@@ -125,7 +130,7 @@ ln -s "$TMP/lock-target" "$TMP/lock-link.json.lock"
 touch "$TMP/lock-target"
 expect_fail run init --state-file "$TMP/lock-link.json" --task-id task-lock --now 0 --policy-json "$POLICY"
 
-# At least one concurrent atomic reserve per process succeeds without lost updates.
+# Concurrent reservations are atomic and do not lose updates.
 CONCURRENT="$TMP/concurrent.json"
 CONCURRENT_POLICY='{"soft_timeout_seconds":100,"hard_timeout_seconds":200,"max_work_units":8,"max_implementation_attempts":1,"max_replans":1,"max_replacements":1}'
 run init --state-file "$CONCURRENT" --task-id concurrent --now 1000 --policy-json "$CONCURRENT_POLICY" >/dev/null
@@ -140,8 +145,6 @@ import json, sys
 p=json.load(open(sys.argv[1])); assert p["counters"]["work_unit"] == 8, p
 PY
 
-# Reservations from different kinds may interleave in wall-clock order; only
-# each individual kind's append order must be monotonic.
 INTERLEAVED="$TMP/interleaved.json"
 run init --state-file "$INTERLEAVED" --task-id interleaved --now 2000 --policy-json "$POLICY" >/dev/null
 run reserve --state-file "$INTERLEAVED" --task-id interleaved --now 2001 --kind implementation_attempt \
@@ -155,7 +158,7 @@ p=json.load(open(sys.argv[1])); assert p["counters"]["implementation_attempt"] =
 assert p["counters"]["work_unit"] == 1, p
 PY
 
-# Compiler carries the efficient budget only for delegated plans; direct and legacy strategies stay None.
+# Every delegated built-in strategy now emits a cumulative task budget; direct plans remain unbudgeted.
 cat >"$TMP/policy.toml" <<'EOF'
 schema_version = 4
 [strategy]
@@ -185,27 +188,33 @@ critical_effort = "max"
 max_concurrent_threads = 4
 max_repair_cycles = 2
 EOF
-python3 "$ROOT/scripts/strategy_runtime.py" --policy "$TMP/policy.toml" plan --repo-policy none --quota-pressure unknown \
-  --routing delegate --complexity complex --scope cross-module >"$TMP/plan.json"
+
+for profile in efficient balanced quality speed; do
+  python3 "$ROOT/scripts/strategy_runtime.py" --policy "$TMP/policy.toml" plan --repo-policy none --quota-pressure unknown \
+    --profile "$profile" --routing delegate --complexity complex --scope cross-module >"$TMP/${profile}-plan.json"
+done
 python3 "$ROOT/scripts/strategy_runtime.py" --policy "$TMP/policy.toml" plan --repo-policy none --quota-pressure unknown \
   --routing direct --complexity complex --scope cross-module >"$TMP/direct-plan.json"
-python3 "$ROOT/scripts/strategy_runtime.py" --policy "$TMP/policy.toml" plan --repo-policy none --quota-pressure unknown \
-  --profile balanced --routing delegate --complexity complex --scope cross-module >"$TMP/legacy-plan.json"
-python3 - "$TMP/plan.json" "$TMP/direct-plan.json" "$TMP/legacy-plan.json" <<'PY'
-import json, sys
-delegated, direct, legacy = (json.load(open(path)) for path in sys.argv[1:])
-assert delegated["schema_version"] == 10, delegated
-assert delegated["task_budget"] == {
-    "soft_timeout_seconds": 1500,
-    "hard_timeout_seconds": 1800,
-    "max_work_units": 2,
-    "max_implementation_attempts": 3,
-    "max_replans": 1,
-    "max_replacements": 1,
-}, delegated
-assert delegated["implementation_stage"]["maximum_work_units"] == delegated["task_budget"]["max_work_units"], delegated
+
+python3 - "$TMP" <<'PY'
+import json
+import sys
+from pathlib import Path
+root = Path(sys.argv[1])
+expected = {
+    "efficient": {"soft_timeout_seconds":1500,"hard_timeout_seconds":1800,"max_work_units":2,"max_implementation_attempts":3,"max_replans":1,"max_replacements":1},
+    "balanced": {"soft_timeout_seconds":2700,"hard_timeout_seconds":3300,"max_work_units":2,"max_implementation_attempts":4,"max_replans":2,"max_replacements":2},
+    "quality": {"soft_timeout_seconds":5400,"hard_timeout_seconds":6600,"max_work_units":3,"max_implementation_attempts":6,"max_replans":3,"max_replacements":3},
+    "speed": {"soft_timeout_seconds":1200,"hard_timeout_seconds":1800,"max_work_units":3,"max_implementation_attempts":4,"max_replans":1,"max_replacements":1},
+}
+for name, budget in expected.items():
+    plan = json.load(open(root / f"{name}-plan.json"))
+    assert plan["schema_version"] == 10 and plan["strategy"] == name, plan
+    assert plan["task_budget"] == budget, plan
+    assert plan["implementation_stage"]["maximum_work_units"] == budget["max_work_units"], plan
+
+direct = json.load(open(root / "direct-plan.json"))
 assert direct["schema_version"] == 10 and direct["task_budget"] is None, direct
-assert legacy["schema_version"] == 10 and legacy["task_budget"] is None, legacy
 PY
 
 printf 'task budget runtime test passed\n'

--- a/tests/task-budget-runtime.sh
+++ b/tests/task-budget-runtime.sh
@@ -6,9 +6,10 @@ TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 RUNTIME="$ROOT/scripts/strategies/task_budget_runtime.py"
 STATE="$TMP/task-budget.json"
-POLICY='{"soft_timeout_seconds":10,"hard_timeout_seconds":20,"max_work_units":2,"max_implementation_attempts":2,"max_replans":1,"max_replacements":1}'
+POLICY='{"soft_timeout_seconds":10,"hard_timeout_seconds":20,"max_work_units":2,"max_implementation_attempts":2,"max_replans":1,"max_replacements":1,"max_review_attempts":2,"parent_finalization_seconds":2}'
 
 python3 -m py_compile \
+  "$ROOT/scripts/strategy_runtime.py" \
   "$ROOT/scripts/strategies/base.py" \
   "$ROOT/scripts/strategies/efficient.py" \
   "$ROOT/scripts/strategies/balanced.py" \
@@ -16,127 +17,101 @@ python3 -m py_compile \
   "$ROOT/scripts/strategies/speed.py" \
   "$RUNTIME"
 
-run() {
-  python3 "$RUNTIME" "$@"
-}
-
+run() { python3 "$RUNTIME" "$@"; }
 expect_fail() {
   if "$@" >"$TMP/expected.out" 2>"$TMP/expected.err"; then
-    echo "command unexpectedly succeeded: $*" >&2
-    exit 1
+    echo "command unexpectedly succeeded: $*" >&2; exit 1
   fi
-  test ! -s "$TMP/expected.out"
-  test -s "$TMP/expected.err"
+  test ! -s "$TMP/expected.out"; test -s "$TMP/expected.err"
 }
 
 run init --state-file "$STATE" --task-id task-alpha --now 100 --policy-json "$POLICY" >"$TMP/init.json"
 python3 - "$TMP/init.json" "$STATE" <<'PY'
-import hashlib
-import json
-import sys
-
-result = json.load(open(sys.argv[1]))
-state = json.load(open(sys.argv[2]))
+import hashlib, json, sys
+result=json.load(open(sys.argv[1])); state=json.load(open(sys.argv[2]))
 assert result["initialized"] is True and result["action"] == "continue", result
-assert state["schema_version"] == 1, state
+assert state["schema_version"] == 2, state
 assert state["task_id"] == hashlib.sha256(b"task-alpha").hexdigest(), state
-assert "task-alpha" not in json.dumps(state), state
-assert "src/secret.py" not in json.dumps(state), state
 assert state["limits"] == {
-    "work_unit": 2,
-    "implementation_attempt": 2,
-    "replan": 1,
-    "replacement": 1,
+    "work_unit":2,"implementation_attempt":2,"replan":1,"replacement":1,"review_attempt":2
 }, state
+assert "task-alpha" not in json.dumps(state), state
 PY
 
-# Re-init is idempotent and never refreshes the original start/deadlines.
 run init --state-file "$STATE" --task-id task-alpha --now 101 --policy-json "$POLICY" >"$TMP/reinit.json"
 python3 - "$TMP/reinit.json" "$STATE" <<'PY'
 import json, sys
-result = json.load(open(sys.argv[1])); state = json.load(open(sys.argv[2]))
-assert result["initialized"] is False and result["idempotent"] is True, result
-assert state["started_at"] == 100 and state["soft_deadline"] == 110 and state["hard_deadline"] == 120, state
+r=json.load(open(sys.argv[1])); s=json.load(open(sys.argv[2]))
+assert r["initialized"] is False and r["idempotent"] is True, r
+assert s["started_at"] == 100 and s["soft_deadline"] == 110 and s["hard_deadline"] == 120, s
 PY
 
-# Existing ledger identity is immutable: neither a different task nor policy may reset it.
 expect_fail run init --state-file "$STATE" --task-id task-other --now 101 --policy-json "$POLICY"
-OTHER_POLICY='{"soft_timeout_seconds":11,"hard_timeout_seconds":20,"max_work_units":2,"max_implementation_attempts":2,"max_replans":1,"max_replacements":1}'
+OTHER_POLICY='{"soft_timeout_seconds":11,"hard_timeout_seconds":20,"max_work_units":2,"max_implementation_attempts":2,"max_replans":1,"max_replacements":1,"max_review_attempts":2,"parent_finalization_seconds":2}'
 expect_fail run init --state-file "$STATE" --task-id task-alpha --now 101 --policy-json "$OTHER_POLICY"
 
-# Each reservation is hashed, fingerprint-idempotent, and bounded by its kind.
 run reserve --state-file "$STATE" --task-id task-alpha --now 102 --kind work_unit --reservation-id unit-1 --fingerprint 'src/secret.py' >"$TMP/unit.json"
 run reserve --state-file "$STATE" --task-id task-alpha --now 103 --kind work_unit --reservation-id unit-1 --fingerprint 'src/secret.py' >"$TMP/unit-repeat.json"
 python3 - "$TMP/unit-repeat.json" "$STATE" <<'PY'
 import hashlib, json, sys
-result = json.load(open(sys.argv[1])); state = json.load(open(sys.argv[2]))
-assert result["idempotent"] is True and result["counters"]["work_unit"] == 1, result
-entry = state["reservations"]["work_unit"][0]
-assert entry["reservation_id"] == hashlib.sha256(b"unit-1").hexdigest(), entry
-assert entry["fingerprint"] == hashlib.sha256(b"src/secret.py").hexdigest(), entry
-assert "src/secret.py" not in json.dumps(state), state
+r=json.load(open(sys.argv[1])); s=json.load(open(sys.argv[2]))
+assert r["idempotent"] is True and r["counters"]["work_unit"] == 1, r
+e=s["reservations"]["work_unit"][0]
+assert e["reservation_id"] == hashlib.sha256(b"unit-1").hexdigest(), e
+assert e["fingerprint"] == hashlib.sha256(b"src/secret.py").hexdigest(), e
+assert "src/secret.py" not in json.dumps(s), s
 PY
 expect_fail run reserve --state-file "$STATE" --task-id task-alpha --now 103 --kind work_unit --reservation-id unit-1 --fingerprint changed
 run reserve --state-file "$STATE" --task-id task-alpha --now 104 --kind work_unit --reservation-id unit-2 --fingerprint delta-2 >/dev/null
 expect_fail run reserve --state-file "$STATE" --task-id task-alpha --now 105 --kind work_unit --reservation-id unit-3 --fingerprint delta-3
-
 run reserve --state-file "$STATE" --task-id task-alpha --now 106 --kind implementation_attempt --reservation-id attempt-1 --fingerprint attempt >/dev/null
 run reserve --state-file "$STATE" --task-id task-alpha --now 107 --kind implementation_attempt --reservation-id attempt-2 --fingerprint attempt >/dev/null
 expect_fail run reserve --state-file "$STATE" --task-id task-alpha --now 108 --kind implementation_attempt --reservation-id attempt-3 --fingerprint attempt
 run reserve --state-file "$STATE" --task-id task-alpha --now 109 --kind replan --reservation-id replan-1 --fingerprint remaining-delta >/dev/null
-expect_fail run reserve --state-file "$STATE" --task-id task-alpha --now 109 --kind replan --reservation-id replan-2 --fingerprint another-delta
 run reserve --state-file "$STATE" --task-id task-alpha --now 109 --kind replacement --reservation-id replacement-1 --fingerprint isolated >/dev/null
-expect_fail run reserve --state-file "$STATE" --task-id task-alpha --now 109 --kind replacement --reservation-id replacement-2 --fingerprint isolated
 
-# Time decisions are deterministic and soft/hard boundaries reject new work.
-run status --state-file "$STATE" --task-id task-alpha --now 109 >"$TMP/continue.json"
-python3 - "$TMP/continue.json" <<'PY'
-import json, sys
-p=json.load(open(sys.argv[1])); assert p["action"] == "continue" and p["permits_new_work"] is True, p
-PY
 run status --state-file "$STATE" --task-id task-alpha --now 110 >"$TMP/converge.json"
 python3 - "$TMP/converge.json" <<'PY'
 import json, sys
-p=json.load(open(sys.argv[1])); assert p["action"] == "converge" and p["permits_new_work"] is False and not p["cancel_required"], p
+p=json.load(open(sys.argv[1])); assert p["action"]=="converge" and not p["permits_new_work"] and p["permits_new_review"], p
 PY
 expect_fail run reserve --state-file "$STATE" --task-id task-alpha --now 110 --kind replan --reservation-id replan-soft --fingerprint blocked
+# Read-only required-completion attempts remain admissible after soft.
+run reserve --state-file "$STATE" --task-id task-alpha --now 111 --kind review_attempt --reservation-id review-1 --fingerprint reviewer-a >"$TMP/review1.json"
+run reserve --state-file "$STATE" --task-id task-alpha --now 112 --kind review_attempt --reservation-id review-2 --fingerprint reviewer-b >"$TMP/review2.json"
+expect_fail run reserve --state-file "$STATE" --task-id task-alpha --now 113 --kind review_attempt --reservation-id review-3 --fingerprint reviewer-c
+# Replay remains idempotent even after the hard boundary.
+run reserve --state-file "$STATE" --task-id task-alpha --now 120 --kind review_attempt --reservation-id review-1 --fingerprint reviewer-a >"$TMP/review-replay.json"
+python3 - "$TMP/review-replay.json" <<'PY'
+import json, sys
+p=json.load(open(sys.argv[1])); assert p["idempotent"] is True and p["counters"]["review_attempt"] == 2, p
+PY
+expect_fail run reserve --state-file "$STATE" --task-id task-alpha --now 120 --kind review_attempt --reservation-id review-new --fingerprint reviewer-new
 run status --state-file "$STATE" --task-id task-alpha --now 120 >"$TMP/stop.json"
 python3 - "$TMP/stop.json" <<'PY'
 import json, sys
-p=json.load(open(sys.argv[1])); assert p["action"] == "stop" and p["cancel_required"] is True, p
+p=json.load(open(sys.argv[1])); assert p["action"]=="stop" and p["cancel_required"], p
 PY
-expect_fail run reserve --state-file "$STATE" --task-id task-alpha --now 120 --kind replan --reservation-id replan-hard --fingerprint blocked
-run finish --state-file "$STATE" --task-id task-alpha --now 121 --outcome success >"$TMP/finish.json"
-python3 - "$TMP/finish.json" <<'PY'
-import json, sys
-p=json.load(open(sys.argv[1])); assert p["closed"] is True and p["action"] == "stop" and not p["cancel_required"], p
-PY
-expect_fail run reserve --state-file "$STATE" --task-id task-alpha --now 121 --kind replan --reservation-id replan-closed --fingerprint blocked
+run finish --state-file "$STATE" --task-id task-alpha --now 121 --outcome success >/dev/null
+expect_fail run reserve --state-file "$STATE" --task-id task-alpha --now 121 --kind review_attempt --reservation-id closed --fingerprint closed
 
-# Input/type/time/symlink hardening fails closed without a traceback.
 expect_fail run status --state-file "$STATE" --task-id task-alpha --now 99
 expect_fail run status --state-file "$STATE" --task-id task-alpha --now 1700000000000
 expect_fail run status --state-file "$STATE" --task-id task-alpha --now nan
 if python3 "$RUNTIME" init --state-file "$TMP/bool.json" --task-id bool --now 0 --policy-json \
-  '{"soft_timeout_seconds":true,"hard_timeout_seconds":20,"max_work_units":1,"max_implementation_attempts":1,"max_replans":0,"max_replacements":0}' \
+  '{"soft_timeout_seconds":true,"hard_timeout_seconds":20,"max_work_units":1,"max_implementation_attempts":1,"max_replans":0,"max_replacements":0,"max_review_attempts":0,"parent_finalization_seconds":1}' \
   >"$TMP/bool.out" 2>"$TMP/bool.err"; then
-  echo "boolean policy value unexpectedly accepted" >&2
-  exit 1
+  echo "boolean policy value unexpectedly accepted" >&2; exit 1
 fi
 grep -Fq 'must be an integer' "$TMP/bool.err"
 ln -s "$STATE" "$TMP/state-link.json"
 expect_fail run status --state-file "$TMP/state-link.json" --task-id task-alpha --now 121
-ln -s "$TMP/lock-target" "$TMP/lock-link.json.lock"
-touch "$TMP/lock-target"
-expect_fail run init --state-file "$TMP/lock-link.json" --task-id task-lock --now 0 --policy-json "$POLICY"
 
-# Concurrent reservations are atomic and do not lose updates.
 CONCURRENT="$TMP/concurrent.json"
-CONCURRENT_POLICY='{"soft_timeout_seconds":100,"hard_timeout_seconds":200,"max_work_units":8,"max_implementation_attempts":1,"max_replans":1,"max_replacements":1}'
+CONCURRENT_POLICY='{"soft_timeout_seconds":100,"hard_timeout_seconds":200,"max_work_units":8,"max_implementation_attempts":1,"max_replans":1,"max_replacements":1,"max_review_attempts":1,"parent_finalization_seconds":1}'
 run init --state-file "$CONCURRENT" --task-id concurrent --now 1000 --policy-json "$CONCURRENT_POLICY" >/dev/null
 for i in 1 2 3 4 5 6 7 8; do
-  run reserve --state-file "$CONCURRENT" --task-id concurrent --now 1001 --kind work_unit \
-    --reservation-id "unit-$i" --fingerprint "delta-$i" >"$TMP/concurrent-$i.json" &
+  run reserve --state-file "$CONCURRENT" --task-id concurrent --now 1001 --kind work_unit --reservation-id "unit-$i" --fingerprint "delta-$i" >"$TMP/concurrent-$i.json" &
 done
 wait
 run status --state-file "$CONCURRENT" --task-id concurrent --now 1002 >"$TMP/concurrent-status.json"
@@ -145,20 +120,6 @@ import json, sys
 p=json.load(open(sys.argv[1])); assert p["counters"]["work_unit"] == 8, p
 PY
 
-INTERLEAVED="$TMP/interleaved.json"
-run init --state-file "$INTERLEAVED" --task-id interleaved --now 2000 --policy-json "$POLICY" >/dev/null
-run reserve --state-file "$INTERLEAVED" --task-id interleaved --now 2001 --kind implementation_attempt \
-  --reservation-id attempt-1 --fingerprint attempt-1 >/dev/null
-run reserve --state-file "$INTERLEAVED" --task-id interleaved --now 2002 --kind work_unit \
-  --reservation-id unit-1 --fingerprint logical-unit-1 >/dev/null
-run status --state-file "$INTERLEAVED" --task-id interleaved --now 2003 >"$TMP/interleaved-status.json"
-python3 - "$TMP/interleaved-status.json" <<'PY'
-import json, sys
-p=json.load(open(sys.argv[1])); assert p["counters"]["implementation_attempt"] == 1, p
-assert p["counters"]["work_unit"] == 1, p
-PY
-
-# Every delegated built-in strategy now emits a cumulative task budget; direct plans remain unbudgeted.
 cat >"$TMP/policy.toml" <<'EOF'
 schema_version = 4
 [strategy]
@@ -188,33 +149,32 @@ critical_effort = "max"
 max_concurrent_threads = 4
 max_repair_cycles = 2
 EOF
-
 for profile in efficient balanced quality speed; do
   python3 "$ROOT/scripts/strategy_runtime.py" --policy "$TMP/policy.toml" plan --repo-policy none --quota-pressure unknown \
     --profile "$profile" --routing delegate --complexity complex --scope cross-module >"$TMP/${profile}-plan.json"
 done
 python3 "$ROOT/scripts/strategy_runtime.py" --policy "$TMP/policy.toml" plan --repo-policy none --quota-pressure unknown \
   --routing direct --complexity complex --scope cross-module >"$TMP/direct-plan.json"
-
 python3 - "$TMP" <<'PY'
-import json
-import sys
+import json, sys
 from pathlib import Path
-root = Path(sys.argv[1])
-expected = {
-    "efficient": {"soft_timeout_seconds":1500,"hard_timeout_seconds":1800,"max_work_units":2,"max_implementation_attempts":3,"max_replans":1,"max_replacements":1},
-    "balanced": {"soft_timeout_seconds":2700,"hard_timeout_seconds":3300,"max_work_units":2,"max_implementation_attempts":4,"max_replans":2,"max_replacements":2},
-    "quality": {"soft_timeout_seconds":5400,"hard_timeout_seconds":6600,"max_work_units":3,"max_implementation_attempts":6,"max_replans":3,"max_replacements":3},
-    "speed": {"soft_timeout_seconds":1200,"hard_timeout_seconds":1800,"max_work_units":3,"max_implementation_attempts":4,"max_replans":1,"max_replacements":1},
+root=Path(sys.argv[1])
+expected={
+ "efficient":{"soft_timeout_seconds":1500,"hard_timeout_seconds":1800,"max_work_units":2,"max_implementation_attempts":3,"max_replans":1,"max_replacements":1,"max_review_attempts":0,"parent_finalization_seconds":150},
+ "balanced":{"soft_timeout_seconds":2700,"hard_timeout_seconds":3300,"max_work_units":2,"max_implementation_attempts":4,"max_replans":2,"max_replacements":2,"max_review_attempts":0,"parent_finalization_seconds":180},
+ "quality":{"soft_timeout_seconds":5400,"hard_timeout_seconds":8700,"max_work_units":3,"max_implementation_attempts":6,"max_replans":3,"max_replacements":3,"max_review_attempts":4,"parent_finalization_seconds":300},
+ "speed":{"soft_timeout_seconds":1200,"hard_timeout_seconds":1800,"max_work_units":3,"max_implementation_attempts":4,"max_replans":1,"max_replacements":1,"max_review_attempts":0,"parent_finalization_seconds":120},
 }
-for name, budget in expected.items():
-    plan = json.load(open(root / f"{name}-plan.json"))
-    assert plan["schema_version"] == 10 and plan["strategy"] == name, plan
-    assert plan["task_budget"] == budget, plan
-    assert plan["implementation_stage"]["maximum_work_units"] == budget["max_work_units"], plan
+for name,budget in expected.items():
+    p=json.load(open(root/f"{name}-plan.json"))
+    assert p["schema_version"]==11 and p["strategy"]==name, p
+    assert p["task_budget"]==budget, (name,p["task_budget"])
+    assert p["implementation_stage"]["maximum_work_units"]==budget["max_work_units"], p
+    if p["reviewer_workers"]:
+        assert p["review_stage"]["fallback_policy"]=="retry_review", p
 
-direct = json.load(open(root / "direct-plan.json"))
-assert direct["schema_version"] == 10 and direct["task_budget"] is None, direct
+direct=json.load(open(root/"direct-plan.json"))
+assert direct["schema_version"]==11 and direct["task_budget"] is None, direct
 PY
 
 printf 'task budget runtime test passed\n'

--- a/tests/test_shared_strategy_lifecycle.py
+++ b/tests/test_shared_strategy_lifecycle.py
@@ -11,6 +11,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 
 from strategies import get  # noqa: E402
+from strategies.base import standard_lifecycle  # noqa: E402
 from strategies.lifecycle_runtime import CheckpointRecord, LifecyclePolicy, WorkerObservation, evaluate_worker  # noqa: E402
 from strategies.work_unit_runtime import validate_manifest  # noqa: E402
 
@@ -93,6 +94,27 @@ def assert_review_retry(name: str, profile) -> None:
     assert decision.replan_scope is None and decision.checkpoint_reuse_mode is None,decision
 
 
+def assert_v11_default_lifecycle() -> None:
+    implementation=standard_lifecycle(task(),"implementation")
+    implementation.validate()
+    assert implementation.soft_timeout_seconds==1200,implementation
+    assert implementation.checkpoint_rearm_seconds==240,implementation
+    assert implementation.max_worker_repair_attempts==1,implementation
+    assert implementation.work_unit_mode=="single",implementation
+    assert implementation.minimum_work_units==implementation.maximum_work_units==1,implementation
+    decision=evaluate_worker(
+        LifecyclePolicy.from_dict(asdict(implementation)),
+        WorkerObservation(
+            scope_id="default-implementation",stage="implementation",started_at=100,last_progress_at=1300,
+            last_meaningful_progress_at=1300,now=1300,writable=True,in_flight=True,
+        ),
+    )
+    assert decision.action=="request_checkpoint",decision
+    review=standard_lifecycle(task(),"review")
+    review.validate()
+    assert review.fallback_policy=="retry_review",review
+
+
 def main() -> None:
     routine=task()
     complex_cross=task(complexity="complex",scope="cross-module")
@@ -117,11 +139,22 @@ def main() -> None:
             assert_task_budget(strategy,p,budget_expected[strategy][label])
         assert_review_retry(strategy,routine)
 
+    assert_v11_default_lifecycle()
+
     multi=task(parallelism="high",write_conflict="low",writable_workstreams=4)
     assert get("efficient").lifecycle(multi,"implementation").maximum_work_units==1
     assert get("balanced").lifecycle(multi,"implementation").maximum_work_units==2
     assert get("quality").lifecycle(multi,"implementation").maximum_work_units==2
     assert get("speed").lifecycle(multi,"implementation").maximum_work_units==4
+
+    # Speed's 1/3/4 values are semantic baselines. Proven isolated writable
+    # topology may raise the total logical-unit envelope up to its 8-implementer
+    # strategy budget, allowing serial waves without inventing new workstreams.
+    speed_eight=task(parallelism="high",write_conflict="low",writable_workstreams=8)
+    speed_stage=get("speed").lifecycle(speed_eight,"implementation")
+    speed_budget=get("speed").task_budget(speed_eight)
+    assert speed_stage.maximum_work_units==8,speed_stage
+    assert speed_budget.max_work_units==8 and speed_budget.max_implementation_attempts==9,speed_budget
 
     print("shared strategy lifecycle and task-budget contract tests passed")
 

--- a/tests/test_shared_strategy_lifecycle.py
+++ b/tests/test_shared_strategy_lifecycle.py
@@ -86,10 +86,7 @@ def assert_review_retry(name: str, profile) -> None:
     assert stage.fallback_policy=="retry_review",(name,stage)
     decision=evaluate_worker(
         LifecyclePolicy.from_dict(asdict(stage)),
-        WorkerObservation(
-            scope_id=f"{name}-review",stage="review",started_at=100,last_progress_at=100,now=100,
-            terminal_failure=True,writable=False,
-        ),
+        WorkerObservation(scope_id=f"{name}-review",stage="review",started_at=100,last_progress_at=100,now=100,terminal_failure=True,writable=False),
     )
     assert decision.action=="retry_review",decision
     assert decision.replacement_allowed is True and decision.fence_required is False,decision
@@ -120,9 +117,8 @@ def main() -> None:
             assert_task_budget(strategy,p,budget_expected[strategy][label])
         assert_review_retry(strategy,routine)
 
-    # Proven writable streams are themselves natural unit boundaries.
     multi=task(parallelism="high",write_conflict="low",writable_workstreams=4)
-    assert get("efficient").lifecycle(multi,"implementation").maximum_work_units==2
+    assert get("efficient").lifecycle(multi,"implementation").maximum_work_units==1
     assert get("balanced").lifecycle(multi,"implementation").maximum_work_units==2
     assert get("quality").lifecycle(multi,"implementation").maximum_work_units==2
     assert get("speed").lifecycle(multi,"implementation").maximum_work_units==4

--- a/tests/test_shared_strategy_lifecycle.py
+++ b/tests/test_shared_strategy_lifecycle.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Cross-strategy convergence/recovery and cumulative-budget coverage."""
+"""Cross-strategy convergence/recovery and budget coverage."""
 from __future__ import annotations
 
 import sys
@@ -11,249 +11,124 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 
 from strategies import get  # noqa: E402
-from strategies.lifecycle_runtime import (  # noqa: E402
-    CheckpointRecord,
-    LifecyclePolicy,
-    WorkerObservation,
-    evaluate_worker,
-)
+from strategies.lifecycle_runtime import CheckpointRecord, LifecyclePolicy, WorkerObservation, evaluate_worker  # noqa: E402
 from strategies.work_unit_runtime import validate_manifest  # noqa: E402
 
 
 def task(**overrides):
     values = {
-        "complexity": "routine",
-        "risk": "medium",
-        "scope": "module",
-        "iteration_intensity": "iterative",
-        "uncertainty": "medium",
-        "exploration_need": "medium",
-        "verification_cost": "medium",
-        "quality_intent": "normal",
-        "parallelism": "limited",
-        "write_conflict": "low",
-        "writable_workstreams": 1,
+        "complexity":"routine","risk":"medium","scope":"module","iteration_intensity":"iterative",
+        "uncertainty":"medium","exploration_need":"medium","verification_cost":"medium","quality_intent":"normal",
+        "parallelism":"limited","write_conflict":"low","writable_workstreams":1,
     }
     values.update(overrides)
     return SimpleNamespace(**values)
 
 
 def manifest(count: int) -> dict:
-    return {
-        "units": [
-            {
-                "unit_id": f"u{index}",
-                "scope_id": f"scope-{index}",
-                "generation": 0,
-                "acceptance_delta": f"acceptance delta {index}",
-                "write_scope_id": f"write-{index}",
-                "write_paths": [f"src/unit-{index}.py"],
-                "validation": [f"test unit {index}"],
-                "depends_on": [],
-            }
-            for index in range(1, count + 1)
-        ]
-    }
+    return {"units":[{
+        "unit_id":f"u{i}","scope_id":f"scope-{i}","generation":0,"acceptance_delta":f"acceptance {i}",
+        "write_scope_id":f"write-{i}","write_paths":[f"src/unit-{i}.py"],"validation":[f"test {i}"],"depends_on":[],
+    } for i in range(1,count+1)]}
 
 
-def assert_profile(name: str, profile, expected: tuple[int, int, int, int, int]) -> None:
-    soft, rearm, repairs, maximum_units, hard = expected
-    stage = get(name).lifecycle(profile, "implementation")
-    stage.validate()
+def assert_profile(name: str, profile, expected: tuple[int,int,int,int,int]) -> None:
+    soft,rearm,repairs,max_units,hard=expected
+    stage=get(name).lifecycle(profile,"implementation"); stage.validate()
+    assert (stage.soft_timeout_seconds,stage.checkpoint_rearm_seconds,stage.max_worker_repair_attempts,stage.maximum_work_units,stage.hard_timeout_seconds)==expected,(name,stage)
+    assert stage.minimum_work_units==1,stage
+    bounded=max_units>1
+    assert stage.work_unit_mode==("bounded" if bounded else "single"),stage
+    assert stage.join_between_work_units is bounded and stage.require_write_paths is bounded,stage
 
-    assert stage.soft_timeout_seconds == soft, (name, stage)
-    assert stage.checkpoint_rearm_seconds == rearm, (name, stage)
-    assert stage.max_worker_repair_attempts == repairs, (name, stage)
-    assert stage.minimum_work_units == 1, (name, stage)
-    assert stage.maximum_work_units == maximum_units, (name, stage)
-    assert stage.hard_timeout_seconds == hard, (name, stage)
-    assert stage.soft_timeout_seconds + stage.checkpoint_rearm_seconds < stage.hard_timeout_seconds, (name, stage)
+    policy=LifecyclePolicy.from_dict(asdict(stage)); started=100.0; first_now=started+soft
+    first=evaluate_worker(policy,WorkerObservation(
+        scope_id=f"{name}-first",stage="implementation",started_at=started,last_progress_at=first_now,
+        last_meaningful_progress_at=first_now,now=first_now,writable=True,in_flight=True,
+    ))
+    assert first.action=="request_checkpoint" and first.next_checkpoint_sequence==1,first
+    harvested=first_now+2; second_now=harvested+rearm
+    seq=(CheckpointRecord(1,0,first_now,first_now+1,harvested),)
+    second=evaluate_worker(policy,WorkerObservation(
+        scope_id=f"{name}-second",stage="implementation",started_at=started,last_progress_at=second_now,
+        last_meaningful_progress_at=second_now,now=second_now,writable=True,in_flight=True,checkpoint_sequence=seq,
+    ))
+    assert second.action=="request_checkpoint" and second.next_checkpoint_sequence==2,second
+    liveness=evaluate_worker(policy,WorkerObservation(
+        scope_id=f"{name}-liveness",stage="implementation",started_at=started,last_progress_at=second_now,
+        now=second_now,writable=True,in_flight=True,checkpoint_sequence=seq,
+    ))
+    assert liveness.action=="continue",liveness
 
-    bounded = maximum_units > 1
-    assert stage.work_unit_mode == ("bounded" if bounded else "single"), (name, stage)
-    assert stage.join_between_work_units is bounded, (name, stage)
-    assert stage.require_write_paths is bounded, (name, stage)
-
-    policy = LifecyclePolicy.from_dict(asdict(stage))
-    started = 100.0
-    first_now = started + soft
-    first = evaluate_worker(
-        policy,
-        WorkerObservation(
-            scope_id=f"{name}-first",
-            stage="implementation",
-            started_at=started,
-            last_progress_at=first_now,
-            last_meaningful_progress_at=first_now,
-            now=first_now,
-            writable=True,
-            in_flight=True,
-        ),
-    )
-    assert first.action == "request_checkpoint", (name, first)
-    assert first.next_checkpoint_sequence == 1, (name, first)
-    assert first.cancel_required is False and first.fence_required is False, (name, first)
-
-    harvested_at = first_now + 2
-    second_now = harvested_at + rearm
-    sequence = (
-        CheckpointRecord(
-            sequence=1,
-            generation=0,
-            requested_at=first_now,
-            received_at=first_now + 1,
-            harvested_at=harvested_at,
-        ),
-    )
-    second = evaluate_worker(
-        policy,
-        WorkerObservation(
-            scope_id=f"{name}-second",
-            stage="implementation",
-            started_at=started,
-            last_progress_at=second_now,
-            last_meaningful_progress_at=second_now,
-            now=second_now,
-            writable=True,
-            in_flight=True,
-            checkpoint_sequence=sequence,
-        ),
-    )
-    assert second.action == "request_checkpoint", (name, second)
-    assert second.next_checkpoint_sequence == 2, (name, second)
-    assert second.harvested_checkpoint_sequence == 1, (name, second)
-
-    legacy_liveness_only = evaluate_worker(
-        policy,
-        WorkerObservation(
-            scope_id=f"{name}-legacy-liveness",
-            stage="implementation",
-            started_at=started,
-            last_progress_at=second_now,
-            now=second_now,
-            writable=True,
-            in_flight=True,
-            checkpoint_sequence=sequence,
-        ),
-    )
-    assert legacy_liveness_only.action == "continue", (name, legacy_liveness_only)
-
-    policy_json = asdict(stage)
-    valid_one = validate_manifest(
-        policy_json,
-        manifest(1),
-        implementation_workers=1,
-        max_concurrent_threads=4,
-    )
-    assert valid_one["valid"] and valid_one["unit_count"] == 1, (name, valid_one)
-
-    valid_max = validate_manifest(
-        policy_json,
-        manifest(maximum_units),
-        implementation_workers=1,
-        max_concurrent_threads=4,
-    )
-    assert valid_max["valid"] and valid_max["unit_count"] == maximum_units, (name, valid_max)
-
+    policy_json=asdict(stage)
+    assert validate_manifest(policy_json,manifest(1),implementation_workers=1,max_concurrent_threads=4)["valid"]
+    assert validate_manifest(policy_json,manifest(max_units),implementation_workers=1,max_concurrent_threads=4)["valid"]
     try:
-        validate_manifest(
-            policy_json,
-            manifest(maximum_units + 1),
-            implementation_workers=1,
-            max_concurrent_threads=4,
-        )
+        validate_manifest(policy_json,manifest(max_units+1),implementation_workers=1,max_concurrent_threads=4)
     except ValueError:
         pass
     else:
-        raise AssertionError(f"{name}: manifest above maximum_work_units unexpectedly accepted")
+        raise AssertionError(f"{name}: manifest above maximum accepted")
 
 
-def assert_task_budget(name: str, profile, expected: tuple[int, int, int, int, int, int]) -> None:
-    soft, hard, max_units, max_attempts, max_replans, max_replacements = expected
-    spec = get(name)
-    assert spec.task_budget is not None, name
-    budget = spec.task_budget(profile)
-    budget.validate()
-    assert budget.soft_timeout_seconds == soft, (name, budget)
-    assert budget.hard_timeout_seconds == hard, (name, budget)
-    assert budget.max_work_units == max_units, (name, budget)
-    assert budget.max_implementation_attempts == max_attempts, (name, budget)
-    assert budget.max_replans == max_replans, (name, budget)
-    assert budget.max_replacements == max_replacements, (name, budget)
-    stage = spec.lifecycle(profile, "implementation")
-    assert budget.max_work_units == stage.maximum_work_units, (name, budget, stage)
+def assert_task_budget(name: str, profile, expected: tuple[int,int,int,int,int,int,int,int]) -> None:
+    soft,hard,max_units,max_attempts,replans,replacements,review_attempts,parent_finalization=expected
+    spec=get(name); budget=spec.task_budget(profile); budget.validate()
+    assert (
+        budget.soft_timeout_seconds,budget.hard_timeout_seconds,budget.max_work_units,budget.max_implementation_attempts,
+        budget.max_replans,budget.max_replacements,budget.max_review_attempts,budget.parent_finalization_seconds,
+    )==expected,(name,budget)
+    assert budget.max_work_units==spec.lifecycle(profile,"implementation").maximum_work_units,(name,budget)
+
+
+def assert_review_retry(name: str, profile) -> None:
+    stage=get(name).lifecycle(profile,"review"); stage.validate()
+    assert stage.fallback_policy=="retry_review",(name,stage)
+    decision=evaluate_worker(
+        LifecyclePolicy.from_dict(asdict(stage)),
+        WorkerObservation(
+            scope_id=f"{name}-review",stage="review",started_at=100,last_progress_at=100,now=100,
+            terminal_failure=True,writable=False,
+        ),
+    )
+    assert decision.action=="retry_review",decision
+    assert decision.replacement_allowed is True and decision.fence_required is False,decision
+    assert decision.replan_scope is None and decision.checkpoint_reuse_mode is None,decision
 
 
 def main() -> None:
-    routine = task()
-    complex_cross = task(complexity="complex", scope="cross-module")
-    demanding = task(
-        complexity="critical",
-        risk="critical",
-        scope="repo-wide",
-        iteration_intensity="heavy-loop",
-        verification_cost="high",
-        quality_intent="absolute",
-    )
+    routine=task()
+    complex_cross=task(complexity="complex",scope="cross-module")
+    demanding=task(complexity="critical",risk="critical",scope="repo-wide",iteration_intensity="heavy-loop",verification_cost="high",quality_intent="absolute")
 
-    lifecycle_expected = {
-        "efficient": {
-            "routine": (600, 180, 1, 1, 1800),
-            "complex": (900, 240, 2, 2, 1800),
-            "demanding": (1200, 300, 2, 3, 1800),
-        },
-        "balanced": {
-            "routine": (1200, 240, 1, 1, 2400),
-            "complex": (1500, 300, 2, 2, 2400),
-            "demanding": (1800, 360, 2, 3, 2400),
-        },
-        "quality": {
-            "routine": (1800, 360, 2, 1, 3600),
-            "complex": (2400, 480, 3, 3, 3600),
-            "demanding": (2700, 600, 3, 4, 3600),
-        },
-        "speed": {
-            "routine": (420, 180, 1, 1, 1200),
-            "complex": (600, 180, 1, 3, 1200),
-            "demanding": (720, 180, 1, 4, 1200),
-        },
+    lifecycle_expected={
+        "efficient":{"routine":(600,180,1,1,1800),"complex":(900,240,2,2,1800),"demanding":(1200,300,2,3,1800)},
+        "balanced":{"routine":(1200,240,1,1,2400),"complex":(1500,300,2,2,2400),"demanding":(1800,360,2,3,2400)},
+        "quality":{"routine":(1800,360,2,1,3600),"complex":(2400,480,3,3,3600),"demanding":(2700,600,3,4,3600)},
+        "speed":{"routine":(420,180,1,1,1200),"complex":(600,180,1,3,1200),"demanding":(720,180,1,4,1200)},
     }
+    budget_expected={
+        "efficient":{"routine":(1500,1800,1,2,1,1,2,150),"complex":(1500,1800,2,3,1,1,2,150),"demanding":(1500,1800,3,4,1,1,2,150)},
+        "balanced":{"routine":(2400,3000,1,3,2,2,2,180),"complex":(2700,3300,2,4,2,2,2,180),"demanding":(3000,3600,3,5,2,2,2,180)},
+        "quality":{"routine":(4800,6000,1,4,3,3,2,300),"complex":(5400,6600,3,6,3,3,2,300),"demanding":(6000,7200,4,7,3,3,4,300)},
+        "speed":{"routine":(1200,1800,1,2,1,1,2,120),"complex":(1200,1800,3,4,1,1,2,120),"demanding":(1200,1800,4,5,1,1,2,120)},
+    }
+    profiles={"routine":routine,"complex":complex_cross,"demanding":demanding}
+    for strategy,matrix in lifecycle_expected.items():
+        for label,p in profiles.items():
+            assert_profile(strategy,p,matrix[label])
+            assert_task_budget(strategy,p,budget_expected[strategy][label])
+        assert_review_retry(strategy,routine)
 
-    budget_expected = {
-        "efficient": {
-            "routine": (1500, 1800, 1, 2, 1, 1),
-            "complex": (1500, 1800, 2, 3, 1, 1),
-            "demanding": (1500, 1800, 3, 4, 1, 1),
-        },
-        "balanced": {
-            "routine": (2400, 3000, 1, 3, 2, 2),
-            "complex": (2700, 3300, 2, 4, 2, 2),
-            "demanding": (3000, 3600, 3, 5, 2, 2),
-        },
-        "quality": {
-            "routine": (4800, 6000, 1, 4, 3, 3),
-            "complex": (5400, 6600, 3, 6, 3, 3),
-            "demanding": (6000, 7200, 4, 7, 3, 3),
-        },
-        "speed": {
-            "routine": (1200, 1800, 1, 2, 1, 1),
-            "complex": (1200, 1800, 3, 4, 1, 1),
-            "demanding": (1200, 1800, 4, 5, 1, 1),
-        },
-    }
-
-    profiles = {
-        "routine": routine,
-        "complex": complex_cross,
-        "demanding": demanding,
-    }
-    for strategy, matrix in lifecycle_expected.items():
-        for label, profile in profiles.items():
-            assert_profile(strategy, profile, matrix[label])
-            assert_task_budget(strategy, profile, budget_expected[strategy][label])
+    # Proven writable streams are themselves natural unit boundaries.
+    multi=task(parallelism="high",write_conflict="low",writable_workstreams=4)
+    assert get("efficient").lifecycle(multi,"implementation").maximum_work_units==2
+    assert get("balanced").lifecycle(multi,"implementation").maximum_work_units==2
+    assert get("quality").lifecycle(multi,"implementation").maximum_work_units==2
+    assert get("speed").lifecycle(multi,"implementation").maximum_work_units==4
 
     print("shared strategy lifecycle and task-budget contract tests passed")
 
 
-if __name__ == "__main__":
+if __name__=="__main__":
     main()

--- a/tests/test_shared_strategy_lifecycle.py
+++ b/tests/test_shared_strategy_lifecycle.py
@@ -107,7 +107,7 @@ def main() -> None:
     budget_expected={
         "efficient":{"routine":(1500,1800,1,2,1,1,2,150),"complex":(1500,1800,2,3,1,1,2,150),"demanding":(1500,1800,3,4,1,1,2,150)},
         "balanced":{"routine":(2400,3000,1,3,2,2,2,180),"complex":(2700,3300,2,4,2,2,2,180),"demanding":(3000,3600,3,5,2,2,2,180)},
-        "quality":{"routine":(4800,6000,1,4,3,3,2,300),"complex":(5400,6600,3,6,3,3,2,300),"demanding":(6000,7200,4,7,3,3,4,300)},
+        "quality":{"routine":(4800,6000,1,4,3,3,2,300),"complex":(5400,6600,3,6,3,3,4,300),"demanding":(6000,7200,4,7,3,3,4,300)},
         "speed":{"routine":(1200,1800,1,2,1,1,2,120),"complex":(1200,1800,3,4,1,1,2,120),"demanding":(1200,1800,4,5,1,1,2,120)},
     }
     profiles={"routine":routine,"complex":complex_cross,"demanding":demanding}

--- a/tests/test_shared_strategy_lifecycle.py
+++ b/tests/test_shared_strategy_lifecycle.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Cross-strategy convergence/recovery contract coverage."""
+"""Cross-strategy convergence/recovery and cumulative-budget coverage."""
 from __future__ import annotations
 
 import sys
@@ -168,6 +168,22 @@ def assert_profile(name: str, profile, expected: tuple[int, int, int, int, int])
         raise AssertionError(f"{name}: manifest above maximum_work_units unexpectedly accepted")
 
 
+def assert_task_budget(name: str, profile, expected: tuple[int, int, int, int, int, int]) -> None:
+    soft, hard, max_units, max_attempts, max_replans, max_replacements = expected
+    spec = get(name)
+    assert spec.task_budget is not None, name
+    budget = spec.task_budget(profile)
+    budget.validate()
+    assert budget.soft_timeout_seconds == soft, (name, budget)
+    assert budget.hard_timeout_seconds == hard, (name, budget)
+    assert budget.max_work_units == max_units, (name, budget)
+    assert budget.max_implementation_attempts == max_attempts, (name, budget)
+    assert budget.max_replans == max_replans, (name, budget)
+    assert budget.max_replacements == max_replacements, (name, budget)
+    stage = spec.lifecycle(profile, "implementation")
+    assert budget.max_work_units == stage.maximum_work_units, (name, budget, stage)
+
+
 def main() -> None:
     routine = task()
     complex_cross = task(complexity="complex", scope="cross-module")
@@ -180,7 +196,7 @@ def main() -> None:
         quality_intent="absolute",
     )
 
-    expected = {
+    lifecycle_expected = {
         "efficient": {
             "routine": (600, 180, 1, 1, 1800),
             "complex": (900, 240, 2, 2, 1800),
@@ -203,12 +219,40 @@ def main() -> None:
         },
     }
 
-    for strategy, matrix in expected.items():
-        assert_profile(strategy, routine, matrix["routine"])
-        assert_profile(strategy, complex_cross, matrix["complex"])
-        assert_profile(strategy, demanding, matrix["demanding"])
+    budget_expected = {
+        "efficient": {
+            "routine": (1500, 1800, 1, 2, 1, 1),
+            "complex": (1500, 1800, 2, 3, 1, 1),
+            "demanding": (1500, 1800, 3, 4, 1, 1),
+        },
+        "balanced": {
+            "routine": (2400, 3000, 1, 3, 2, 2),
+            "complex": (2700, 3300, 2, 4, 2, 2),
+            "demanding": (3000, 3600, 3, 5, 2, 2),
+        },
+        "quality": {
+            "routine": (4800, 6000, 1, 4, 3, 3),
+            "complex": (5400, 6600, 3, 6, 3, 3),
+            "demanding": (6000, 7200, 4, 7, 3, 3),
+        },
+        "speed": {
+            "routine": (1200, 1800, 1, 2, 1, 1),
+            "complex": (1200, 1800, 3, 4, 1, 1),
+            "demanding": (1200, 1800, 4, 5, 1, 1),
+        },
+    }
 
-    print("shared strategy lifecycle contract tests passed")
+    profiles = {
+        "routine": routine,
+        "complex": complex_cross,
+        "demanding": demanding,
+    }
+    for strategy, matrix in lifecycle_expected.items():
+        for label, profile in profiles.items():
+            assert_profile(strategy, profile, matrix[label])
+            assert_task_budget(strategy, profile, budget_expected[strategy][label])
+
+    print("shared strategy lifecycle and task-budget contract tests passed")
 
 
 if __name__ == "__main__":

--- a/tests/test_shared_strategy_lifecycle.py
+++ b/tests/test_shared_strategy_lifecycle.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Cross-strategy convergence/recovery contract coverage."""
+from __future__ import annotations
+
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from strategies import get  # noqa: E402
+from strategies.lifecycle_runtime import (  # noqa: E402
+    CheckpointRecord,
+    LifecyclePolicy,
+    WorkerObservation,
+    evaluate_worker,
+)
+from strategies.work_unit_runtime import validate_manifest  # noqa: E402
+
+
+def task(**overrides):
+    values = {
+        "complexity": "routine",
+        "risk": "medium",
+        "scope": "module",
+        "iteration_intensity": "iterative",
+        "uncertainty": "medium",
+        "exploration_need": "medium",
+        "verification_cost": "medium",
+        "quality_intent": "normal",
+        "parallelism": "limited",
+        "write_conflict": "low",
+        "writable_workstreams": 1,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def manifest(count: int) -> dict:
+    return {
+        "units": [
+            {
+                "unit_id": f"u{index}",
+                "scope_id": f"scope-{index}",
+                "generation": 0,
+                "acceptance_delta": f"acceptance delta {index}",
+                "write_scope_id": f"write-{index}",
+                "write_paths": [f"src/unit-{index}.py"],
+                "validation": [f"test unit {index}"],
+                "depends_on": [],
+            }
+            for index in range(1, count + 1)
+        ]
+    }
+
+
+def assert_profile(name: str, profile, expected: tuple[int, int, int, int, int]) -> None:
+    soft, rearm, repairs, maximum_units, hard = expected
+    stage = get(name).lifecycle(profile, "implementation")
+    stage.validate()
+
+    assert stage.soft_timeout_seconds == soft, (name, stage)
+    assert stage.checkpoint_rearm_seconds == rearm, (name, stage)
+    assert stage.max_worker_repair_attempts == repairs, (name, stage)
+    assert stage.minimum_work_units == 1, (name, stage)
+    assert stage.maximum_work_units == maximum_units, (name, stage)
+    assert stage.hard_timeout_seconds == hard, (name, stage)
+    assert stage.soft_timeout_seconds + stage.checkpoint_rearm_seconds < stage.hard_timeout_seconds, (name, stage)
+
+    bounded = maximum_units > 1
+    assert stage.work_unit_mode == ("bounded" if bounded else "single"), (name, stage)
+    assert stage.join_between_work_units is bounded, (name, stage)
+    assert stage.require_write_paths is bounded, (name, stage)
+
+    policy = LifecyclePolicy.from_dict(asdict(stage))
+    started = 100.0
+    first_now = started + soft
+    first = evaluate_worker(
+        policy,
+        WorkerObservation(
+            scope_id=f"{name}-first",
+            stage="implementation",
+            started_at=started,
+            last_progress_at=first_now,
+            last_meaningful_progress_at=first_now,
+            now=first_now,
+            writable=True,
+            in_flight=True,
+        ),
+    )
+    assert first.action == "request_checkpoint", (name, first)
+    assert first.next_checkpoint_sequence == 1, (name, first)
+    assert first.cancel_required is False and first.fence_required is False, (name, first)
+
+    harvested_at = first_now + 2
+    second_now = harvested_at + rearm
+    sequence = (
+        CheckpointRecord(
+            sequence=1,
+            generation=0,
+            requested_at=first_now,
+            received_at=first_now + 1,
+            harvested_at=harvested_at,
+        ),
+    )
+    second = evaluate_worker(
+        policy,
+        WorkerObservation(
+            scope_id=f"{name}-second",
+            stage="implementation",
+            started_at=started,
+            last_progress_at=second_now,
+            last_meaningful_progress_at=second_now,
+            now=second_now,
+            writable=True,
+            in_flight=True,
+            checkpoint_sequence=sequence,
+        ),
+    )
+    assert second.action == "request_checkpoint", (name, second)
+    assert second.next_checkpoint_sequence == 2, (name, second)
+    assert second.harvested_checkpoint_sequence == 1, (name, second)
+
+    legacy_liveness_only = evaluate_worker(
+        policy,
+        WorkerObservation(
+            scope_id=f"{name}-legacy-liveness",
+            stage="implementation",
+            started_at=started,
+            last_progress_at=second_now,
+            now=second_now,
+            writable=True,
+            in_flight=True,
+            checkpoint_sequence=sequence,
+        ),
+    )
+    assert legacy_liveness_only.action == "continue", (name, legacy_liveness_only)
+
+    policy_json = asdict(stage)
+    valid_one = validate_manifest(
+        policy_json,
+        manifest(1),
+        implementation_workers=1,
+        max_concurrent_threads=4,
+    )
+    assert valid_one["valid"] and valid_one["unit_count"] == 1, (name, valid_one)
+
+    valid_max = validate_manifest(
+        policy_json,
+        manifest(maximum_units),
+        implementation_workers=1,
+        max_concurrent_threads=4,
+    )
+    assert valid_max["valid"] and valid_max["unit_count"] == maximum_units, (name, valid_max)
+
+    try:
+        validate_manifest(
+            policy_json,
+            manifest(maximum_units + 1),
+            implementation_workers=1,
+            max_concurrent_threads=4,
+        )
+    except ValueError:
+        pass
+    else:
+        raise AssertionError(f"{name}: manifest above maximum_work_units unexpectedly accepted")
+
+
+def main() -> None:
+    routine = task()
+    complex_cross = task(complexity="complex", scope="cross-module")
+    demanding = task(
+        complexity="critical",
+        risk="critical",
+        scope="repo-wide",
+        iteration_intensity="heavy-loop",
+        verification_cost="high",
+        quality_intent="absolute",
+    )
+
+    expected = {
+        "efficient": {
+            "routine": (600, 180, 1, 1, 1800),
+            "complex": (900, 240, 2, 2, 1800),
+            "demanding": (1200, 300, 2, 3, 1800),
+        },
+        "balanced": {
+            "routine": (1200, 240, 1, 1, 2400),
+            "complex": (1500, 300, 2, 2, 2400),
+            "demanding": (1800, 360, 2, 3, 2400),
+        },
+        "quality": {
+            "routine": (1800, 360, 2, 1, 3600),
+            "complex": (2400, 480, 3, 3, 3600),
+            "demanding": (2700, 600, 3, 4, 3600),
+        },
+        "speed": {
+            "routine": (420, 180, 1, 1, 1200),
+            "complex": (600, 180, 1, 3, 1200),
+            "demanding": (720, 180, 1, 4, 1200),
+        },
+    }
+
+    for strategy, matrix in expected.items():
+        assert_profile(strategy, routine, matrix["routine"])
+        assert_profile(strategy, complex_cross, matrix["complex"])
+        assert_profile(strategy, demanding, matrix["demanding"])
+
+    print("shared strategy lifecycle contract tests passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_task_phase_runtime.py
+++ b/tests/test_task_phase_runtime.py
@@ -2,6 +2,8 @@
 """Regression coverage for task-budget phase admission and required review tail."""
 from __future__ import annotations
 
+import json
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -156,9 +158,8 @@ def main() -> None:
         else:
             raise AssertionError("new implementation reservation unexpectedly entered required-review tail")
 
-    # The phase helper refuses a different plan against an existing ledger,
-    # preventing a caller from extending the admission window with another
-    # review topology or task budget after initialization.
+    # The phase helper refuses a different budget plan against an existing
+    # ledger, preventing a caller from extending the admission window after init.
     quality = plan("quality")
     with tempfile.TemporaryDirectory() as tmp:
         state = str(Path(tmp) / "identity.json")
@@ -169,7 +170,56 @@ def main() -> None:
         except LedgerError as exc:
             assert "plan/policy mismatch" in str(exc), exc
         else:
-            raise AssertionError("different ExecutionPlan unexpectedly reused task phase ledger")
+            raise AssertionError("different budget plan unexpectedly reused task phase ledger")
+
+    # Exercise the real argparse path: --now arrives as text in every shell.
+    phase_cli = ROOT / "scripts/strategies/task_phase_runtime.py"
+    quality = plan("quality")
+    with tempfile.TemporaryDirectory() as tmp:
+        state = str(Path(tmp) / "cli.json")
+        plan_json = json.dumps(quality.to_dict(), separators=(",", ":"))
+        init_run = subprocess.run(
+            [
+                sys.executable,
+                str(phase_cli),
+                "init",
+                "--state-file",
+                state,
+                "--task-id",
+                "cli",
+                "--plan-json",
+                plan_json,
+                "--now",
+                "100",
+            ],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        initialized = json.loads(init_run.stdout)
+        assert initialized["soft_deadline"] == 3100, initialized
+        status_run = subprocess.run(
+            [
+                sys.executable,
+                str(phase_cli),
+                "status",
+                "--state-file",
+                state,
+                "--task-id",
+                "cli",
+                "--plan-json",
+                plan_json,
+                "--phase",
+                "required_completion",
+                "--now",
+                "3100",
+            ],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        required = json.loads(status_run.stdout)
+        assert required["action"] == "complete_required" and required["permits_phase_start"], required
 
     # High technical risk may opt into multiple evidence-backed quality units,
     # but minimum_work_units remains one so this never forces a fake split.

--- a/tests/test_task_phase_runtime.py
+++ b/tests/test_task_phase_runtime.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Regression coverage for task-budget phase admission and required completion."""
+"""Regression coverage for schema-v11 task phase admission."""
 from __future__ import annotations
 
 import json
@@ -15,7 +15,7 @@ sys.path.insert(0, str(ROOT / "scripts"))
 from strategy_runtime import Modifiers, TaskProfile, compile_plan  # noqa: E402
 from strategies import get  # noqa: E402
 from strategies.task_budget_runtime import LedgerError, init_ledger  # noqa: E402
-from strategies.task_phase_runtime import init, reserve_implementation, status  # noqa: E402
+from strategies.task_phase_runtime import init, reserve_implementation, reserve_phase, status  # noqa: E402
 
 
 def profile(**overrides) -> TaskProfile:
@@ -36,13 +36,7 @@ def profile(**overrides) -> TaskProfile:
     return TaskProfile(**values)
 
 
-def plan(
-    strategy: str,
-    *,
-    strict: bool = False,
-    task: TaskProfile | None = None,
-    fanout: str = "auto",
-):
+def plan(strategy: str, *, strict: bool = False, task: TaskProfile | None = None, fanout: str = "auto"):
     return compile_plan(
         task or profile(),
         strategy=strategy,
@@ -56,14 +50,17 @@ def assert_tail(
     *,
     strict: bool = False,
     expected_soft: int,
-    expected_effective_hard: int,
+    expected_hard: int,
     expected_reviewer_reserve: int,
     expected_parent_reserve: int,
 ) -> None:
     execution_plan = plan(strategy, strict=strict)
+    assert execution_plan.schema_version == 11, execution_plan
     assert execution_plan.task_budget is not None, execution_plan
-    assert execution_plan.review_stage is not None, execution_plan
-    assert execution_plan.reviewer_workers > 0, execution_plan
+    assert execution_plan.review_stage is not None and execution_plan.reviewer_workers > 0, execution_plan
+    assert execution_plan.review_stage.fallback_policy == "retry_review", execution_plan
+    assert execution_plan.task_budget.soft_timeout_seconds == expected_soft, execution_plan
+    assert execution_plan.task_budget.hard_timeout_seconds == expected_hard, execution_plan
 
     start = 100.0
     with tempfile.TemporaryDirectory() as tmp:
@@ -71,163 +68,104 @@ def assert_tail(
         initialized = init(state, strategy, execution_plan.to_dict(), start)
         plan_json = execution_plan.to_dict()
         cutoff = start + expected_soft
-        hard = start + expected_effective_hard
+        hard = start + expected_hard
 
         assert initialized["soft_deadline"] == cutoff, initialized
         assert initialized["hard_deadline"] == hard, initialized
-        assert initialized["effective_task_budget"]["soft_timeout_seconds"] == expected_soft, initialized
-        assert initialized["effective_task_budget"]["hard_timeout_seconds"] == expected_effective_hard, initialized
+        assert initialized["task_budget"] == execution_plan.task_budget.__dict__, initialized
         assert initialized["reviewer_reserve_seconds"] == expected_reviewer_reserve, initialized
         assert initialized["parent_finalization_reserve_seconds"] == expected_parent_reserve, initialized
-        assert initialized["required_completion_reserve_seconds"] == (
-            expected_reviewer_reserve + expected_parent_reserve
-        ), initialized
-        assert initialized["hard_deadline_extended"] == (
-            expected_effective_hard > execution_plan.task_budget.hard_timeout_seconds
-        ), initialized
+        assert initialized["required_completion_reserve_seconds"] == expected_reviewer_reserve + expected_parent_reserve, initialized
 
         before = status(state, strategy, plan_json, "implementation", cutoff - 1)
-        assert before["permits_phase_start"] is True and before["action"] == "continue", before
-
+        assert before["permits_phase_start"] and before["action"] == "continue", before
         at_cutoff = status(state, strategy, plan_json, "implementation", cutoff)
-        assert at_cutoff["permits_phase_start"] is False, at_cutoff
+        assert not at_cutoff["permits_phase_start"], at_cutoff
         assert at_cutoff["action"] == "converge_for_required_completion", at_cutoff
-        assert at_cutoff["checkpoint_convergence_required"] is True, at_cutoff
-        assert at_cutoff["required_completion_handoff"] is True, at_cutoff
-
+        assert at_cutoff["checkpoint_convergence_required"], at_cutoff
         required = status(state, strategy, plan_json, "required_completion", cutoff)
-        assert required["permits_phase_start"] is True, required
-        assert required["action"] == "complete_required", required
+        assert required["permits_phase_start"] and required["action"] == "complete_required", required
+
+        review = reserve_phase(
+            state,
+            strategy,
+            plan_json,
+            "required_completion",
+            "review_attempt",
+            "review-0",
+            "review-generation-0",
+            cutoff,
+        )
+        assert review["reserved"] and not review["idempotent"], review
+        assert review["counters"]["review_attempt"] == 1, review
 
         near_hard = status(state, strategy, plan_json, "required_completion", hard - 1)
-        assert near_hard["permits_phase_start"] is True, near_hard
+        assert near_hard["permits_phase_start"], near_hard
         stopped = status(state, strategy, plan_json, "required_completion", hard)
-        assert stopped["permits_phase_start"] is False and stopped["action"] == "stop", stopped
+        assert not stopped["permits_phase_start"] and stopped["action"] == "stop", stopped
 
 
 def assert_parallel_topology_budget(strategy: str, *, fanout: str = "auto") -> None:
     execution_plan = plan(
         strategy,
-        task=profile(
-            parallelism="high",
-            write_conflict="low",
-            writable_workstreams=4,
-        ),
+        task=profile(parallelism="high", write_conflict="low", writable_workstreams=4),
         fanout=fanout,
     )
-    assert execution_plan.implementation_stage is not None, execution_plan
-    assert execution_plan.task_budget is not None, execution_plan
+    assert execution_plan.implementation_stage is not None and execution_plan.task_budget is not None, execution_plan
     assert execution_plan.implementation_workers >= 1, execution_plan
     assert execution_plan.implementation_stage.maximum_work_units >= execution_plan.implementation_workers, execution_plan
     assert execution_plan.task_budget.max_work_units >= execution_plan.implementation_workers, execution_plan
     assert execution_plan.task_budget.max_implementation_attempts >= execution_plan.implementation_workers, execution_plan
-
-    # Phase init repeats the invariant and therefore fails closed if a future
-    # compiler/strategy regression emits an impossible plan.
     with tempfile.TemporaryDirectory() as tmp:
-        state = str(Path(tmp) / f"{strategy}-parallel.json")
-        init(state, f"{strategy}-parallel", execution_plan.to_dict(), 100)
+        init(str(Path(tmp) / f"{strategy}.json"), strategy, execution_plan.to_dict(), 100)
 
 
 def main() -> None:
-    # General work retains the strategy soft target. Required review is additive:
-    # effective hard extends to preserve both the reviewer hard window and a
-    # distinct Parent finalization reserve.
-    assert_tail(
-        "quality",
-        expected_soft=4800,
-        expected_effective_hard=8100,
-        expected_reviewer_reserve=3000,
-        expected_parent_reserve=300,
-    )
-    assert_tail(
-        "balanced",
-        strict=True,
-        expected_soft=2400,
-        expected_effective_hard=4380,
-        expected_reviewer_reserve=1800,
-        expected_parent_reserve=180,
-    )
-    assert_tail(
-        "speed",
-        strict=True,
-        expected_soft=1200,
-        expected_effective_hard=2220,
-        expected_reviewer_reserve=900,
-        expected_parent_reserve=120,
-    )
-    assert_tail(
-        "efficient",
-        strict=True,
-        expected_soft=1500,
-        expected_effective_hard=2850,
-        expected_reviewer_reserve=1200,
-        expected_parent_reserve=150,
-    )
+    assert_tail("quality", expected_soft=4800, expected_hard=8100, expected_reviewer_reserve=3000, expected_parent_reserve=300)
+    assert_tail("balanced", strict=True, expected_soft=2400, expected_hard=4380, expected_reviewer_reserve=1800, expected_parent_reserve=180)
+    assert_tail("speed", strict=True, expected_soft=1200, expected_hard=2220, expected_reviewer_reserve=900, expected_parent_reserve=120)
+    assert_tail("efficient", strict=True, expected_soft=1500, expected_hard=2850, expected_reviewer_reserve=1200, expected_parent_reserve=150)
 
-    # Parent-only review keeps the original strategy task envelope unchanged.
+    # Parent-only plans have no reviewer capacity and keep the strategy base hard deadline.
     balanced = plan("balanced")
     assert balanced.reviewer_workers == 0 and balanced.review_stage is None, balanced
+    assert balanced.task_budget.max_review_attempts == 0, balanced
+    assert balanced.task_budget.hard_timeout_seconds == 3000, balanced
     with tempfile.TemporaryDirectory() as tmp:
         state = str(Path(tmp) / "balanced-parent.json")
         initialized = init(state, "balanced-parent", balanced.to_dict(), 100)
-        assert initialized["effective_task_budget"] == {
-            "soft_timeout_seconds": 2400,
-            "hard_timeout_seconds": 3000,
-            "max_work_units": balanced.task_budget.max_work_units,
-            "max_implementation_attempts": balanced.task_budget.max_implementation_attempts,
-            "max_replans": 2,
-            "max_replacements": 2,
-        }, initialized
+        assert initialized["required_completion_reserve_seconds"] == 0, initialized
         decision = status(state, "balanced-parent", balanced.to_dict(), "implementation", 2500)
-        assert decision["required_completion_reserve_seconds"] == 0, decision
         assert decision["action"] == "converge", decision
+        no_completion = status(state, "balanced-parent", balanced.to_dict(), "required_completion", 2500)
+        assert not no_completion["permits_phase_start"] and no_completion["action"] == "stop", no_completion
 
-    # The raw ledger soft deadline remains the general-work boundary. It rejects
-    # genuinely new implementation work there but keeps idempotent replay valid.
+    # General work closes at soft while exact replay stays idempotent.
     quality = plan("quality")
     with tempfile.TemporaryDirectory() as tmp:
         state = str(Path(tmp) / "quality-reserve.json")
         init(state, "quality-reserve", quality.to_dict(), 100)
-        first = reserve_implementation(
-            state,
-            "quality-reserve",
-            quality.to_dict(),
-            "implementation_attempt",
-            "attempt-before-tail",
-            "unit-0-generation-0",
-            4899,
-        )
-        assert first["reserved"] is True and first["idempotent"] is False, first
-
-        replay = reserve_implementation(
-            state,
-            "quality-reserve",
-            quality.to_dict(),
-            "implementation_attempt",
-            "attempt-before-tail",
-            "unit-0-generation-0",
-            4900,
-        )
-        assert replay["reserved"] is True and replay["idempotent"] is True, replay
-        assert replay["permits_phase_start"] is False, replay
-
+        first = reserve_implementation(state, "quality-reserve", quality.to_dict(), "implementation_attempt", "attempt-0", "unit-0-generation-0", 4899)
+        assert first["reserved"] and not first["idempotent"], first
+        replay = reserve_implementation(state, "quality-reserve", quality.to_dict(), "implementation_attempt", "attempt-0", "unit-0-generation-0", 4900)
+        assert replay["reserved"] and replay["idempotent"], replay
         try:
-            reserve_implementation(
-                state,
-                "quality-reserve",
-                quality.to_dict(),
-                "implementation_attempt",
-                "attempt-in-tail",
-                "unit-0-generation-1",
-                4900,
-            )
+            reserve_implementation(state, "quality-reserve", quality.to_dict(), "implementation_attempt", "attempt-1", "unit-0-generation-1", 4900)
         except LedgerError as exc:
-            assert "soft deadline reached" in str(exc), exc
+            assert "does not permit" in str(exc) or "soft deadline" in str(exc), exc
         else:
-            raise AssertionError("new implementation reservation unexpectedly entered required-completion tail")
+            raise AssertionError("new implementation attempt entered required-completion tail")
 
-    # Initial budget-plan identity remains immutable across replanning.
+        review = reserve_phase(state, "quality-reserve", quality.to_dict(), "required_completion", "review_attempt", "review-1", "reviewer-1", 4900)
+        assert review["reserved"] and review["counters"]["review_attempt"] == 1, review
+        try:
+            reserve_phase(state, "quality-reserve", quality.to_dict(), "implementation", "review_attempt", "bad-phase", "bad", 4900)
+        except LedgerError as exc:
+            assert "require" in str(exc), exc
+        else:
+            raise AssertionError("review_attempt accepted in implementation phase")
+
+    # Budget identity is tied to the original canonical plan.
     quality = plan("quality")
     with tempfile.TemporaryDirectory() as tmp:
         state = str(Path(tmp) / "identity.json")
@@ -238,91 +176,50 @@ def main() -> None:
         except LedgerError as exc:
             assert "plan/policy mismatch" in str(exc), exc
         else:
-            raise AssertionError("different budget plan unexpectedly reused task phase ledger")
+            raise AssertionError("different canonical budget plan reused task ledger")
 
-    # There is no grandfathered pre-phase state. A raw ledger created with a
-    # different policy fingerprint fails closed instead of silently changing semantics.
+    # No grandfathering: a raw pre-canonical policy ledger fails closed.
     quality = plan("quality")
+    raw_quality_policy = get("quality").task_budget(profile())
+    assert raw_quality_policy.hard_timeout_seconds != quality.task_budget.hard_timeout_seconds
     with tempfile.TemporaryDirectory() as tmp:
         state = str(Path(tmp) / "mismatch.json")
-        init_ledger(state, "mismatch", quality.task_budget, 100)
+        init_ledger(state, "mismatch", raw_quality_policy, 100)
         try:
             status(state, "mismatch", quality.to_dict(), "implementation", 101)
         except LedgerError as exc:
             assert "plan/policy mismatch" in str(exc), exc
         else:
-            raise AssertionError("mismatched raw ledger unexpectedly adopted phase-aware semantics")
+            raise AssertionError("non-canonical ledger was grandfathered")
 
-    # Exercise the real argparse path: --now arrives as text in every shell.
+    # Real CLI path accepts textual --now and phase/kind pairing.
     phase_cli = ROOT / "scripts/strategies/task_phase_runtime.py"
     quality = plan("quality")
     with tempfile.TemporaryDirectory() as tmp:
         state = str(Path(tmp) / "cli.json")
         plan_json = json.dumps(quality.to_dict(), separators=(",", ":"))
-        init_run = subprocess.run(
-            [
-                sys.executable,
-                str(phase_cli),
-                "init",
-                "--state-file",
-                state,
-                "--task-id",
-                "cli",
-                "--plan-json",
-                plan_json,
-                "--now",
-                "100",
-            ],
-            check=True,
-            text=True,
-            capture_output=True,
-        )
+        init_run = subprocess.run([
+            sys.executable, str(phase_cli), "init", "--state-file", state, "--task-id", "cli", "--plan-json", plan_json, "--now", "100"
+        ], check=True, text=True, capture_output=True)
         initialized = json.loads(init_run.stdout)
-        assert initialized["soft_deadline"] == 4900, initialized
-        assert initialized["hard_deadline"] == 8200, initialized
-        status_run = subprocess.run(
-            [
-                sys.executable,
-                str(phase_cli),
-                "status",
-                "--state-file",
-                state,
-                "--task-id",
-                "cli",
-                "--plan-json",
-                plan_json,
-                "--phase",
-                "required_completion",
-                "--now",
-                "4900",
-            ],
-            check=True,
-            text=True,
-            capture_output=True,
-        )
-        required = json.loads(status_run.stdout)
-        assert required["action"] == "complete_required" and required["permits_phase_start"], required
+        assert initialized["soft_deadline"] == 4900 and initialized["hard_deadline"] == 8200, initialized
+        review_run = subprocess.run([
+            sys.executable, str(phase_cli), "reserve", "--state-file", state, "--task-id", "cli", "--plan-json", plan_json,
+            "--phase", "required_completion", "--kind", "review_attempt", "--reservation-id", "review-cli", "--fingerprint", "review-cli-v0", "--now", "4900"
+        ], check=True, text=True, capture_output=True)
+        review = json.loads(review_run.stdout)
+        assert review["reserved"] and review["phase"] == "required_completion", review
 
-    # High technical risk may opt into multiple evidence-backed quality units,
-    # but minimum_work_units remains one so this never forces a fake split.
     high_risk = profile(risk="high")
     quality_stage = get("quality").lifecycle(high_risk, "implementation")
-    assert quality_stage.minimum_work_units == 1, quality_stage
-    assert quality_stage.maximum_work_units == 3, quality_stage
+    assert quality_stage.minimum_work_units == 1 and quality_stage.maximum_work_units == 3, quality_stage
 
-    # Real multi-writer topology must always fit the logical-unit and attempt
-    # budgets. This is the regression that the previous single-worker tests missed.
     assert_parallel_topology_budget("balanced")
     assert_parallel_topology_budget("quality")
     assert_parallel_topology_budget("speed")
     assert_parallel_topology_budget("efficient", fanout="aggressive")
 
-    # Explicitly corrupt a valid plan to prove phase init rejects under-provisioned
-    # topology even if a future strategy/compiler bug bypasses normal checks.
-    speed_parallel = plan(
-        "speed",
-        task=profile(parallelism="high", write_conflict="low", writable_workstreams=4),
-    ).to_dict()
+    speed_parallel = plan("speed", task=profile(parallelism="high", write_conflict="low", writable_workstreams=4)).to_dict()
     assert speed_parallel["implementation_workers"] > 1, speed_parallel
     broken = deepcopy(speed_parallel)
     broken["implementation_stage"]["maximum_work_units"] = 1
@@ -333,7 +230,7 @@ def main() -> None:
         except LedgerError as exc:
             assert "topology exceeds task budget max_work_units" in str(exc), exc
         else:
-            raise AssertionError("under-provisioned parallel topology unexpectedly initialized")
+            raise AssertionError("under-provisioned parallel topology initialized")
 
     print("task phase admission tests passed")
 

--- a/tests/test_task_phase_runtime.py
+++ b/tests/test_task_phase_runtime.py
@@ -108,15 +108,26 @@ def assert_tail(
         assert not finalization["permits_review_start"], finalization
         assert finalization["permits_parent_finalization"], finalization
         assert finalization["action"] == "finalize_parent", finalization
+
+        # A reservation committed before review_deadline remains exactly replayable
+        # after admission closes; this acknowledgement does not create new work.
+        replay = reserve_phase(
+            state, strategy, plan_json, "required_completion", "review_attempt",
+            "review-1", "review-generation-1", review_deadline,
+        )
+        assert replay["reserved"] and replay["idempotent"], replay
+        assert replay["action"] == "finalize_parent", replay
+        assert replay["counters"]["review_attempt"] == 2, replay
+
         try:
             reserve_phase(
                 state, strategy, plan_json, "required_completion", "review_attempt",
                 "review-too-late", "review-generation-2", review_deadline,
             )
         except LedgerError as exc:
-            assert "Parent finalization reserve" in str(exc), exc
+            assert "admission deadline" in str(exc), exc
         else:
-            raise AssertionError("review retry consumed Parent finalization reserve")
+            raise AssertionError("new review retry consumed Parent finalization reserve")
 
         near_hard = status(state, strategy, plan_json, "required_completion", hard - 1)
         assert near_hard["permits_phase_start"] and near_hard["action"] == "finalize_parent", near_hard

--- a/tests/test_task_phase_runtime.py
+++ b/tests/test_task_phase_runtime.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-"""Regression coverage for task-budget phase admission and required review tail."""
+"""Regression coverage for task-budget phase admission and required completion."""
 from __future__ import annotations
 
 import json
 import subprocess
 import sys
 import tempfile
+from copy import deepcopy
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -35,16 +36,30 @@ def profile(**overrides) -> TaskProfile:
     return TaskProfile(**values)
 
 
-def plan(strategy: str, *, strict: bool = False, task: TaskProfile | None = None):
+def plan(
+    strategy: str,
+    *,
+    strict: bool = False,
+    task: TaskProfile | None = None,
+    fanout: str = "auto",
+):
     return compile_plan(
         task or profile(),
         strategy=strategy,
         routing_mode="delegate",
-        modifiers=Modifiers(review="strict" if strict else "auto", fanout="auto"),
+        modifiers=Modifiers(review="strict" if strict else "auto", fanout=fanout),
     )
 
 
-def assert_tail(strategy: str, expected_elapsed_cutoff: int, *, strict: bool = False) -> None:
+def assert_tail(
+    strategy: str,
+    *,
+    strict: bool = False,
+    expected_soft: int,
+    expected_effective_hard: int,
+    expected_reviewer_reserve: int,
+    expected_parent_reserve: int,
+) -> None:
     execution_plan = plan(strategy, strict=strict)
     assert execution_plan.task_budget is not None, execution_plan
     assert execution_plan.review_stage is not None, execution_plan
@@ -55,15 +70,24 @@ def assert_tail(strategy: str, expected_elapsed_cutoff: int, *, strict: bool = F
         state = str(Path(tmp) / f"{strategy}.json")
         initialized = init(state, strategy, execution_plan.to_dict(), start)
         plan_json = execution_plan.to_dict()
-        cutoff = start + expected_elapsed_cutoff
+        cutoff = start + expected_soft
+        hard = start + expected_effective_hard
 
-        assert initialized["effective_task_budget"]["soft_timeout_seconds"] == expected_elapsed_cutoff, initialized
         assert initialized["soft_deadline"] == cutoff, initialized
-        assert initialized["legacy_unclamped"] is False, initialized
+        assert initialized["hard_deadline"] == hard, initialized
+        assert initialized["effective_task_budget"]["soft_timeout_seconds"] == expected_soft, initialized
+        assert initialized["effective_task_budget"]["hard_timeout_seconds"] == expected_effective_hard, initialized
+        assert initialized["reviewer_reserve_seconds"] == expected_reviewer_reserve, initialized
+        assert initialized["parent_finalization_reserve_seconds"] == expected_parent_reserve, initialized
+        assert initialized["required_completion_reserve_seconds"] == (
+            expected_reviewer_reserve + expected_parent_reserve
+        ), initialized
+        assert initialized["hard_deadline_extended"] == (
+            expected_effective_hard > execution_plan.task_budget.hard_timeout_seconds
+        ), initialized
 
         before = status(state, strategy, plan_json, "implementation", cutoff - 1)
-        assert before["permits_phase_start"] is True, before
-        assert before["action"] == "continue", before
+        assert before["permits_phase_start"] is True and before["action"] == "continue", before
 
         at_cutoff = status(state, strategy, plan_json, "implementation", cutoff)
         assert at_cutoff["permits_phase_start"] is False, at_cutoff
@@ -74,28 +98,74 @@ def assert_tail(strategy: str, expected_elapsed_cutoff: int, *, strict: bool = F
         required = status(state, strategy, plan_json, "required_completion", cutoff)
         assert required["permits_phase_start"] is True, required
         assert required["action"] == "complete_required", required
-        assert required["required_completion_reserve_seconds"] == execution_plan.review_stage.hard_timeout_seconds, required
 
-        hard = start + execution_plan.task_budget.hard_timeout_seconds
         near_hard = status(state, strategy, plan_json, "required_completion", hard - 1)
         assert near_hard["permits_phase_start"] is True, near_hard
         stopped = status(state, strategy, plan_json, "required_completion", hard)
         assert stopped["permits_phase_start"] is False and stopped["action"] == "stop", stopped
 
 
+def assert_parallel_topology_budget(strategy: str, *, fanout: str = "auto") -> None:
+    execution_plan = plan(
+        strategy,
+        task=profile(
+            parallelism="high",
+            write_conflict="low",
+            writable_workstreams=4,
+        ),
+        fanout=fanout,
+    )
+    assert execution_plan.implementation_stage is not None, execution_plan
+    assert execution_plan.task_budget is not None, execution_plan
+    assert execution_plan.implementation_workers >= 1, execution_plan
+    assert execution_plan.implementation_stage.maximum_work_units >= execution_plan.implementation_workers, execution_plan
+    assert execution_plan.task_budget.max_work_units >= execution_plan.implementation_workers, execution_plan
+    assert execution_plan.task_budget.max_implementation_attempts >= execution_plan.implementation_workers, execution_plan
+
+    # Phase init repeats the invariant and therefore fails closed if a future
+    # compiler/strategy regression emits an impossible plan.
+    with tempfile.TemporaryDirectory() as tmp:
+        state = str(Path(tmp) / f"{strategy}-parallel.json")
+        init(state, f"{strategy}-parallel", execution_plan.to_dict(), 100)
+
+
 def main() -> None:
-    # Quality plans require independent review by default. Their ledger soft
-    # deadline is deterministically clamped to preserve the review stage's full
-    # hard tail.
-    assert_tail("quality", 3000)
+    # General work retains the strategy soft target. Required review is additive:
+    # effective hard extends to preserve both the reviewer hard window and a
+    # distinct Parent finalization reserve.
+    assert_tail(
+        "quality",
+        expected_soft=4800,
+        expected_effective_hard=8100,
+        expected_reviewer_reserve=3000,
+        expected_parent_reserve=300,
+    )
+    assert_tail(
+        "balanced",
+        strict=True,
+        expected_soft=2400,
+        expected_effective_hard=4380,
+        expected_reviewer_reserve=1800,
+        expected_parent_reserve=180,
+    )
+    assert_tail(
+        "speed",
+        strict=True,
+        expected_soft=1200,
+        expected_effective_hard=2220,
+        expected_reviewer_reserve=900,
+        expected_parent_reserve=120,
+    )
+    assert_tail(
+        "efficient",
+        strict=True,
+        expected_soft=1500,
+        expected_effective_hard=2850,
+        expected_reviewer_reserve=1200,
+        expected_parent_reserve=150,
+    )
 
-    # Strict review is an explicit required-completion stage even for strategies
-    # that normally use Parent-only review.
-    assert_tail("balanced", 1200, strict=True)
-    assert_tail("speed", 900, strict=True)
-    assert_tail("efficient", 600, strict=True)
-
-    # Parent-only review keeps the original strategy soft deadline unchanged.
+    # Parent-only review keeps the original strategy task envelope unchanged.
     balanced = plan("balanced")
     assert balanced.reviewer_workers == 0 and balanced.review_stage is None, balanced
     with tempfile.TemporaryDirectory() as tmp:
@@ -104,19 +174,17 @@ def main() -> None:
         assert initialized["effective_task_budget"] == {
             "soft_timeout_seconds": 2400,
             "hard_timeout_seconds": 3000,
-            "max_work_units": 1,
-            "max_implementation_attempts": 3,
+            "max_work_units": balanced.task_budget.max_work_units,
+            "max_implementation_attempts": balanced.task_budget.max_implementation_attempts,
             "max_replans": 2,
             "max_replacements": 2,
         }, initialized
-        decision = status(state, "balanced-parent", balanced.to_dict(), "implementation", 100 + 2400)
+        decision = status(state, "balanced-parent", balanced.to_dict(), "implementation", 2500)
         assert decision["required_completion_reserve_seconds"] == 0, decision
-        assert decision["general_work_deadline"] == 100 + 2400, decision
         assert decision["action"] == "converge", decision
 
-    # Phase-aware init moves the raw ledger soft deadline to the required-review
-    # boundary. The underlying atomic reserve therefore rejects *new* work there
-    # while preserving its deliberate idempotent replay behavior.
+    # The raw ledger soft deadline remains the general-work boundary. It rejects
+    # genuinely new implementation work there but keeps idempotent replay valid.
     quality = plan("quality")
     with tempfile.TemporaryDirectory() as tmp:
         state = str(Path(tmp) / "quality-reserve.json")
@@ -128,7 +196,7 @@ def main() -> None:
             "implementation_attempt",
             "attempt-before-tail",
             "unit-0-generation-0",
-            3099,
+            4899,
         )
         assert first["reserved"] is True and first["idempotent"] is False, first
 
@@ -139,7 +207,7 @@ def main() -> None:
             "implementation_attempt",
             "attempt-before-tail",
             "unit-0-generation-0",
-            3100,
+            4900,
         )
         assert replay["reserved"] is True and replay["idempotent"] is True, replay
         assert replay["permits_phase_start"] is False, replay
@@ -152,15 +220,14 @@ def main() -> None:
                 "implementation_attempt",
                 "attempt-in-tail",
                 "unit-0-generation-1",
-                3100,
+                4900,
             )
         except LedgerError as exc:
             assert "soft deadline reached" in str(exc), exc
         else:
-            raise AssertionError("new implementation reservation unexpectedly entered required-review tail")
+            raise AssertionError("new implementation reservation unexpectedly entered required-completion tail")
 
-    # The phase helper refuses a different budget plan against an existing
-    # ledger, preventing a caller from extending the admission window after init.
+    # Initial budget-plan identity remains immutable across replanning.
     quality = plan("quality")
     with tempfile.TemporaryDirectory() as tmp:
         state = str(Path(tmp) / "identity.json")
@@ -173,21 +240,18 @@ def main() -> None:
         else:
             raise AssertionError("different budget plan unexpectedly reused task phase ledger")
 
-    # A task already initialized by the pre-phase runtime keeps its historical
-    # original soft deadline. Calling phase-aware init after upgrade adopts that
-    # ledger without shortening it or inventing a review-tail reservation.
+    # There is no grandfathered pre-phase state. A raw ledger created with a
+    # different policy fingerprint fails closed instead of silently changing semantics.
     quality = plan("quality")
     with tempfile.TemporaryDirectory() as tmp:
-        state = str(Path(tmp) / "legacy.json")
-        init_ledger(state, "legacy", quality.task_budget, 100)
-        adopted = init(state, "legacy", quality.to_dict(), 101)
-        assert adopted["initialized"] is False and adopted["idempotent"] is True, adopted
-        assert adopted["legacy_unclamped"] is True, adopted
-        assert adopted["soft_deadline"] == 4900, adopted
-        assert adopted["required_completion_reserve_seconds"] == 0, adopted
-        legacy_status = status(state, "legacy", quality.to_dict(), "implementation", 3100)
-        assert legacy_status["legacy_unclamped"] is True, legacy_status
-        assert legacy_status["permits_phase_start"] is True, legacy_status
+        state = str(Path(tmp) / "mismatch.json")
+        init_ledger(state, "mismatch", quality.task_budget, 100)
+        try:
+            status(state, "mismatch", quality.to_dict(), "implementation", 101)
+        except LedgerError as exc:
+            assert "plan/policy mismatch" in str(exc), exc
+        else:
+            raise AssertionError("mismatched raw ledger unexpectedly adopted phase-aware semantics")
 
     # Exercise the real argparse path: --now arrives as text in every shell.
     phase_cli = ROOT / "scripts/strategies/task_phase_runtime.py"
@@ -214,7 +278,8 @@ def main() -> None:
             capture_output=True,
         )
         initialized = json.loads(init_run.stdout)
-        assert initialized["soft_deadline"] == 3100, initialized
+        assert initialized["soft_deadline"] == 4900, initialized
+        assert initialized["hard_deadline"] == 8200, initialized
         status_run = subprocess.run(
             [
                 sys.executable,
@@ -229,7 +294,7 @@ def main() -> None:
                 "--phase",
                 "required_completion",
                 "--now",
-                "3100",
+                "4900",
             ],
             check=True,
             text=True,
@@ -244,6 +309,31 @@ def main() -> None:
     quality_stage = get("quality").lifecycle(high_risk, "implementation")
     assert quality_stage.minimum_work_units == 1, quality_stage
     assert quality_stage.maximum_work_units == 3, quality_stage
+
+    # Real multi-writer topology must always fit the logical-unit and attempt
+    # budgets. This is the regression that the previous single-worker tests missed.
+    assert_parallel_topology_budget("balanced")
+    assert_parallel_topology_budget("quality")
+    assert_parallel_topology_budget("speed")
+    assert_parallel_topology_budget("efficient", fanout="aggressive")
+
+    # Explicitly corrupt a valid plan to prove phase init rejects under-provisioned
+    # topology even if a future strategy/compiler bug bypasses normal checks.
+    speed_parallel = plan(
+        "speed",
+        task=profile(parallelism="high", write_conflict="low", writable_workstreams=4),
+    ).to_dict()
+    assert speed_parallel["implementation_workers"] > 1, speed_parallel
+    broken = deepcopy(speed_parallel)
+    broken["implementation_stage"]["maximum_work_units"] = 1
+    broken["task_budget"]["max_work_units"] = 1
+    with tempfile.TemporaryDirectory() as tmp:
+        try:
+            init(str(Path(tmp) / "broken.json"), "broken", broken, 100)
+        except LedgerError as exc:
+            assert "topology exceeds task budget max_work_units" in str(exc), exc
+        else:
+            raise AssertionError("under-provisioned parallel topology unexpectedly initialized")
 
     print("task phase admission tests passed")
 

--- a/tests/test_task_phase_runtime.py
+++ b/tests/test_task_phase_runtime.py
@@ -69,9 +69,11 @@ def assert_tail(
         plan_json = execution_plan.to_dict()
         cutoff = start + expected_soft
         hard = start + expected_hard
+        review_deadline = hard - expected_parent_reserve
 
         assert initialized["soft_deadline"] == cutoff, initialized
         assert initialized["hard_deadline"] == hard, initialized
+        assert initialized["review_deadline"] == review_deadline, initialized
         assert initialized["task_budget"] == execution_plan.task_budget.__dict__, initialized
         assert initialized["reviewer_reserve_seconds"] == expected_reviewer_reserve, initialized
         assert initialized["parent_finalization_reserve_seconds"] == expected_parent_reserve, initialized
@@ -85,6 +87,7 @@ def assert_tail(
         assert at_cutoff["checkpoint_convergence_required"], at_cutoff
         required = status(state, strategy, plan_json, "required_completion", cutoff)
         assert required["permits_phase_start"] and required["action"] == "complete_required", required
+        assert required["permits_review_start"] and required["permits_parent_finalization"], required
 
         review = reserve_phase(
             state,
@@ -99,8 +102,44 @@ def assert_tail(
         assert review["reserved"] and not review["idempotent"], review
         assert review["counters"]["review_attempt"] == 1, review
 
+        # A failed reviewer may retry inside the review window, but not one
+        # instant later: the final tail is exclusively Parent finalization.
+        retry = reserve_phase(
+            state,
+            strategy,
+            plan_json,
+            "required_completion",
+            "review_attempt",
+            "review-1",
+            "review-generation-1",
+            review_deadline - 1,
+        )
+        assert retry["reserved"] and retry["counters"]["review_attempt"] == 2, retry
+
+        finalization = status(state, strategy, plan_json, "required_completion", review_deadline)
+        assert finalization["permits_phase_start"], finalization
+        assert finalization["permits_required_completion"], finalization
+        assert not finalization["permits_review_start"], finalization
+        assert finalization["permits_parent_finalization"], finalization
+        assert finalization["action"] == "finalize_parent", finalization
+        try:
+            reserve_phase(
+                state,
+                strategy,
+                plan_json,
+                "required_completion",
+                "review_attempt",
+                "review-too-late",
+                "review-generation-2",
+                review_deadline,
+            )
+        except LedgerError as exc:
+            assert "Parent finalization reserve" in str(exc), exc
+        else:
+            raise AssertionError("review retry consumed Parent finalization reserve")
+
         near_hard = status(state, strategy, plan_json, "required_completion", hard - 1)
-        assert near_hard["permits_phase_start"], near_hard
+        assert near_hard["permits_phase_start"] and near_hard["action"] == "finalize_parent", near_hard
         stopped = status(state, strategy, plan_json, "required_completion", hard)
         assert not stopped["permits_phase_start"] and stopped["action"] == "stop", stopped
 
@@ -135,6 +174,7 @@ def main() -> None:
         state = str(Path(tmp) / "balanced-parent.json")
         initialized = init(state, "balanced-parent", balanced.to_dict(), 100)
         assert initialized["required_completion_reserve_seconds"] == 0, initialized
+        assert initialized["review_deadline"] is None, initialized
         decision = status(state, "balanced-parent", balanced.to_dict(), "implementation", 2500)
         assert decision["action"] == "converge", decision
         no_completion = status(state, "balanced-parent", balanced.to_dict(), "required_completion", 2500)
@@ -203,6 +243,7 @@ def main() -> None:
         ], check=True, text=True, capture_output=True)
         initialized = json.loads(init_run.stdout)
         assert initialized["soft_deadline"] == 4900 and initialized["hard_deadline"] == 8200, initialized
+        assert initialized["review_deadline"] == 7900, initialized
         review_run = subprocess.run([
             sys.executable, str(phase_cli), "reserve", "--state-file", state, "--task-id", "cli", "--plan-json", plan_json,
             "--phase", "required_completion", "--kind", "review_attempt", "--reservation-id", "review-cli", "--fingerprint", "review-cli-v0", "--now", "4900"

--- a/tests/test_task_phase_runtime.py
+++ b/tests/test_task_phase_runtime.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Regression coverage for task-budget phase admission and required review tail."""
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from strategy_runtime import Modifiers, TaskProfile, compile_plan  # noqa: E402
+from strategies import get  # noqa: E402
+from strategies.task_budget_runtime import LedgerError, init_ledger  # noqa: E402
+from strategies.task_phase_runtime import reserve_implementation, status  # noqa: E402
+
+
+def profile(**overrides) -> TaskProfile:
+    values = {
+        "complexity": "routine",
+        "uncertainty": "medium",
+        "risk": "medium",
+        "scope": "module",
+        "parallelism": "limited",
+        "write_conflict": "low",
+        "exploration_need": "medium",
+        "verification_cost": "medium",
+        "iteration_intensity": "iterative",
+        "writable_workstreams": 1,
+        "quality_intent": "normal",
+    }
+    values.update(overrides)
+    return TaskProfile(**values)
+
+
+def plan(strategy: str, *, strict: bool = False, task: TaskProfile | None = None):
+    return compile_plan(
+        task or profile(),
+        strategy=strategy,
+        routing_mode="delegate",
+        modifiers=Modifiers(review="strict" if strict else "auto", fanout="auto"),
+    )
+
+
+def assert_tail(strategy: str, expected_elapsed_cutoff: int, *, strict: bool = False) -> None:
+    execution_plan = plan(strategy, strict=strict)
+    assert execution_plan.task_budget is not None, execution_plan
+    assert execution_plan.review_stage is not None, execution_plan
+    assert execution_plan.reviewer_workers > 0, execution_plan
+
+    start = 100.0
+    with tempfile.TemporaryDirectory() as tmp:
+        state = str(Path(tmp) / f"{strategy}.json")
+        init_ledger(state, strategy, execution_plan.task_budget, start)
+        plan_json = execution_plan.to_dict()
+        cutoff = start + expected_elapsed_cutoff
+
+        before = status(state, strategy, plan_json, "implementation", cutoff - 1)
+        assert before["permits_phase_start"] is True, before
+        assert before["action"] == "continue", before
+
+        at_cutoff = status(state, strategy, plan_json, "implementation", cutoff)
+        assert at_cutoff["permits_phase_start"] is False, at_cutoff
+        assert at_cutoff["action"] == "converge_for_required_completion", at_cutoff
+        assert at_cutoff["checkpoint_convergence_required"] is True, at_cutoff
+        assert at_cutoff["required_completion_handoff"] is True, at_cutoff
+
+        required = status(state, strategy, plan_json, "required_completion", cutoff)
+        assert required["permits_phase_start"] is True, required
+        assert required["action"] == "complete_required", required
+        assert required["required_completion_reserve_seconds"] == execution_plan.review_stage.hard_timeout_seconds, required
+
+        hard = start + execution_plan.task_budget.hard_timeout_seconds
+        near_hard = status(state, strategy, plan_json, "required_completion", hard - 1)
+        assert near_hard["permits_phase_start"] is True, near_hard
+        stopped = status(state, strategy, plan_json, "required_completion", hard)
+        assert stopped["permits_phase_start"] is False and stopped["action"] == "stop", stopped
+
+
+def main() -> None:
+    # Quality plans require independent review by default. Their general-work
+    # admission closes early enough to preserve the review stage's full hard tail.
+    assert_tail("quality", 3000)
+
+    # Strict review is an explicit required-completion stage even for strategies
+    # that normally use Parent-only review.
+    assert_tail("balanced", 1200, strict=True)
+    assert_tail("speed", 900, strict=True)
+    assert_tail("efficient", 600, strict=True)
+
+    # Parent-only review keeps the original strategy soft deadline unchanged.
+    balanced = plan("balanced")
+    assert balanced.reviewer_workers == 0 and balanced.review_stage is None, balanced
+    with tempfile.TemporaryDirectory() as tmp:
+        state = str(Path(tmp) / "balanced-parent.json")
+        init_ledger(state, "balanced-parent", balanced.task_budget, 100)
+        decision = status(state, "balanced-parent", balanced.to_dict(), "implementation", 100 + 2400)
+        assert decision["required_completion_reserve_seconds"] == 0, decision
+        assert decision["general_work_deadline"] == 100 + 2400, decision
+        assert decision["action"] == "converge", decision
+
+    # The phase-aware reservation wrapper closes the race in policy semantics:
+    # the raw ledger soft deadline may be later, but new implementation work is
+    # rejected once the required-review tail begins.
+    quality = plan("quality")
+    with tempfile.TemporaryDirectory() as tmp:
+        state = str(Path(tmp) / "quality-reserve.json")
+        init_ledger(state, "quality-reserve", quality.task_budget, 100)
+        reserve_implementation(
+            state,
+            "quality-reserve",
+            quality.to_dict(),
+            "implementation_attempt",
+            "attempt-before-tail",
+            "unit-0-generation-0",
+            3099,
+        )
+        try:
+            reserve_implementation(
+                state,
+                "quality-reserve",
+                quality.to_dict(),
+                "implementation_attempt",
+                "attempt-in-tail",
+                "unit-0-generation-1",
+                3100,
+            )
+        except LedgerError as exc:
+            assert "required-completion reserve reached" in str(exc), exc
+        else:
+            raise AssertionError("implementation reservation unexpectedly entered required-review tail")
+
+    # High technical risk may opt into multiple evidence-backed quality units,
+    # but minimum_work_units remains one so this never forces a fake split.
+    high_risk = profile(risk="high")
+    quality_stage = get("quality").lifecycle(high_risk, "implementation")
+    assert quality_stage.minimum_work_units == 1, quality_stage
+    assert quality_stage.maximum_work_units == 3, quality_stage
+
+    print("task phase admission tests passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_task_phase_runtime.py
+++ b/tests/test_task_phase_runtime.py
@@ -11,8 +11,8 @@ sys.path.insert(0, str(ROOT / "scripts"))
 
 from strategy_runtime import Modifiers, TaskProfile, compile_plan  # noqa: E402
 from strategies import get  # noqa: E402
-from strategies.task_budget_runtime import LedgerError, init_ledger  # noqa: E402
-from strategies.task_phase_runtime import reserve_implementation, status  # noqa: E402
+from strategies.task_budget_runtime import LedgerError  # noqa: E402
+from strategies.task_phase_runtime import init, reserve_implementation, status  # noqa: E402
 
 
 def profile(**overrides) -> TaskProfile:
@@ -51,9 +51,12 @@ def assert_tail(strategy: str, expected_elapsed_cutoff: int, *, strict: bool = F
     start = 100.0
     with tempfile.TemporaryDirectory() as tmp:
         state = str(Path(tmp) / f"{strategy}.json")
-        init_ledger(state, strategy, execution_plan.task_budget, start)
+        initialized = init(state, strategy, execution_plan.to_dict(), start)
         plan_json = execution_plan.to_dict()
         cutoff = start + expected_elapsed_cutoff
+
+        assert initialized["effective_task_budget"]["soft_timeout_seconds"] == expected_elapsed_cutoff, initialized
+        assert initialized["soft_deadline"] == cutoff, initialized
 
         before = status(state, strategy, plan_json, "implementation", cutoff - 1)
         assert before["permits_phase_start"] is True, before
@@ -78,8 +81,9 @@ def assert_tail(strategy: str, expected_elapsed_cutoff: int, *, strict: bool = F
 
 
 def main() -> None:
-    # Quality plans require independent review by default. Their general-work
-    # admission closes early enough to preserve the review stage's full hard tail.
+    # Quality plans require independent review by default. Their ledger soft
+    # deadline is deterministically clamped to preserve the review stage's full
+    # hard tail.
     assert_tail("quality", 3000)
 
     # Strict review is an explicit required-completion stage even for strategies
@@ -93,20 +97,28 @@ def main() -> None:
     assert balanced.reviewer_workers == 0 and balanced.review_stage is None, balanced
     with tempfile.TemporaryDirectory() as tmp:
         state = str(Path(tmp) / "balanced-parent.json")
-        init_ledger(state, "balanced-parent", balanced.task_budget, 100)
+        initialized = init(state, "balanced-parent", balanced.to_dict(), 100)
+        assert initialized["effective_task_budget"] == {
+            "soft_timeout_seconds": 2400,
+            "hard_timeout_seconds": 3000,
+            "max_work_units": 1,
+            "max_implementation_attempts": 3,
+            "max_replans": 2,
+            "max_replacements": 2,
+        }, initialized
         decision = status(state, "balanced-parent", balanced.to_dict(), "implementation", 100 + 2400)
         assert decision["required_completion_reserve_seconds"] == 0, decision
         assert decision["general_work_deadline"] == 100 + 2400, decision
         assert decision["action"] == "converge", decision
 
-    # The phase-aware reservation wrapper closes the race in policy semantics:
-    # the raw ledger soft deadline may be later, but new implementation work is
-    # rejected once the required-review tail begins.
+    # Phase-aware init moves the raw ledger soft deadline to the required-review
+    # boundary. The underlying atomic reserve therefore rejects *new* work there
+    # while preserving its deliberate idempotent replay behavior.
     quality = plan("quality")
     with tempfile.TemporaryDirectory() as tmp:
         state = str(Path(tmp) / "quality-reserve.json")
-        init_ledger(state, "quality-reserve", quality.task_budget, 100)
-        reserve_implementation(
+        init(state, "quality-reserve", quality.to_dict(), 100)
+        first = reserve_implementation(
             state,
             "quality-reserve",
             quality.to_dict(),
@@ -115,6 +127,20 @@ def main() -> None:
             "unit-0-generation-0",
             3099,
         )
+        assert first["reserved"] is True and first["idempotent"] is False, first
+
+        replay = reserve_implementation(
+            state,
+            "quality-reserve",
+            quality.to_dict(),
+            "implementation_attempt",
+            "attempt-before-tail",
+            "unit-0-generation-0",
+            3100,
+        )
+        assert replay["reserved"] is True and replay["idempotent"] is True, replay
+        assert replay["permits_phase_start"] is False, replay
+
         try:
             reserve_implementation(
                 state,
@@ -126,9 +152,24 @@ def main() -> None:
                 3100,
             )
         except LedgerError as exc:
-            assert "required-completion reserve reached" in str(exc), exc
+            assert "soft deadline reached" in str(exc), exc
         else:
-            raise AssertionError("implementation reservation unexpectedly entered required-review tail")
+            raise AssertionError("new implementation reservation unexpectedly entered required-review tail")
+
+    # The phase helper refuses a different plan against an existing ledger,
+    # preventing a caller from extending the admission window with another
+    # review topology or task budget after initialization.
+    quality = plan("quality")
+    with tempfile.TemporaryDirectory() as tmp:
+        state = str(Path(tmp) / "identity.json")
+        init(state, "identity", quality.to_dict(), 100)
+        other = plan("quality", task=profile(complexity="complex", scope="cross-module"))
+        try:
+            status(state, "identity", other.to_dict(), "implementation", 101)
+        except LedgerError as exc:
+            assert "plan/policy mismatch" in str(exc), exc
+        else:
+            raise AssertionError("different ExecutionPlan unexpectedly reused task phase ledger")
 
     # High technical risk may opt into multiple evidence-backed quality units,
     # but minimum_work_units remains one so this never forces a fake split.

--- a/tests/test_task_phase_runtime.py
+++ b/tests/test_task_phase_runtime.py
@@ -15,7 +15,7 @@ sys.path.insert(0, str(ROOT / "scripts"))
 from strategy_runtime import Modifiers, TaskProfile, compile_plan  # noqa: E402
 from strategies import get  # noqa: E402
 from strategies.task_budget_runtime import LedgerError, init_ledger  # noqa: E402
-from strategies.task_phase_runtime import init, reserve_implementation, reserve_phase, status  # noqa: E402
+from strategies.task_phase_runtime import init, reserve_phase, status  # noqa: E402
 
 
 def profile(**overrides) -> TaskProfile:
@@ -90,29 +90,15 @@ def assert_tail(
         assert required["permits_review_start"] and required["permits_parent_finalization"], required
 
         review = reserve_phase(
-            state,
-            strategy,
-            plan_json,
-            "required_completion",
-            "review_attempt",
-            "review-0",
-            "review-generation-0",
-            cutoff,
+            state, strategy, plan_json, "required_completion", "review_attempt",
+            "review-0", "review-generation-0", cutoff,
         )
         assert review["reserved"] and not review["idempotent"], review
         assert review["counters"]["review_attempt"] == 1, review
 
-        # A failed reviewer may retry inside the review window, but not one
-        # instant later: the final tail is exclusively Parent finalization.
         retry = reserve_phase(
-            state,
-            strategy,
-            plan_json,
-            "required_completion",
-            "review_attempt",
-            "review-1",
-            "review-generation-1",
-            review_deadline - 1,
+            state, strategy, plan_json, "required_completion", "review_attempt",
+            "review-1", "review-generation-1", review_deadline - 1,
         )
         assert retry["reserved"] and retry["counters"]["review_attempt"] == 2, retry
 
@@ -124,14 +110,8 @@ def assert_tail(
         assert finalization["action"] == "finalize_parent", finalization
         try:
             reserve_phase(
-                state,
-                strategy,
-                plan_json,
-                "required_completion",
-                "review_attempt",
-                "review-too-late",
-                "review-generation-2",
-                review_deadline,
+                state, strategy, plan_json, "required_completion", "review_attempt",
+                "review-too-late", "review-generation-2", review_deadline,
             )
         except LedgerError as exc:
             assert "Parent finalization reserve" in str(exc), exc
@@ -165,7 +145,6 @@ def main() -> None:
     assert_tail("speed", strict=True, expected_soft=1200, expected_hard=2220, expected_reviewer_reserve=900, expected_parent_reserve=120)
     assert_tail("efficient", strict=True, expected_soft=1500, expected_hard=2850, expected_reviewer_reserve=1200, expected_parent_reserve=150)
 
-    # Parent-only plans have no reviewer capacity and keep the strategy base hard deadline.
     balanced = plan("balanced")
     assert balanced.reviewer_workers == 0 and balanced.review_stage is None, balanced
     assert balanced.task_budget.max_review_attempts == 0, balanced
@@ -180,32 +159,45 @@ def main() -> None:
         no_completion = status(state, "balanced-parent", balanced.to_dict(), "required_completion", 2500)
         assert not no_completion["permits_phase_start"] and no_completion["action"] == "stop", no_completion
 
-    # General work closes at soft while exact replay stays idempotent.
     quality = plan("quality")
     with tempfile.TemporaryDirectory() as tmp:
         state = str(Path(tmp) / "quality-reserve.json")
         init(state, "quality-reserve", quality.to_dict(), 100)
-        first = reserve_implementation(state, "quality-reserve", quality.to_dict(), "implementation_attempt", "attempt-0", "unit-0-generation-0", 4899)
+        first = reserve_phase(
+            state, "quality-reserve", quality.to_dict(), "implementation", "implementation_attempt",
+            "attempt-0", "unit-0-generation-0", 4899,
+        )
         assert first["reserved"] and not first["idempotent"], first
-        replay = reserve_implementation(state, "quality-reserve", quality.to_dict(), "implementation_attempt", "attempt-0", "unit-0-generation-0", 4900)
+        replay = reserve_phase(
+            state, "quality-reserve", quality.to_dict(), "implementation", "implementation_attempt",
+            "attempt-0", "unit-0-generation-0", 4900,
+        )
         assert replay["reserved"] and replay["idempotent"], replay
         try:
-            reserve_implementation(state, "quality-reserve", quality.to_dict(), "implementation_attempt", "attempt-1", "unit-0-generation-1", 4900)
+            reserve_phase(
+                state, "quality-reserve", quality.to_dict(), "implementation", "implementation_attempt",
+                "attempt-1", "unit-0-generation-1", 4900,
+            )
         except LedgerError as exc:
-            assert "does not permit" in str(exc) or "soft deadline" in str(exc), exc
+            assert "soft deadline" in str(exc), exc
         else:
             raise AssertionError("new implementation attempt entered required-completion tail")
 
-        review = reserve_phase(state, "quality-reserve", quality.to_dict(), "required_completion", "review_attempt", "review-1", "reviewer-1", 4900)
+        review = reserve_phase(
+            state, "quality-reserve", quality.to_dict(), "required_completion", "review_attempt",
+            "review-1", "reviewer-1", 4900,
+        )
         assert review["reserved"] and review["counters"]["review_attempt"] == 1, review
         try:
-            reserve_phase(state, "quality-reserve", quality.to_dict(), "implementation", "review_attempt", "bad-phase", "bad", 4900)
+            reserve_phase(
+                state, "quality-reserve", quality.to_dict(), "implementation", "review_attempt",
+                "bad-phase", "bad", 4900,
+            )
         except LedgerError as exc:
             assert "require" in str(exc), exc
         else:
             raise AssertionError("review_attempt accepted in implementation phase")
 
-    # Budget identity is tied to the original canonical plan.
     quality = plan("quality")
     with tempfile.TemporaryDirectory() as tmp:
         state = str(Path(tmp) / "identity.json")
@@ -218,7 +210,6 @@ def main() -> None:
         else:
             raise AssertionError("different canonical budget plan reused task ledger")
 
-    # No grandfathering: a raw pre-canonical policy ledger fails closed.
     quality = plan("quality")
     raw_quality_policy = get("quality").task_budget(profile())
     assert raw_quality_policy.hard_timeout_seconds != quality.task_budget.hard_timeout_seconds
@@ -230,23 +221,24 @@ def main() -> None:
         except LedgerError as exc:
             assert "plan/policy mismatch" in str(exc), exc
         else:
-            raise AssertionError("non-canonical ledger was grandfathered")
+            raise AssertionError("non-canonical ledger was accepted")
 
-    # Real CLI path accepts textual --now and phase/kind pairing.
     phase_cli = ROOT / "scripts/strategies/task_phase_runtime.py"
     quality = plan("quality")
     with tempfile.TemporaryDirectory() as tmp:
         state = str(Path(tmp) / "cli.json")
         plan_json = json.dumps(quality.to_dict(), separators=(",", ":"))
         init_run = subprocess.run([
-            sys.executable, str(phase_cli), "init", "--state-file", state, "--task-id", "cli", "--plan-json", plan_json, "--now", "100"
+            sys.executable, str(phase_cli), "init", "--state-file", state, "--task-id", "cli",
+            "--plan-json", plan_json, "--now", "100",
         ], check=True, text=True, capture_output=True)
         initialized = json.loads(init_run.stdout)
         assert initialized["soft_deadline"] == 4900 and initialized["hard_deadline"] == 8200, initialized
         assert initialized["review_deadline"] == 7900, initialized
         review_run = subprocess.run([
-            sys.executable, str(phase_cli), "reserve", "--state-file", state, "--task-id", "cli", "--plan-json", plan_json,
-            "--phase", "required_completion", "--kind", "review_attempt", "--reservation-id", "review-cli", "--fingerprint", "review-cli-v0", "--now", "4900"
+            sys.executable, str(phase_cli), "reserve", "--state-file", state, "--task-id", "cli",
+            "--plan-json", plan_json, "--phase", "required_completion", "--kind", "review_attempt",
+            "--reservation-id", "review-cli", "--fingerprint", "review-cli-v0", "--now", "4900",
         ], check=True, text=True, capture_output=True)
         review = json.loads(review_run.stdout)
         assert review["reserved"] and review["phase"] == "required_completion", review

--- a/tests/test_task_phase_runtime.py
+++ b/tests/test_task_phase_runtime.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(ROOT / "scripts"))
 
 from strategy_runtime import Modifiers, TaskProfile, compile_plan  # noqa: E402
 from strategies import get  # noqa: E402
-from strategies.task_budget_runtime import LedgerError  # noqa: E402
+from strategies.task_budget_runtime import LedgerError, init_ledger  # noqa: E402
 from strategies.task_phase_runtime import init, reserve_implementation, status  # noqa: E402
 
 
@@ -59,6 +59,7 @@ def assert_tail(strategy: str, expected_elapsed_cutoff: int, *, strict: bool = F
 
         assert initialized["effective_task_budget"]["soft_timeout_seconds"] == expected_elapsed_cutoff, initialized
         assert initialized["soft_deadline"] == cutoff, initialized
+        assert initialized["legacy_unclamped"] is False, initialized
 
         before = status(state, strategy, plan_json, "implementation", cutoff - 1)
         assert before["permits_phase_start"] is True, before
@@ -171,6 +172,22 @@ def main() -> None:
             assert "plan/policy mismatch" in str(exc), exc
         else:
             raise AssertionError("different budget plan unexpectedly reused task phase ledger")
+
+    # A task already initialized by the pre-phase runtime keeps its historical
+    # original soft deadline. Calling phase-aware init after upgrade adopts that
+    # ledger without shortening it or inventing a review-tail reservation.
+    quality = plan("quality")
+    with tempfile.TemporaryDirectory() as tmp:
+        state = str(Path(tmp) / "legacy.json")
+        init_ledger(state, "legacy", quality.task_budget, 100)
+        adopted = init(state, "legacy", quality.to_dict(), 101)
+        assert adopted["initialized"] is False and adopted["idempotent"] is True, adopted
+        assert adopted["legacy_unclamped"] is True, adopted
+        assert adopted["soft_deadline"] == 4900, adopted
+        assert adopted["required_completion_reserve_seconds"] == 0, adopted
+        legacy_status = status(state, "legacy", quality.to_dict(), "implementation", 3100)
+        assert legacy_status["legacy_unclamped"] is True, legacy_status
+        assert legacy_status["permits_phase_start"] is True, legacy_status
 
     # Exercise the real argparse path: --now arrives as text in every shell.
     phase_cli = ROOT / "scripts/strategies/task_phase_runtime.py"

--- a/tests/work-unit-runtime.sh
+++ b/tests/work-unit-runtime.sh
@@ -8,18 +8,14 @@ POLICY="$TMP/codex-flow.toml"
 
 cat > "$POLICY" <<'EOF'
 schema_version = 4
-
 [strategy]
 enabled = true
 profile = "efficient"
-
 [routing]
 mode = "adaptive"
-
 [modifiers]
 review = "auto"
 fanout = "auto"
-
 [parent]
 model_policy = "latest-capable"
 min_model = "auto"
@@ -27,7 +23,6 @@ min_reasoning_effort = "high"
 routine_effort = "high"
 complex_effort = "high"
 critical_effort = "xhigh"
-
 [worker]
 model_policy = "latest-efficient"
 model = "auto"
@@ -36,7 +31,6 @@ min_reasoning_effort = "xhigh"
 routine_effort = "xhigh"
 complex_effort = "xhigh"
 critical_effort = "max"
-
 [runtime]
 max_concurrent_threads = 4
 max_repair_cycles = 2
@@ -45,351 +39,121 @@ EOF
 plan() {
   python3 "$ROOT/scripts/strategy_runtime.py" --policy "$POLICY" plan --repo-policy none --quota-pressure unknown "$@"
 }
-
 validate_units() {
-  local policy_json="$1" manifest_json="$2" implementation_workers="$3" max_threads="$4"
   python3 "$ROOT/scripts/strategies/work_unit_runtime.py" \
-    --policy-json "$policy_json" \
-    --manifest-json "$manifest_json" \
-    --implementation-workers "$implementation_workers" \
-    --max-concurrent-threads "$max_threads"
+    --policy-json "$1" --manifest-json "$2" \
+    --implementation-workers "$3" --max-concurrent-threads "$4"
 }
 
 WORK_UNITS="$ROOT/scripts/strategies/work_unit_runtime.py"
 python3 -m py_compile "$WORK_UNITS"
 
-# Routine implementation remains a single bounded transaction.
 plan --routing delegate --complexity routine --scope module > "$TMP/routine.json"
-python3 - "$TMP/routine.json" > "$TMP/routine-policy.json" <<'PY'
-import json, sys
-p=json.load(open(sys.argv[1])); imp=p["implementation_stage"]
-assert imp["work_unit_mode"]=="single", imp
-assert imp["minimum_work_units"]==1, imp
-assert imp["maximum_work_units"]==1, imp
-assert imp["require_write_paths"] is False, imp
-assert imp["join_between_work_units"] is False, imp
-assert imp["soft_timeout_seconds"]==600 and imp["hard_timeout_seconds"]==1800, imp
-assert imp["max_worker_repair_attempts"]==1, imp
-print(json.dumps(imp, separators=(",", ":")))
-PY
-
-# Complex/cross-module work has bounded capacity for independently evidenced units and joins Parent between them.
 plan --routing delegate --complexity complex --scope cross-module > "$TMP/complex.json"
+plan --routing delegate --complexity complex --scope repo-wide --iteration-intensity heavy-loop > "$TMP/repo.json"
+python3 - "$TMP/routine.json" "$TMP/complex.json" "$TMP/repo.json" <<'PY'
+import json,sys
+r,c,p=[json.load(open(x))['implementation_stage'] for x in sys.argv[1:]]
+assert (r['work_unit_mode'],r['minimum_work_units'],r['maximum_work_units'],r['require_write_paths'])==('single',1,1,False),r
+assert (c['work_unit_mode'],c['minimum_work_units'],c['maximum_work_units'],c['require_write_paths'])==('bounded',1,2,True),c
+assert (p['work_unit_mode'],p['minimum_work_units'],p['maximum_work_units'],p['require_write_paths'])==('bounded',1,3,True),p
+PY
 python3 - "$TMP/complex.json" > "$TMP/complex-policy.json" <<'PY'
-import json, sys
-p=json.load(open(sys.argv[1])); imp=p["implementation_stage"]
-assert imp["work_unit_mode"]=="bounded", imp
-assert imp["minimum_work_units"]==1, imp
-assert imp["maximum_work_units"]==2, imp
-assert imp["require_write_paths"] is True, imp
-assert imp["join_between_work_units"] is True, imp
-assert imp["soft_timeout_seconds"]==900 and imp["hard_timeout_seconds"]==1800, imp
-assert imp["max_worker_repair_attempts"]==2, imp
-print(json.dumps(imp, separators=(",", ":")))
+import json,sys
+print(json.dumps(json.load(open(sys.argv[1]))['implementation_stage'],separators=(',',':')))
 PY
 COMPLEX_POLICY="$(cat "$TMP/complex-policy.json")"
-LEGACY_COMPLEX_POLICY="$(python3 - "$COMPLEX_POLICY" <<'PY'
-import json, sys
-p=json.loads(sys.argv[1])
-p.pop("maximum_work_units", None)
-p.pop("require_write_paths", None)
-print(json.dumps(p, separators=(",", ":")))
-PY
-)"
 
-# Repo-wide/heavy-loop work gets bounded capacity up to three units without lowering the old hard ceiling.
-plan --routing delegate --complexity complex --scope repo-wide --iteration-intensity heavy-loop > "$TMP/repo-wide.json"
-python3 - "$TMP/repo-wide.json" <<'PY'
-import json, sys
-p=json.load(open(sys.argv[1])); imp=p["implementation_stage"]
-assert imp["work_unit_mode"]=="bounded", imp
-assert imp["minimum_work_units"]==1, imp
-assert imp["maximum_work_units"]==3, imp
-assert imp["require_write_paths"] is True, imp
-assert imp["join_between_work_units"] is True, imp
-assert imp["hard_timeout_seconds"]==1800, imp
-PY
-python3 - "$TMP/repo-wide.json" > "$TMP/repo-wide-policy.json" <<'PY'
-import json, sys
-print(json.dumps(json.load(open(sys.argv[1]))["implementation_stage"], separators=(",", ":")))
-PY
-REPO_WIDE_POLICY="$(cat "$TMP/repo-wide-policy.json")"
-REPO_WIDE_ONE='{"units":[{"unit_id":"repo-all","scope_id":"repo-wide","acceptance_delta":"complete repository change","write_scope_id":"repo-live","validation":["run repository checks"],"generation":0,"write_paths":["src/repo.py"]}]}'
-validate_units "$REPO_WIDE_POLICY" "$REPO_WIDE_ONE" 1 4 > "$TMP/repo-wide-one.json"
-python3 - "$TMP/repo-wide-one.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1]))
-assert d["valid"] and d["unit_count"] == 1 and d["maximum_work_units"] == 3, d
+ONE='{"units":[{"unit_id":"u1","scope_id":"all","generation":0,"acceptance_delta":"complete change","write_scope_id":"live","write_paths":["src/all.py"],"validation":["test all"],"depends_on":[]}]}'
+validate_units "$COMPLEX_POLICY" "$ONE" 1 4 > "$TMP/one.json"
+
+SERIAL='{"units":[{"unit_id":"u1","scope_id":"auth","generation":0,"acceptance_delta":"parser","write_scope_id":"auth-live","write_paths":["src/auth/parser.py"],"validation":["test parser"],"depends_on":[]},{"unit_id":"u2","scope_id":"auth","generation":0,"acceptance_delta":"integration","write_scope_id":"auth-live","write_paths":["src/auth/parser.py"],"validation":["test auth"],"depends_on":["u1"]}]}'
+validate_units "$COMPLEX_POLICY" "$SERIAL" 1 4 > "$TMP/serial.json"
+
+PARALLEL='{"units":[{"unit_id":"api","scope_id":"api","generation":0,"acceptance_delta":"api","write_scope_id":"wt-api","write_paths":["src/api.py"],"validation":["test api"],"depends_on":[],"parallel_group":"wave"},{"unit_id":"ui","scope_id":"ui","generation":0,"acceptance_delta":"ui","write_scope_id":"wt-ui","write_paths":["src/ui.py"],"validation":["test ui"],"depends_on":[],"parallel_group":"wave"}]}'
+validate_units "$COMPLEX_POLICY" "$PARALLEL" 2 4 > "$TMP/parallel.json"
+python3 - "$TMP/one.json" "$TMP/serial.json" "$TMP/parallel.json" <<'PY'
+import json,sys
+one,serial,parallel=[json.load(open(x)) for x in sys.argv[1:]]
+assert one['valid'] and one['unit_count']==1,one
+assert serial['valid'] and serial['unit_count']==2,serial
+assert parallel['parallel_groups']==['wave'] and parallel['max_parallel_units']==2,parallel
 PY
 
-# Same writable scope is valid only as an explicit serial dependency chain.
-SERIAL_MANIFEST='{"units":[{"unit_id":"impl-1","scope_id":"module-auth","acceptance_delta":"implement parser change","write_scope_id":"auth-live","validation":["test parser"],"depends_on":[],"generation":0,"write_paths":["src/auth/parser.py"]},{"unit_id":"impl-2","scope_id":"module-auth","acceptance_delta":"add regression coverage and finish integration","write_scope_id":"auth-live","validation":["test auth regression"],"depends_on":["impl-1"],"generation":0,"write_paths":["src/auth/parser.py"]}]}'
-validate_units "$COMPLEX_POLICY" "$SERIAL_MANIFEST" 1 4 > "$TMP/serial.json"
-python3 - "$TMP/serial.json" <<'PY'
-import json, sys
-p=json.load(open(sys.argv[1]))
-assert p["valid"] is True and p["unit_count"]==2, p
-assert p["work_unit_mode"]=="bounded" and p["join_between_work_units"] is True, p
-assert p["max_parallel_units"]==1, p
-PY
-LEGACY_MIN2='{"work_unit_mode":"bounded","minimum_work_units":2,"join_between_work_units":true}'
-validate_units "$LEGACY_MIN2" "$SERIAL_MANIFEST" 1 4 > "$TMP/legacy-min2.json"
-python3 - "$TMP/legacy-min2.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1])); assert d["valid"] and d["minimum_work_units"] == 2, d
-PY
-
-# Shared writable scope without an explicit dependency is rejected: never imply concurrent same-scope writers.
-BAD_SHARED='{"units":[{"unit_id":"impl-1","scope_id":"module-auth","acceptance_delta":"first half","write_scope_id":"auth-live","validation":["test one"],"generation":0,"write_paths":["src/auth/parser.py"]},{"unit_id":"impl-2","scope_id":"module-auth","acceptance_delta":"second half","write_scope_id":"auth-live","validation":["test two"],"generation":0,"write_paths":["src/auth/parser.py"]}]}'
-if validate_units "$COMPLEX_POLICY" "$BAD_SHARED" 1 4 > /dev/null 2> "$TMP/shared.err"; then
-  echo "overlapping writable units unexpectedly accepted" >&2
-  exit 1
-fi
-grep -Fq "must directly depend on previous unit" "$TMP/shared.err"
-
-# Proven isolated scopes may share a parallel wave when the resolved plan has two implementation slots.
-PARALLEL_MANIFEST='{"units":[{"unit_id":"impl-api","scope_id":"api","acceptance_delta":"update API contract","write_scope_id":"worktree-api","validation":["test api"],"parallel_group":"wave-1","generation":0,"write_paths":["src/api/contract.py"]},{"unit_id":"impl-ui","scope_id":"ui","acceptance_delta":"update UI consumer","write_scope_id":"worktree-ui","validation":["test ui"],"parallel_group":"wave-1","generation":0,"write_paths":["src/ui/consumer.py"]}]}'
-validate_units "$COMPLEX_POLICY" "$PARALLEL_MANIFEST" 2 4 > "$TMP/parallel.json"
-python3 - "$TMP/parallel.json" <<'PY'
-import json, sys
-p=json.load(open(sys.argv[1]))
-assert p["parallel_groups"]==["wave-1"] and p["max_parallel_units"]==2, p
-PY
-
-# Parallel groups cannot hide overlapping writers.
-BAD_PARALLEL='{"units":[{"unit_id":"impl-a","scope_id":"a","acceptance_delta":"a","write_scope_id":"shared","validation":["test a"],"parallel_group":"wave-1","generation":0,"write_paths":["src/shared/a.py"]},{"unit_id":"impl-b","scope_id":"b","acceptance_delta":"b","write_scope_id":"shared","validation":["test b"],"parallel_group":"wave-1","depends_on":["impl-a"],"generation":0,"write_paths":["src/shared/a.py"]}]}'
-if validate_units "$COMPLEX_POLICY" "$BAD_PARALLEL" 2 4 > /dev/null 2> "$TMP/parallel.err"; then
-  echo "unsafe parallel work units unexpectedly accepted" >&2
-  exit 1
-fi
-grep -Eq "overlapping write scope|dependency-linked units" "$TMP/parallel.err"
-
-# Indirect dependencies are also ordering edges and therefore cannot share one parallel wave.
-TRANSITIVE_PARALLEL='{"units":[{"unit_id":"impl-base","scope_id":"base","acceptance_delta":"base","write_scope_id":"worktree-base","validation":["test base"],"parallel_group":"wave-1","generation":0,"write_paths":["src/base.py"]},{"unit_id":"impl-middle","scope_id":"middle","acceptance_delta":"middle","write_scope_id":"worktree-middle","validation":["test middle"],"depends_on":["impl-base"],"generation":0,"write_paths":["src/middle.py"]},{"unit_id":"impl-top","scope_id":"top","acceptance_delta":"top","write_scope_id":"worktree-top","validation":["test top"],"depends_on":["impl-middle"],"parallel_group":"wave-1","generation":0,"write_paths":["src/top.py"]}]}'
-if validate_units "$LEGACY_COMPLEX_POLICY" "$TRANSITIVE_PARALLEL" 2 4 > /dev/null 2> "$TMP/transitive.err"; then
-  echo "transitively dependent parallel units unexpectedly accepted" >&2
-  exit 1
-fi
-grep -Fq "transitively dependency-linked units" "$TMP/transitive.err"
-
-# A manifest cannot exceed either resolved implementation slots or the Runtime thread ceiling.
-TOO_WIDE='{"units":[{"unit_id":"impl-a","scope_id":"a","acceptance_delta":"a","write_scope_id":"wa","validation":["test a"],"parallel_group":"wave-1","generation":0,"write_paths":["src/a.py"]},{"unit_id":"impl-b","scope_id":"b","acceptance_delta":"b","write_scope_id":"wb","validation":["test b"],"parallel_group":"wave-1","generation":0,"write_paths":["src/b.py"]},{"unit_id":"impl-c","scope_id":"c","acceptance_delta":"c","write_scope_id":"wc","validation":["test c"],"parallel_group":"wave-1","generation":0,"write_paths":["src/c.py"]}]}'
-if validate_units "$LEGACY_COMPLEX_POLICY" "$TOO_WIDE" 2 4 > /dev/null 2> "$TMP/width.err"; then
-  echo "parallel group wider than implementation_workers unexpectedly accepted" >&2
-  exit 1
-fi
-grep -Fq "allows at most 2 concurrent implementation units" "$TMP/width.err"
-if validate_units "$LEGACY_COMPLEX_POLICY" "$PARALLEL_MANIFEST" 4 1 > /dev/null 2> "$TMP/thread-width.err"; then
-  echo "parallel group wider than max_concurrent_threads unexpectedly accepted" >&2
-  exit 1
-fi
-grep -Fq "allows at most 1 concurrent implementation units" "$TMP/thread-width.err"
-
-# Bounded mode permits one unit when no natural independent split is evidenced.
-ONE_BIG='{"units":[{"unit_id":"impl-all","scope_id":"all","acceptance_delta":"do everything","write_scope_id":"all-live","validation":["test all"],"generation":0,"write_paths":["src/all.py"]}]}'
-validate_units "$COMPLEX_POLICY" "$ONE_BIG" 1 4 > "$TMP/one.json"
-python3 - "$TMP/one.json" <<'PY'
-import json, sys
-d=json.load(open(sys.argv[1])); assert d["valid"] and d["unit_count"] == 1, d
-PY
-
-# The hardened bounded contract rejects type confusion, duplicate deltas, unsafe
-# paths, missing parallel isolation evidence, and manifests above the policy max.
+# v11 bounded policy fields are mandatory; no legacy policy defaulting.
 python3 - "$ROOT" "$COMPLEX_POLICY" <<'PY'
-import copy
-import json
-import sys
-
-sys.path.insert(0, sys.argv[1] + "/scripts")
+import copy,json,sys
+sys.path.insert(0,sys.argv[1]+'/scripts')
 from strategies.work_unit_runtime import validate_manifest
-
-policy = json.loads(sys.argv[2])
-base_unit = {
-    "unit_id": "u1",
-    "scope_id": "scope-1",
-    "acceptance_delta": "delta-1",
-    "write_scope_id": "write-1",
-    "validation": ["test one"],
-    "depends_on": [],
-    "generation": 0,
-    "write_paths": ["src/one.py"],
+policy=json.loads(sys.argv[2])
+unit={
+ 'unit_id':'u1','scope_id':'s1','generation':0,'acceptance_delta':'d1','write_scope_id':'w1',
+ 'write_paths':['src/one.py'],'validation':['test one'],'depends_on':[]
 }
-peer_unit = {
-    "unit_id": "u2",
-    "scope_id": "scope-2",
-    "acceptance_delta": "delta-2",
-    "write_scope_id": "write-2",
-    "validation": ["test two"],
-    "depends_on": [],
-    "generation": 0,
-    "write_paths": ["src/two.py"],
+peer={
+ 'unit_id':'u2','scope_id':'s2','generation':0,'acceptance_delta':'d2','write_scope_id':'w2',
+ 'write_paths':['src/two.py'],'validation':['test two'],'depends_on':[]
 }
+def invalid(manifest,pol=policy,workers=1,threads=4):
+    try: validate_manifest(pol,manifest,implementation_workers=workers,max_concurrent_threads=threads)
+    except ValueError: return
+    raise AssertionError((manifest,pol))
+def valid(manifest,pol=policy,workers=1,threads=4):
+    return validate_manifest(pol,manifest,implementation_workers=workers,max_concurrent_threads=threads)
 
-def manifest(*units):
-    return {"units": list(units)}
+for field in ('work_unit_mode','minimum_work_units','join_between_work_units','maximum_work_units','require_write_paths'):
+    p=copy.deepcopy(policy); p.pop(field,None); invalid({'units':[unit]},p)
 
-def invalid(candidate, candidate_policy=policy, *, workers=1, threads=4):
-    try:
-        validate_manifest(candidate_policy, candidate, implementation_workers=workers, max_concurrent_threads=threads)
-    except ValueError:
-        return
-    raise AssertionError(f"invalid manifest unexpectedly accepted: {candidate}")
+# bounded units require explicit generation and write_paths.
+for field in ('generation','write_paths'):
+    u=copy.deepcopy(unit); u.pop(field); invalid({'units':[u]})
 
-def valid(candidate, candidate_policy=policy, *, workers=1, threads=4):
-    validate_manifest(candidate_policy, candidate, implementation_workers=workers, max_concurrent_threads=threads)
-
-def invalid_unit(candidate):
-    # Keep the surrounding manifest valid so a malformed unit cannot be hidden
-    # by the bounded policy's minimum-unit rejection.
-    invalid(manifest(candidate, copy.deepcopy(peer_unit)))
-
-# Every contract string is type-checked instead of stringified.
-for key, values in {
-    "unit_id": [None, True, 7, {}],
-    "scope_id": [None, False, 7, []],
-    "acceptance_delta": [None, True, 7, {}],
-    "write_scope_id": [None, False, 7, []],
+# Type confusion and unsafe paths fail closed.
+for key,values in {
+ 'unit_id':[None,True,7,{}], 'scope_id':[None,False,7,[]],
+ 'acceptance_delta':[None,True,7,{}], 'write_scope_id':[None,False,7,[]],
+ 'generation':[None,True,1.0,'1',-1],
 }.items():
     for value in values:
-        bad = copy.deepcopy(base_unit)
-        bad[key] = value
-        invalid_unit(bad)
-for value in [None, "test one", {}, [None], [True], [7], [{}]]:
-    bad = copy.deepcopy(base_unit); bad["validation"] = value
-    invalid_unit(bad)
-for value in [None, "u0", {}, [None], [True], [7], [{}]]:
-    bad = copy.deepcopy(base_unit); bad["depends_on"] = value
-    invalid_unit(bad)
-for value in [True, 7, {}]:
-    bad = copy.deepcopy(base_unit); bad["parallel_group"] = value
-    invalid_unit(bad)
-null_group = copy.deepcopy(base_unit); null_group["parallel_group"] = None
-valid(manifest(null_group, copy.deepcopy(peer_unit)))
+        u=copy.deepcopy(unit); u[key]=value; invalid({'units':[u]})
+for path in ['', '.', '..', '../escape.py', 'src/../escape.py', '/absolute.py', 'C:/drive.py', 'src/*.py', 'src\\win.py', 'src//double.py']:
+    u=copy.deepcopy(unit); u['write_paths']=[path]; invalid({'units':[u]})
 
-# Integers reject bool, float, string, null, and negative generation.
-for key, values in {
-    "generation": [None, True, 1.0, "1", -1],
-}.items():
-    for value in values:
-        bad = copy.deepcopy(base_unit); bad[key] = value
-        invalid_unit(bad)
-for value in [None, "src/one.py", {}, [], [None], [True], [7], [{}]]:
-    bad = copy.deepcopy(base_unit); bad["write_paths"] = value
-    invalid_unit(bad)
+# Duplicate deltas and un-ordered path overlap are invalid.
+u=copy.deepcopy(peer); u['acceptance_delta']='d1'; invalid({'units':[unit,u]})
+u=copy.deepcopy(peer); u['write_paths']=['src']; invalid({'units':[unit,u]})
+u['depends_on']=['u1']; valid({'units':[unit,u]})
 
-# Policy and resolved concurrency fields use the same no-coercion contract.
-valid_pair = manifest(copy.deepcopy(base_unit), copy.deepcopy(peer_unit))
-for key, values in {
-    "work_unit_mode": [None, True, 7, {}],
-    "minimum_work_units": [None, True, 2.0, "2"],
-    "join_between_work_units": [None, 1, "true"],
-    "maximum_work_units": [True, 2.0, "2", 0, 1],
-    "require_write_paths": [None, 1, "true"],
-}.items():
-    for value in values:
-        bad_policy = copy.deepcopy(policy); bad_policy[key] = value
-        invalid(valid_pair, bad_policy)
-invalid(valid_pair, policy, workers=True)
-invalid(valid_pair, policy, threads=True)
-invalid([], policy)
-try:
-    validate_manifest(policy, [], implementation_workers=1, max_concurrent_threads=4)
-except ValueError:
-    pass
-else:
-    raise AssertionError("non-object manifest unexpectedly accepted")
+# Same writable scope requires direct predecessor ordering.
+u=copy.deepcopy(peer); u['write_scope_id']='w1'; invalid({'units':[unit,u]})
+u['depends_on']=['u1']; valid({'units':[unit,u]})
 
-# Duplicate acceptance deltas are not independently harvestable units.
-duplicate = copy.deepcopy(base_unit)
-duplicate["unit_id"] = "u2"
-duplicate["write_scope_id"] = "write-2"
-duplicate["write_paths"] = ["src/two.py"]
-invalid(manifest(base_unit, duplicate))
+# Parallel isolation and width are enforced.
+a=copy.deepcopy(unit); b=copy.deepcopy(peer); a['parallel_group']=b['parallel_group']='wave'
+valid({'units':[a,b]},workers=2)
+invalid({'units':[a,b]},workers=1)
+b['write_paths']=['src/one.py']; invalid({'units':[a,b]},workers=2)
 
-# Path preflight is lexical and fail-closed.
-for path in [
-    "", ".", "..", "../escape.py", "src/../escape.py", "/absolute.py",
-    "C:/drive.py", "C:relative.py", "//server/share.py", "src/*.py",
-    "src/[a].py", "src\\windows.py", "src\x00nul.py", "src//double.py", "src/./dot.py",
-]:
-    bad = copy.deepcopy(base_unit); bad["write_paths"] = [path]
-    invalid(manifest(bad))
+# Maximum units remain authoritative.
+third=copy.deepcopy(peer); third.update(unit_id='u3',scope_id='s3',acceptance_delta='d3',write_scope_id='w3',write_paths=['src/three.py'])
+invalid({'units':[unit,peer,third]})
 
-# Same/ancestor paths require a direct or transitive serial dependency.
-ancestor = copy.deepcopy(base_unit)
-ancestor["unit_id"] = "u2"
-ancestor["acceptance_delta"] = "delta-2"
-ancestor["write_scope_id"] = "write-2"
-ancestor["write_paths"] = ["src"]
-invalid(manifest(base_unit, ancestor))
-ancestor["depends_on"] = ["u1"]
-valid(manifest(base_unit, ancestor))
-
-# Same logical write-scope units retain the stronger direct predecessor fence;
-# an indirect dependency is not enough even when paths are distinct.
-middle = copy.deepcopy(peer_unit)
-middle["depends_on"] = ["u1"]
-same_scope_late = copy.deepcopy(base_unit)
-same_scope_late["unit_id"] = "u3"
-same_scope_late["acceptance_delta"] = "delta-3"
-same_scope_late["validation"] = ["test three"]
-same_scope_late["write_paths"] = ["src/three.py"]
-same_scope_late["depends_on"] = ["u2"]
-invalid(manifest(base_unit, middle, same_scope_late), {**policy, "maximum_work_units": 3})
-
-# A parallel group needs concrete non-overlapping path evidence, even for a
-# legacy policy that otherwise permits path-less serial manifests.
-legacy = {"work_unit_mode": "bounded", "minimum_work_units": 2, "join_between_work_units": True}
-parallel_missing = [copy.deepcopy(base_unit), copy.deepcopy(ancestor)]
-for unit in parallel_missing:
-    unit.pop("write_paths", None)
-    unit["parallel_group"] = "wave"
-    unit["depends_on"] = []
-invalid(manifest(*parallel_missing), legacy, workers=2)
-
-# The exact new maximum is enforced independently of worker concurrency.
-too_many = []
-for index in range(3):
-    unit = copy.deepcopy(base_unit)
-    unit["unit_id"] = f"u{index + 1}"
-    unit["acceptance_delta"] = f"delta-{index + 1}"
-    unit["write_scope_id"] = f"write-{index + 1}"
-    unit["write_paths"] = [f"src/{index + 1}.py"]
-    too_many.append(unit)
-invalid(manifest(*too_many), policy, workers=1)
-
-# Legacy single policy remains valid without generation/write_paths.
-legacy_single = {"work_unit_mode": "single", "minimum_work_units": 1, "join_between_work_units": False}
-legacy_unit = {
-    "unit_id": "legacy",
-    "scope_id": "legacy",
-    "acceptance_delta": "legacy delta",
-    "write_scope_id": "legacy-write",
-    "validation": ["legacy test"],
-}
-valid(manifest(legacy_unit), legacy_single)
-
-# Fingerprints are deterministic and include one entry per unit.
-fingerprint_unit = copy.deepcopy(base_unit)
-fingerprint_unit["unit_id"] = "u2"
-fingerprint_unit["acceptance_delta"] = "delta-2"
-fingerprint_unit["write_scope_id"] = "write-2"
-fingerprint_unit["write_paths"] = ["src/two.py"]
-fingerprint_unit["depends_on"] = ["u1"]
-first = validate_manifest(policy, manifest(base_unit, fingerprint_unit), implementation_workers=1, max_concurrent_threads=4)
-second = validate_manifest(policy, manifest(base_unit, fingerprint_unit), implementation_workers=1, max_concurrent_threads=4)
-assert first["unit_fingerprints"] == second["unit_fingerprints"], (first, second)
-assert len(first["unit_fingerprints"]["u1"]) == 64 and len(first["unit_fingerprints"]["u2"]) == 64, first
-assert len(first["logical_unit_fingerprints"]["u1"]) == 64, first
-
-# A replacement generation is a new implementation attempt but remains the
-# same logical work unit for cumulative task-budget counting.
-next_generation = copy.deepcopy(fingerprint_unit)
-next_generation["generation"] = 1
-third = validate_manifest(policy, manifest(base_unit, next_generation), implementation_workers=1, max_concurrent_threads=4)
-assert first["unit_fingerprints"]["u2"] != third["unit_fingerprints"]["u2"], (first, third)
-assert first["logical_unit_fingerprints"]["u2"] == third["logical_unit_fingerprints"]["u2"], (first, third)
-print("adversarial work-unit contract tests passed")
+# Fingerprints are deterministic; generation changes attempt fingerprint only.
+first=valid({'units':[unit,peer]})
+second=valid({'units':[unit,peer]})
+assert first['unit_fingerprints']==second['unit_fingerprints']
+next_peer=copy.deepcopy(peer); next_peer['generation']=1
+third_result=valid({'units':[unit,next_peer]})
+assert first['unit_fingerprints']['u2']!=third_result['unit_fingerprints']['u2']
+assert first['logical_unit_fingerprints']['u2']==third_result['logical_unit_fingerprints']['u2']
+print('strict v11 work-unit contract tests passed')
 PY
 
-printf 'bounded work-unit runtime tests passed\n'
+# A legacy bounded policy must now fail instead of being normalized.
+LEGACY='{"work_unit_mode":"bounded","minimum_work_units":1,"join_between_work_units":true}'
+if validate_units "$LEGACY" "$ONE" 1 4 >/dev/null 2>&1; then
+  echo "legacy bounded policy unexpectedly accepted" >&2
+  exit 1
+fi
+
+printf 'bounded work-unit v11 contract tests passed\n'


### PR DESCRIPTION
## Summary

Apply one shared convergence/recovery/admission runtime to every built-in delegated strategy while preserving each strategy's optimization objective.

This branch intentionally defines one unreleased execution contract:

- ExecutionPlan schema **v11**
- durable task-ledger schema **v2**
- no pre-v11 task-ledger migration/grandfather path
- one canonical task budget emitted by the compiler
- strict v11 checkpoint/work-unit contracts; removed legacy task-execution shims fail closed

## Shared lifecycle / recovery

All four built-in strategies use the same deterministic implementation mechanics:

- meaningful-progress-aware soft checkpoints;
- multi-round checkpoint rearm after explicit acceptance-relevant progress + cooldown;
- harvest-before-fallback;
- remaining-delta implementation replan;
- generation lineage and writer fencing;
- Worker-local repair bounds;
- evidence-based bounded implementation with `minimum_work_units=1`.

No strategy is forced into a fake split. Strategy semantic unit limits may be raised only by already-proven isolated writable topology within that strategy's WorkerBudget; logical units may therefore execute in serial waves and are not identical to simultaneous Worker count.

## Strategy tuning

| Strategy | Impl soft checkpoint | Rearm | Local repairs | Logical-unit envelope | Worker hard |
| --- | --- | --- | --- | --- | --- |
| `efficient` | 600 / 900 / 1200s | 180 / 240 / 300s | 1–2 | semantic 1–3; topology-backed ≤2 where applicable | 1800s |
| `balanced` | 1200 / 1500 / 1800s | 240 / 300 / 360s | 1–2 | semantic/topology ≤3 | 2400s |
| `quality` | 1800 / 2400 / 2700s | 360 / 480 / 600s | 2–3 | semantic/topology ≤4 | 3600s |
| `speed` | 420 / 600 / 720s | 180s | 1 | semantic 1 / 3 / 4; proven topology may raise to 8 | 1200s |

## Canonical cumulative task budget

Every delegated built-in strategy emits `task_budget`; direct plans emit `task_budget=null`.

Schema-v11 task budget fields:

```text
soft_timeout_seconds
hard_timeout_seconds
max_work_units
max_implementation_attempts
max_replans
max_replacements
max_review_attempts
parent_finalization_seconds
```

Compiler invariants include:

```text
implementation_workers <= max_work_units
implementation_workers <= max_implementation_attempts
implementation_stage.maximum_work_units == max_work_units
reviewer_workers <= max_review_attempts  # when reviewers are planned
```

When no reviewer is planned, canonical `max_review_attempts=0`.

For independent review:

```text
completion_tail = review_stage.hard_timeout_seconds
                + parent_finalization_seconds

canonical_hard = max(
  raw_hard,
  soft_timeout_seconds + completion_tail
)
```

This preserves the complete strategy general-work window. For example, `efficient + strict` keeps its 1500-second general-work budget instead of shrinking implementation to make review fit.

## Phase-aware admission

`task_phase_runtime.py` consumes the immutable initial ExecutionPlan and never derives a second effective budget.

```text
started_at
  |
  | general exploration / writable implementation
  v
soft_deadline = general_work_deadline
  |
  | required read-only review
  v
review_deadline = hard_deadline - parent_finalization_seconds
  |
  | Parent finalization only
  v
hard_deadline = absolute stop
```

General reservations are `work_unit`, `implementation_attempt`, `replan`, and `replacement`. New general work stops at soft; exact replay of an already-recorded reservation remains idempotent.

Reviewer starts/retries use durable `review_attempt` reservations. New reviewer admission closes at `review_deadline`, preserving the Parent finalization tail.

**`action=finalize_parent` is only an admission transition. It is not evidence that required review succeeded.** A required/quorum review still needs at least `review_stage.min_successful_workers` accepted reviewer results. If that join is unsatisfied at `review_deadline`, execution fails/escalates from collected evidence rather than silently downgrading to Parent-only success.

Before Parent-only finalization, writable Workers must be terminal/cancel-confirmed or safely fenced and all returned checkpoints must be harvested; unresolved writable work may not consume the finalization reserve.

The initial budget-plan identity remains bound to the ledger across semantic replans. A newer ExecutionPlan may change current topology/lifecycle but cannot reset counters, replace the ledger policy, or extend task deadlines.

## Review retry is not implementation replan

Review lifecycle fallback is `retry_review`:

- read-only replacement;
- consumes `review_attempt`;
- no implementation `replan_scope`;
- no writable scope;
- no writer fence;
- forbidden after `review_deadline`.

Implementation `replan` remains remaining-delta-only and preserves normal writer-safety/fencing rules.

## Strict unreleased contract

Because this task-execution contract has not shipped with persisted running tasks, v11 intentionally removes compatibility paths for the intermediate designs developed in #22/#23/#24:

- no legacy checkpoint timestamp CLI fields; checkpoint sequence is authoritative;
- no legacy bounded manifest defaults; required v11 fields fail closed when missing;
- no phase reservation compatibility alias;
- implementation lifecycle requires soft timeout + checkpoint-rearm policy;
- incompatible task-ledger schema/policy fails closed.

Persistent user policy compatibility remains separate and continues to use policy schema v4.

## Reasoning rollout

Reasoning rollout remains intentionally `efficient`-specific. The existing `legacy | shadow | adaptive` experiment is unchanged; balanced/quality/speed do not silently inherit efficient's reasoning policy.

## Validation

Coverage includes:

- cross-strategy lifecycle/budget matrices;
- v11-safe default StrategySpec lifecycle;
- semantic vs topology-backed unit envelopes (including speed with 8 proven workstreams);
- checkpoint rearm and liveness-only non-rearm;
- harvest/replan/writer-fence invariants;
- strict v11 work-unit manifests and path isolation;
- schema-v11 canonical task budgets;
- schema-v2 durable limits/idempotency;
- general-work cutoff vs required-review admission;
- review retry/replay before the review admission boundary;
- protected Parent finalization tail;
- strict review for efficient/balanced/speed;
- quality default independent review;
- plan/policy identity mismatch fail-closed behavior;
- Linux/Windows installer/CLI smoke coverage.

## Scope / follow-up

This PR is the shared convergence/recovery/admission foundation. It does **not** claim the long-tail Worker latency problem is fully solved.

Separate follow-up work remains:

- strategy-specific reasoning/latency tuning beyond the current efficient experiment;
- scheduler-native checkpoint/cancellation transport and durable checkpoint payload storage;
- stronger writable-scope/worktree ownership beyond lexical `write_paths` preflight;
- latency p50/p95 tuning from structured runtime telemetry.