### PR TITLE
tune(efficient): increase safe worker fan-out and benchmark token efficiency

### DIFF
--- a/benchmark/profiles.json
+++ b/benchmark/profiles.json
@@ -60,14 +60,23 @@
       ]
     },
     "agentic": {
-      "description": "One repetition comparing direct baselines with real FlowPilot runtime execution.",
+      "description": "One repetition comparing direct baselines with real FlowPilot runtime execution under efficient and balanced profiles.",
       "repetitions": 1,
       "matrix": [
         {"id": "luna-direct", "strategy": "direct", "model": "gpt-5.6-luna", "reasoning_effort": "high"},
         {"id": "terra-direct", "strategy": "direct", "model": "gpt-5.6-terra", "reasoning_effort": "high"},
         {"id": "sol-direct", "strategy": "direct", "model": "gpt-5.6-sol", "reasoning_effort": "high"},
         {
-          "id": "codex-flow-runtime",
+          "id": "codex-flow-runtime-efficient",
+          "strategy": "runtime",
+          "reasoning_policy": "fixed",
+          "profile": "efficient",
+          "routing_mode": "delegate",
+          "parent": {"model": "gpt-5.6-sol", "reasoning_effort": "high"},
+          "worker": {"model": "gpt-5.6-luna", "reasoning_effort": "high"}
+        },
+        {
+          "id": "codex-flow-runtime-balanced",
           "strategy": "runtime",
           "reasoning_policy": "fixed",
           "profile": "balanced",

--- a/scripts/render-benchmark-report.py
+++ b/scripts/render-benchmark-report.py
@@ -77,6 +77,42 @@ def composition(row: dict[str, Any]) -> str:
     return f"{row['model']} parent → {row['worker_model']} worker / {row['reasoning_effort']}"
 
 
+def token_metrics(items: list[dict[str, Any]]) -> dict[str, float]:
+    count = len(items)
+    total_input = sum(item["input_tokens"] for item in items)
+    total_cached = sum(item["cached_input_tokens"] for item in items)
+    total_output = sum(item["output_tokens"] for item in items)
+    parent_tokens = 0
+    worker_tokens = 0
+    for item in items:
+        for usage in item.get("model_usage", []):
+            tokens = usage.get("input_tokens", 0) + usage.get("output_tokens", 0)
+            if usage.get("role") == "parent":
+                parent_tokens += tokens
+            elif usage.get("role") == "worker":
+                worker_tokens += tokens
+    return {
+        "total_tokens": (total_input + total_output) / count,
+        "parent_tokens": parent_tokens / count,
+        "worker_tokens": worker_tokens / count,
+        "cached_input_tokens": total_cached / count,
+        "net_new_input_tokens": (total_input - total_cached) / count,
+        "cache_rate": total_cached / total_input if total_input else 0.0,
+    }
+
+
+def relative_change(value: float, reference: float) -> float | None:
+    return value / reference - 1 if reference else None
+
+
+def fmt_avg_tokens(value: float) -> str:
+    return f"{round(value):,}"
+
+
+def fmt_change(value: float | None) -> str:
+    return signed_pct(value) if value is not None else "n/a"
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--results", required=True)
@@ -94,6 +130,8 @@ def main() -> int:
     total_input = sum(row["input_tokens"] for row in rows)
     total_cached = sum(row["cached_input_tokens"] for row in rows)
     total_output = sum(row["output_tokens"] for row in rows)
+    total_tokens = total_input + total_output
+    net_new_input = total_input - total_cached
     passed = sum(1 for row in rows if row["passed"])
     first_passed = sum(1 for row in rows if row["first_passed"])
     infra_failures = sum(1 for row in rows if row.get("codex_exit_code", 0) != 0)
@@ -103,6 +141,8 @@ def main() -> int:
     grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for row in rows:
         grouped[row["strategy_id"]].append(row)
+    strategy_tokens = {strategy_id: token_metrics(items) for strategy_id, items in grouped.items()}
+    sol_tokens = strategy_tokens.get("sol-direct")
 
     lines = [
         f"# {args.title}",
@@ -118,7 +158,9 @@ def main() -> int:
         f"- Repair cycles: **{repairs}**",
         f"- Parent review cycles: **{reviews}**",
         f"- API-equivalent reference cost: **${total_cost:.6f}**",
-        f"- Tokens: input **{total_input:,}**, cached input **{total_cached:,}**, output **{total_output:,}**",
+        f"- Total tokens: **{total_tokens:,}**",
+        f"- Input tokens: **{total_input:,}** — cached **{total_cached:,}**, net-new **{net_new_input:,}**",
+        f"- Output tokens: **{total_output:,}**",
         "",
         "## Strategy results",
         "",
@@ -136,6 +178,33 @@ def main() -> int:
         lines.append(
             f"| {strategy_id} | {composition(items[0])} | {len(items)} | {pct(item_passed, len(items))} | "
             f"{pct(item_first, len(items))} | {item_repairs} | {item_reviews} | {item_wall:.1f}s | ${item_cost / len(items):.6f} |"
+        )
+
+    lines.extend([
+        "",
+        "## Token efficiency",
+        "",
+        "This table separates raw token volume from where the work ran. Runtime Parent/Worker values come from FlowPilot role-attributed telemetry; net-new input excludes cached input. Deltas use `sol-direct` as the paired high-capability baseline when present.",
+        "",
+        "| Strategy | Avg total tokens | Avg Parent tokens | Avg Worker tokens | Avg cached input | Avg net-new input | Cache rate | Total Δ vs Sol | Net-new Δ vs Sol | Parent reduction vs Sol |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ])
+    for strategy_id, items in sorted(grouped.items()):
+        metrics = strategy_tokens[strategy_id]
+        if sol_tokens is not None:
+            total_delta = relative_change(metrics["total_tokens"], sol_tokens["total_tokens"])
+            net_new_delta = relative_change(metrics["net_new_input_tokens"], sol_tokens["net_new_input_tokens"])
+        else:
+            total_delta = net_new_delta = None
+        if items[0]["strategy"] != "direct" and sol_tokens is not None:
+            parent_reduction = 1 - metrics["parent_tokens"] / sol_tokens["total_tokens"] if sol_tokens["total_tokens"] else None
+        else:
+            parent_reduction = None
+        lines.append(
+            f"| {strategy_id} | {fmt_avg_tokens(metrics['total_tokens'])} | {fmt_avg_tokens(metrics['parent_tokens'])} | "
+            f"{fmt_avg_tokens(metrics['worker_tokens'])} | {fmt_avg_tokens(metrics['cached_input_tokens'])} | "
+            f"{fmt_avg_tokens(metrics['net_new_input_tokens'])} | {metrics['cache_rate']:.1%} | "
+            f"{fmt_change(total_delta)} | {fmt_change(net_new_delta)} | {fmt_change(parent_reduction)} |"
         )
 
     lines.extend([

--- a/scripts/strategies/efficient.py
+++ b/scripts/strategies/efficient.py
@@ -146,7 +146,13 @@ STRATEGY = StrategySpec(
     worker_budget=worker_budget,
     independent_review=never,
     lifecycle=lifecycle,
-    quota_sensitive=True,
+    # Efficient workers are deliberately cheap enough that proven parallel
+    # implementation should not require an aggressive fan-out override.
+    allow_parallel_write=True,
+    # Keep quota pressure focused on expensive Parent usage. The strategy's own
+    # low-speculation WorkerBudget remains the hard envelope (2 implementers,
+    # 5 total Workers at the largest task classes).
+    quota_sensitive=False,
     task_budget=task_budget,
     reasoning_rollout=reasoning_rollout,
 )

--- a/tests/corpus.sh
+++ b/tests/corpus.sh
@@ -53,6 +53,25 @@ assert s['repetitions']==3, s
 assert s['planned_runs']==135, s
 PY
 
+# Agentic is the real FlowPilot comparison surface. Keep both efficient and
+# balanced runtime profiles paired with the same three direct baselines.
+python3 "$ROOT/scripts/materialize-corpus.py" \
+  --corpus "$ROOT/benchmark/corpus.json" \
+  --profiles "$ROOT/benchmark/profiles.json" \
+  --profile agentic \
+  --output-dir "$TMP/agentic" \
+  --manifest "$TMP/agentic.json" > "$TMP/agentic-summary.json"
+python3 - "$TMP/agentic-summary.json" "$TMP/agentic.json" <<'PY'
+import json,sys
+s=json.load(open(sys.argv[1])); m=json.load(open(sys.argv[2]))
+expected=['luna-direct','terra-direct','sol-direct','codex-flow-runtime-efficient','codex-flow-runtime-balanced']
+assert s['tasks']==9 and s['configurations']==5 and s['repetitions']==1, s
+assert s['planned_runs']==45 and s['strategies']==expected, s
+assert [entry['id'] for entry in m['matrix']] == expected, m['matrix']
+profiles={entry['id']:entry.get('profile') for entry in m['matrix'] if entry['strategy']=='runtime'}
+assert profiles == {'codex-flow-runtime-efficient':'efficient','codex-flow-runtime-balanced':'balanced'}, profiles
+PY
+
 python3 "$ROOT/scripts/run-benchmark.py" --manifest "$TMP/quick-a.json" --output "$TMP/unused.jsonl" --dry-run > "$TMP/runner-plan.json"
 python3 - "$TMP/runner-plan.json" <<'PY'
 import json,sys

--- a/tests/report.sh
+++ b/tests/report.sh
@@ -62,7 +62,7 @@ PY
 printf '{}\n' > "$TMP/empty-analysis.json"
 python3 "$ROOT/scripts/render-benchmark-report.py" \
   --results "$TMP/token-results.jsonl" \
-  --prices "$ROOT/tests/fixtures/benchmark-prices.json" \
+  --prices "$ROOT/benchmark/prices/gpt-5.6-2026-08-30.json" \
   --analysis "$TMP/empty-analysis.json" \
   --output "$TMP/token-report.md" \
   --title 'Token attribution fixture'

--- a/tests/report.sh
+++ b/tests/report.sh
@@ -20,6 +20,8 @@ python3 "$ROOT/scripts/render-benchmark-report.py" \
 grep -Fq '# Fixture benchmark' "$TMP/report.md"
 grep -Fq '## Overall' "$TMP/report.md"
 grep -Fq '## Strategy results' "$TMP/report.md"
+grep -Fq '## Token efficiency' "$TMP/report.md"
+grep -Fq 'net-new' "$TMP/report.md"
 grep -Fq '## Sol capability evidence' "$TMP/report.md"
 grep -Fq '## Fixed-high flow evidence' "$TMP/report.md"
 grep -Fq '## Adaptive reasoning evidence' "$TMP/report.md"
@@ -27,5 +29,44 @@ grep -Fq '## Advisory routing' "$TMP/report.md"
 grep -Fq 'gpt-5.6-luna' "$TMP/report.md"
 grep -Fq 'gpt-5.6-terra' "$TMP/report.md"
 grep -Fq 'Conclusions are advisory' "$TMP/report.md"
+
+# Mixed-model runtime reporting must expose raw total volume separately from
+# Parent/Worker attribution and cached-vs-net-new input. This is the key view
+# for deciding whether FlowPilot saves expensive Parent work even when total
+# token volume grows.
+python3 - "$TMP/token-results.jsonl" <<'PY'
+import json,sys
+path=sys.argv[1]
+rows=[
+    {
+        'schema_version':2,'task_id':'t1','task_class':'routine','strategy_id':'sol-direct','strategy':'direct',
+        'reasoning_policy':'fixed','model':'gpt-5.6-sol','reasoning_effort':'high','worker_model':None,
+        'worker_reasoning_effort':None,'passed':True,'first_passed':True,'input_tokens':100,'cached_input_tokens':40,
+        'output_tokens':20,'model_usage':[{'role':'direct','model':'gpt-5.6-sol','reasoning_effort':'high','calls':1,
+        'input_tokens':100,'cached_input_tokens':40,'output_tokens':20}],'repair_cycles':0,'review_cycles':0,
+        'wall_time_seconds':1.0,'codex_exit_code':0
+    },
+    {
+        'schema_version':2,'task_id':'t1','task_class':'routine','strategy_id':'codex-flow-runtime-efficient','strategy':'runtime',
+        'reasoning_policy':'fixed','model':'gpt-5.6-sol','reasoning_effort':'high','worker_model':'gpt-5.6-luna',
+        'worker_reasoning_effort':'high','passed':True,'first_passed':True,'input_tokens':110,'cached_input_tokens':65,
+        'output_tokens':20,'model_usage':[
+            {'role':'parent','model':'gpt-5.6-sol','reasoning_effort':'high','calls':1,'input_tokens':20,'cached_input_tokens':5,'output_tokens':5},
+            {'role':'worker','model':'gpt-5.6-luna','reasoning_effort':'high','calls':1,'input_tokens':90,'cached_input_tokens':60,'output_tokens':15}
+        ],'repair_cycles':0,'review_cycles':0,'wall_time_seconds':1.0,'codex_exit_code':0
+    },
+]
+with open(path,'w') as sink:
+    for row in rows: sink.write(json.dumps(row)+'\n')
+PY
+printf '{}\n' > "$TMP/empty-analysis.json"
+python3 "$ROOT/scripts/render-benchmark-report.py" \
+  --results "$TMP/token-results.jsonl" \
+  --prices "$ROOT/tests/fixtures/benchmark-prices.json" \
+  --analysis "$TMP/empty-analysis.json" \
+  --output "$TMP/token-report.md" \
+  --title 'Token attribution fixture'
+grep -Fq '| codex-flow-runtime-efficient | 130 | 25 | 105 | 65 | 45 | 59.1% | +8.3% | -25.0% | +79.2% |' "$TMP/token-report.md"
+grep -Fq '| sol-direct | 120 | 0 | 0 | 40 | 60 | 40.0% | +0.0% | +0.0% | n/a |' "$TMP/token-report.md"
 
 printf 'report smoke test passed\n'


### PR DESCRIPTION
## Summary
- allow `efficient + fanout=auto` to use multiple implementers when the task already proves isolated writable workstreams
- stop collapsing efficient Worker fan-out solely because account quota pressure is high/critical
- keep the existing low-speculation WorkerBudget as the hard envelope: max 2 implementers and max 5 total Workers for the largest efficient task classes
- extend the real `agentic` benchmark to compare both `runtime-efficient` and `runtime-balanced` against the same Luna/Terra/Sol direct baselines
- surface raw token economics in the benchmark report: total tokens, Parent tokens, Worker tokens, cached input, net-new input, and deltas versus `sol-direct`

## Rationale
Efficient Workers use the cheaper worker model and consume materially less plan quota than Parent execution. The previous `quota_sensitive` clamp made Efficiency overly conservative and frequently reduced implementation to one Worker even when safe parallel workstreams existed.

The benchmark changes make the core hypothesis measurable rather than assumed: FlowPilot may increase raw total token volume while still reducing expensive Parent work. The report now makes that tradeoff explicit instead of hiding it behind API-equivalent cost alone.

## Safety
Parallel implementation still requires all existing runtime gates: `parallelism=high`, `write_conflict=low`, and at least two proven writable workstreams. Conservative fan-out and `parallelism=none` remain hard constraints.

Benchmark fixtures pin the agentic matrix and verify mixed Parent/Worker token attribution plus cached-vs-net-new reporting.